### PR TITLE
Add Tech Card (техкарта) admin feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ angular-8-jwt-authentication-example
 #
 layout
 
+tmp/
 *.log
 
 # compiled output

--- a/src/api/proto-http/admin/index.ts
+++ b/src/api/proto-http/admin/index.ts
@@ -1980,7 +1980,9 @@ export type AddFittingRequest = {
   fitting: common_FittingInsert | undefined;
 };
 
-// FittingInsert is the writable payload for a fitting session.
+// FittingInsert is the writable payload for a fitting session. A fitting anchors
+// to a tech card (the style) and/or a specific product (the colour/SKU sample);
+// at least one of tech_card_id / product_id must be set.
 export type common_FittingInsert = {
   productId: number | undefined;
   modelId: number | undefined;
@@ -1991,6 +1993,7 @@ export type common_FittingInsert = {
   recordedBy: string | undefined;
   sizes: common_FittingSizeInsert[] | undefined;
   mediaIds: number[] | undefined;
+  techCardId: number | undefined;
 };
 
 // FittingStatus is the lifecycle state of a fitting session.
@@ -2022,6 +2025,7 @@ export type ListFittingsRequest = {
   orderFactor: common_OrderFactor | undefined;
   productId: number | undefined;
   modelId: number | undefined;
+  techCardId: number | undefined;
 };
 
 export type ListFittingsResponse = {
@@ -2475,6 +2479,486 @@ export type RunTierBackfillResponse = {
   accountsUpgraded: number | undefined;
 };
 
+export type CreateTechCardRequest = {
+  techCard: common_TechCardInsert | undefined;
+};
+
+export type common_TechCardInsert = {
+  // identification (Sheet «Титул»)
+  styleNumber: string | undefined;
+  name: string | undefined;
+  brand: string | undefined;
+  season: string | undefined;
+  collection: string | undefined;
+  categoryId: number | undefined;
+  targetGender: common_GenderEnum | undefined;
+  stage: common_TechCardStage | undefined;
+  status: string | undefined;
+  approvalState: common_TechCardApprovalState | undefined;
+  approvedBy: string | undefined;
+  releasedAt: wellKnownTimestamp | undefined;
+  measurementUnit: common_TechCardMeasurementUnit | undefined;
+  version: string | undefined;
+  revisionDate: wellKnownTimestamp | undefined;
+  baseModelId: number | undefined;
+  baseSampleSizeId: number | undefined;
+  designer: string | undefined;
+  constructor: string | undefined;
+  technologist: string | undefined;
+  targetCost: googletype_Decimal | undefined;
+  targetRetailPrice: googletype_Decimal | undefined;
+  currency: string | undefined;
+  // construction description (lower block of Sheet «Титул»)
+  description: string | undefined;
+  silhouette: string | undefined;
+  collar: string | undefined;
+  fastening: string | undefined;
+  pockets: string | undefined;
+  sleeveCuff: string | undefined;
+  extraDetails: string | undefined;
+  topstitching: string | undefined;
+  auxMaterials: string | undefined;
+  notes: string | undefined;
+  // children (full-replace on update)
+  sizeIds: number[] | undefined;
+  productIds: number[] | undefined;
+  media: common_TechCardMediaItem[] | undefined;
+  callouts: common_TechCardCallout[] | undefined;
+  revisions: common_TechCardRevision[] | undefined;
+  // materials (Phase 2): bill of materials, colourways, points of measure.
+  bomItems: common_TechCardBomItem[] | undefined;
+  colorways: common_TechCardColorway[] | undefined;
+  pomPoints: common_TechCardPomPoint[] | undefined;
+  // production (Phase 3): construction, operations, labels, packaging, costing.
+  construction: common_TechCardConstruction | undefined;
+  operations: common_TechCardOperation[] | undefined;
+  labels: common_TechCardLabel[] | undefined;
+  packaging: common_TechCardPackaging | undefined;
+  costing: common_TechCardCosting | undefined;
+  // hardening (Phase 3.5a)
+  approvedAt: wellKnownTimestamp | undefined;
+  concept: string | undefined;
+  issues: common_TechCardIssue[] | undefined;
+  sizeQuantities: common_TechCardSizeQuantity[] | undefined;
+  signoffs: common_TechCardSignoff[] | undefined;
+};
+
+// TechCardStage is the development stage of a tech pack: prototype, fit sample,
+// salesman sample, pre-production, production.
+export type common_TechCardStage =
+  | "TECH_CARD_STAGE_UNKNOWN"
+  | "TECH_CARD_STAGE_PROTO"
+  | "TECH_CARD_STAGE_FIT"
+  | "TECH_CARD_STAGE_SMS"
+  | "TECH_CARD_STAGE_PP"
+  | "TECH_CARD_STAGE_PROD";
+// TechCardApprovalState is the gating release state of a tech card, orthogonal to
+// TechCardStage (which tracks development progress). A factory must only receive a
+// card in the RELEASED state.
+export type common_TechCardApprovalState =
+  | "TECH_CARD_APPROVAL_STATE_UNKNOWN"
+  | "TECH_CARD_APPROVAL_STATE_DRAFT"
+  | "TECH_CARD_APPROVAL_STATE_IN_REVIEW"
+  | "TECH_CARD_APPROVAL_STATE_APPROVED"
+  | "TECH_CARD_APPROVAL_STATE_RELEASED"
+  | "TECH_CARD_APPROVAL_STATE_OBSOLETE";
+// TechCardMeasurementUnit is the unit for the card's geometry (callout dimensions
+// and the POM chart). Metric only — the brand works in cm and mm, never inches.
+export type common_TechCardMeasurementUnit =
+  | "TECH_CARD_MEASUREMENT_UNIT_UNKNOWN"
+  | "TECH_CARD_MEASUREMENT_UNIT_CM"
+  | "TECH_CARD_MEASUREMENT_UNIT_MM";
+// TechCardMediaItem is a writable sketch-media reference (id + kind).
+export type common_TechCardMediaItem = {
+  mediaId: number | undefined;
+  kind: common_TechCardMediaKind | undefined;
+  caption: string | undefined;
+};
+
+// TechCardMediaKind classifies a tech-card sketch image.
+export type common_TechCardMediaKind =
+  | "TECH_CARD_MEDIA_KIND_UNKNOWN"
+  | "TECH_CARD_MEDIA_KIND_FRONT"
+  | "TECH_CARD_MEDIA_KIND_BACK"
+  | "TECH_CARD_MEDIA_KIND_DETAIL"
+  | "TECH_CARD_MEDIA_KIND_LINING"
+  | "TECH_CARD_MEDIA_KIND_PREVIEW"
+  | "TECH_CARD_MEDIA_KIND_MOODBOARD"
+  | "TECH_CARD_MEDIA_KIND_REFERENCE"
+  | "TECH_CARD_MEDIA_KIND_SWATCH";
+// TechCardCallout is a numbered detail note pointing at the technical sketch.
+export type common_TechCardCallout = {
+  number: number | undefined;
+  part: string | undefined;
+  description: string | undefined;
+  dimensions: string | undefined;
+  mediaId: number | undefined;
+  posX: googletype_Decimal | undefined;
+  posY: googletype_Decimal | undefined;
+};
+
+// TechCardRevision is one entry in the spec-document changelog (what changed in
+// which section, by whom). This is NOT fit history — fitting verdicts and
+// measurements live in the separate fitting feature.
+export type common_TechCardRevision = {
+  version: string | undefined;
+  revisionDate: wellKnownTimestamp | undefined;
+  author: string | undefined;
+  section: string | undefined;
+  changeNote: string | undefined;
+};
+
+// TechCardBomItem is one bill-of-materials line (Sheet «Спецификация»).
+export type common_TechCardBomItem = {
+  section: common_TechCardBomSection | undefined;
+  name: string | undefined;
+  placement: string | undefined;
+  supplier: string | undefined;
+  supplierRef: string | undefined;
+  color: string | undefined;
+  composition: string | undefined;
+  spec: string | undefined;
+  // consumption vs quantity: fill ONE per line. consumption = per-garment rate of
+  // a measured material (fabric/lining/interlining/insulation/thread) in `unit`
+  // (м/см/г); quantity = discrete count of a countable trim (hardware/label/
+  // packaging), `unit` then = pcs. line_total uses quantity when set, else consumption.
+  consumption: googletype_Decimal | undefined;
+  unit: string | undefined;
+  quantity: googletype_Decimal | undefined;
+  unitPrice: googletype_Decimal | undefined;
+  currency: string | undefined;
+  comment: string | undefined;
+  colorwayColors: common_TechCardBomColorwayColor[] | undefined;
+  lineTotal: googletype_Decimal | undefined;
+  // fabric data for the cutter / marker (Phase 3.5c)
+  fabricWidth: googletype_Decimal | undefined;
+  fabricWeightGsm: googletype_Decimal | undefined;
+  fabricDirection: common_TechCardFabricDirection | undefined;
+  wastagePercent: googletype_Decimal | undefined;
+};
+
+// TechCardBomSection groups a BOM line by material family (Sheet «Спецификация»).
+export type common_TechCardBomSection =
+  | "TECH_CARD_BOM_SECTION_UNKNOWN"
+  | "TECH_CARD_BOM_SECTION_FABRIC"
+  | "TECH_CARD_BOM_SECTION_LINING"
+  | "TECH_CARD_BOM_SECTION_INTERLINING"
+  | "TECH_CARD_BOM_SECTION_INSULATION"
+  | "TECH_CARD_BOM_SECTION_HARDWARE"
+  | "TECH_CARD_BOM_SECTION_THREAD"
+  | "TECH_CARD_BOM_SECTION_LABEL"
+  | "TECH_CARD_BOM_SECTION_PACKAGING";
+// TechCardBomColorwayColor is one «Колористика» matrix cell: the colour of a BOM
+// material in a colourway. colorway_index points into TechCardInsert.colorways — a
+// full-replace upsert has no stable colourway ids to reference on write.
+export type common_TechCardBomColorwayColor = {
+  colorwayIndex: number | undefined;
+  color: string | undefined;
+  pantone: string | undefined;
+};
+
+// TechCardFabricDirection is the cutting layout a fabric requires.
+export type common_TechCardFabricDirection =
+  | "TECH_CARD_FABRIC_DIRECTION_UNKNOWN"
+  | "TECH_CARD_FABRIC_DIRECTION_ANY"
+  | "TECH_CARD_FABRIC_DIRECTION_ONE_WAY"
+  | "TECH_CARD_FABRIC_DIRECTION_TWO_WAY";
+// TechCardColorway is a development colourway (Sheet «Колористика» columns). It is
+// distinct from tech_card_product (published catalog SKUs); product_id optionally
+// links the published SKU that realises this colourway.
+export type common_TechCardColorway = {
+  code: string | undefined;
+  name: string | undefined;
+  labDipStatus: common_TechCardLabDipStatus | undefined;
+  productId: number | undefined;
+  comment: string | undefined;
+  pantone: string | undefined;
+  pantoneSystem: string | undefined;
+  hex: string | undefined;
+  swatchMediaId: number | undefined;
+  labDipRound: number | undefined;
+  labDipSubmittedAt: wellKnownTimestamp | undefined;
+  labDipDecidedAt: wellKnownTimestamp | undefined;
+  labDipDecidedBy: string | undefined;
+  labDipRejectReason: string | undefined;
+};
+
+// TechCardLabDipStatus is the lab-dip approval lifecycle of a colourway.
+export type common_TechCardLabDipStatus =
+  | "TECH_CARD_LAB_DIP_STATUS_UNKNOWN"
+  | "TECH_CARD_LAB_DIP_STATUS_PENDING"
+  | "TECH_CARD_LAB_DIP_STATUS_SUBMITTED"
+  | "TECH_CARD_LAB_DIP_STATUS_APPROVED"
+  | "TECH_CARD_LAB_DIP_STATUS_REJECTED";
+// TechCardPomPoint is a point of measure with its grade and actuals (Sheet «Измерения»).
+// Values are in TechCardInsert.measurement_unit.
+export type common_TechCardPomPoint = {
+  section: string | undefined;
+  code: string | undefined;
+  name: string | undefined;
+  howToMeasure: string | undefined;
+  baseValue: googletype_Decimal | undefined;
+  tolerancePlus: googletype_Decimal | undefined;
+  toleranceMinus: googletype_Decimal | undefined;
+  grades: common_TechCardPomGrade[] | undefined;
+  actuals: common_TechCardPomActual[] | undefined;
+};
+
+// TechCardPomGrade is the graded value of a POM point for one size.
+export type common_TechCardPomGrade = {
+  sizeId: number | undefined;
+  value: googletype_Decimal | undefined;
+};
+
+// TechCardPomActual is an actual measured value, optionally taken in a fitting and
+// at a specific size (so QC can compare it to that size's grade ± tolerance).
+export type common_TechCardPomActual = {
+  fittingId: number | undefined;
+  label: string | undefined;
+  value: googletype_Decimal | undefined;
+  sizeId: number | undefined;
+  // OUTPUT-ONLY: deviation = value - target (grade at size_id, else base_value);
+  // verdict compares the deviation against tolerance_plus / tolerance_minus.
+  deviation: googletype_Decimal | undefined;
+  verdict: common_TechCardPomVerdict | undefined;
+};
+
+// TechCardPomVerdict is the computed in/out-of-tolerance result of an actual.
+export type common_TechCardPomVerdict =
+  | "TECH_CARD_POM_VERDICT_UNKNOWN"
+  | "TECH_CARD_POM_VERDICT_IN_TOLERANCE"
+  | "TECH_CARD_POM_VERDICT_OVER"
+  | "TECH_CARD_POM_VERDICT_UNDER";
+// TechCardConstruction holds general workmanship parameters (Sheet «Обработка»).
+export type common_TechCardConstruction = {
+  mainStitchType: string | undefined;
+  stitchDensity: string | undefined;
+  overlockThreads: string | undefined;
+  seamAllowances: string | undefined;
+  hemFinish: string | undefined;
+  pressing: string | undefined;
+  machineClass: string | undefined;
+  notes: string | undefined;
+  labourRate: googletype_Decimal | undefined;
+  labourRateCurrency: string | undefined;
+};
+
+// TechCardOperation is one per-node sewing operation (Sheet «Обработка»).
+export type common_TechCardOperation = {
+  node: string | undefined;
+  description: string | undefined;
+  seamType: string | undefined;
+  stitchesPerCm: googletype_Decimal | undefined;
+  topstitchWidth: string | undefined;
+  thread: string | undefined;
+  note: string | undefined;
+  operationNumber: number | undefined;
+  machine: string | undefined;
+  seamAllowance: string | undefined;
+  needle: string | undefined;
+  timeNorm: googletype_Decimal | undefined;
+};
+
+// TechCardLabel is one label / tag spec (Sheet «Этикетки и упаковка»).
+export type common_TechCardLabel = {
+  labelType: common_TechCardLabelType | undefined;
+  content: string | undefined;
+  placement: string | undefined;
+  attachment: string | undefined;
+  size: string | undefined;
+  note: string | undefined;
+};
+
+// TechCardLabelType classifies a label / tag (Sheet «Этикетки и упаковка»).
+export type common_TechCardLabelType =
+  | "TECH_CARD_LABEL_TYPE_UNKNOWN"
+  | "TECH_CARD_LABEL_TYPE_MAIN"
+  | "TECH_CARD_LABEL_TYPE_SIZE"
+  | "TECH_CARD_LABEL_TYPE_CARE"
+  | "TECH_CARD_LABEL_TYPE_ORIGIN"
+  | "TECH_CARD_LABEL_TYPE_FLAG"
+  | "TECH_CARD_LABEL_TYPE_HANGTAG"
+  | "TECH_CARD_LABEL_TYPE_BARCODE"
+  | "TECH_CARD_LABEL_TYPE_SPECIAL";
+// TechCardPackaging holds the packaging spec (Sheet «Этикетки и упаковка»).
+export type common_TechCardPackaging = {
+  foldingMethod: string | undefined;
+  polybag: string | undefined;
+  bagSticker: string | undefined;
+  inserts: string | undefined;
+  unitsPerBox: number | undefined;
+  boxMarking: string | undefined;
+  boxDimensions: string | undefined;
+  weightNet: googletype_Decimal | undefined;
+  weightGross: googletype_Decimal | undefined;
+  notes: string | undefined;
+};
+
+// TechCardCosting holds the manually-entered cost articles (Sheet «Калькуляция»).
+// The materials rollup and total are COMPUTED on read from the BOM; they are
+// output-only (ignored on write) and never converted across currencies.
+export type common_TechCardCosting = {
+  cmtCost: googletype_Decimal | undefined;
+  hardwareCost: googletype_Decimal | undefined;
+  packagingCost: googletype_Decimal | undefined;
+  logisticsCost: googletype_Decimal | undefined;
+  overheadCost: googletype_Decimal | undefined;
+  defectPercent: googletype_Decimal | undefined;
+  markupMultiplier: googletype_Decimal | undefined;
+  wholesalePrice: googletype_Decimal | undefined;
+  retailPrice: googletype_Decimal | undefined;
+  currency: string | undefined;
+  notes: string | undefined;
+  // OUTPUT-ONLY computed rollup (ignored on write; no currency conversion).
+  materialsTotal: common_TechCardCostLine[] | undefined;
+  materialsCost: googletype_Decimal | undefined;
+  totalCost: googletype_Decimal | undefined;
+  hasUnconvertedCurrencies: boolean | undefined;
+  totalSam: googletype_Decimal | undefined;
+  labourCost: googletype_Decimal | undefined;
+};
+
+// TechCardCostLine is one currency bucket of the materials rollup.
+export type common_TechCardCostLine = {
+  currency: string | undefined;
+  amount: googletype_Decimal | undefined;
+};
+
+// TechCardIssue is a maker-flagged problem ("this seam is impossible") against an
+// operation or callout (Sheet «Обработка» / «Тех. эскиз»).
+export type common_TechCardIssue = {
+  operationNumber: number | undefined;
+  calloutNumber: number | undefined;
+  raisedBy: string | undefined;
+  severity: common_TechCardIssueSeverity | undefined;
+  status: common_TechCardIssueStatus | undefined;
+  description: string | undefined;
+  resolutionNote: string | undefined;
+};
+
+// TechCardIssueSeverity ranks a flagged construction issue.
+export type common_TechCardIssueSeverity =
+  | "TECH_CARD_ISSUE_SEVERITY_UNKNOWN"
+  | "TECH_CARD_ISSUE_SEVERITY_LOW"
+  | "TECH_CARD_ISSUE_SEVERITY_MEDIUM"
+  | "TECH_CARD_ISSUE_SEVERITY_HIGH";
+// TechCardIssueStatus is the resolution state of a flagged issue.
+export type common_TechCardIssueStatus =
+  | "TECH_CARD_ISSUE_STATUS_UNKNOWN"
+  | "TECH_CARD_ISSUE_STATUS_OPEN"
+  | "TECH_CARD_ISSUE_STATUS_RESOLVED"
+  | "TECH_CARD_ISSUE_STATUS_WONTFIX";
+// TechCardSizeQuantity is the production order quantity for a size (size run).
+export type common_TechCardSizeQuantity = {
+  sizeId: number | undefined;
+  orderQty: number | undefined;
+};
+
+// TechCardSignoff records one responsible role's sign-off of a sheet, so the
+// header approval_state isn't the only gate (Sheet «Титул» coordination).
+export type common_TechCardSignoff = {
+  section: common_TechCardSignoffSection | undefined;
+  state: common_TechCardSignoffState | undefined;
+  signedBy: string | undefined;
+  signedAt: wellKnownTimestamp | undefined;
+  note: string | undefined;
+};
+
+// TechCardInsert is the writable payload for a tech card. Nested lists are full
+// replacements on update (like ProductNew).
+// TechCardSignoffSection is the sheet a sign-off covers.
+export type common_TechCardSignoffSection =
+  | "TECH_CARD_SIGNOFF_SECTION_UNKNOWN"
+  | "TECH_CARD_SIGNOFF_SECTION_DESIGN"
+  | "TECH_CARD_SIGNOFF_SECTION_CONSTRUCTION"
+  | "TECH_CARD_SIGNOFF_SECTION_POM"
+  | "TECH_CARD_SIGNOFF_SECTION_MATERIALS"
+  | "TECH_CARD_SIGNOFF_SECTION_COLOUR"
+  | "TECH_CARD_SIGNOFF_SECTION_LABELS"
+  | "TECH_CARD_SIGNOFF_SECTION_PACKAGING"
+  | "TECH_CARD_SIGNOFF_SECTION_COSTING";
+// TechCardSignoffState is the sign-off decision for a section.
+export type common_TechCardSignoffState =
+  | "TECH_CARD_SIGNOFF_STATE_UNKNOWN"
+  | "TECH_CARD_SIGNOFF_STATE_PENDING"
+  | "TECH_CARD_SIGNOFF_STATE_APPROVED"
+  | "TECH_CARD_SIGNOFF_STATE_REJECTED";
+export type CreateTechCardResponse = {
+  id: number | undefined;
+};
+
+export type GetTechCardRequest = {
+  id: number | undefined;
+};
+
+export type GetTechCardResponse = {
+  techCard: common_TechCard | undefined;
+};
+
+// TechCard is a stored tech card with resolved sketch media.
+export type common_TechCard = {
+  id: number | undefined;
+  techCard: common_TechCardInsert | undefined;
+  createdAt: wellKnownTimestamp | undefined;
+  updatedAt: wellKnownTimestamp | undefined;
+  resolvedMedia: common_TechCardMediaFull[] | undefined;
+  lockVersion: number | undefined;
+};
+
+// TechCardMediaFull is a resolved sketch-media reference for display.
+export type common_TechCardMediaFull = {
+  media: common_MediaFull | undefined;
+  kind: common_TechCardMediaKind | undefined;
+};
+
+export type UpdateTechCardRequest = {
+  id: number | undefined;
+  techCard: common_TechCardInsert | undefined;
+  expectedLockVersion: number | undefined;
+};
+
+export type UpdateTechCardResponse = {
+};
+
+export type DeleteTechCardRequest = {
+  id: number | undefined;
+};
+
+export type DeleteTechCardResponse = {
+};
+
+export type ListTechCardsRequest = {
+  limit: number | undefined;
+  offset: number | undefined;
+  orderFactor: common_OrderFactor | undefined;
+  stage: common_TechCardStage | undefined;
+  gender: common_GenderEnum | undefined;
+  brand: string | undefined;
+  season: string | undefined;
+  name: string | undefined;
+  productId: number | undefined;
+};
+
+export type ListTechCardsResponse = {
+  techCards: common_TechCardListItem[] | undefined;
+  total: number | undefined;
+};
+
+// TechCardListItem is a lightweight tech-card header for list views.
+export type common_TechCardListItem = {
+  id: number | undefined;
+  styleNumber: string | undefined;
+  name: string | undefined;
+  brand: string | undefined;
+  stage: common_TechCardStage | undefined;
+  status: string | undefined;
+  targetGender: common_GenderEnum | undefined;
+  season: string | undefined;
+  createdAt: wellKnownTimestamp | undefined;
+  updatedAt: wellKnownTimestamp | undefined;
+  approvalState: common_TechCardApprovalState | undefined;
+};
+
 export interface AdminService {
   // Retrieves a key-value dictionary.
   GetDictionary(request: GetDictionaryRequest): Promise<GetDictionaryResponse>;
@@ -2562,6 +3046,19 @@ export interface AdminService {
   // Declared last on purpose (see ListModels ordering note) so GET /fitting/list
   // is not shadowed by GET /fitting/{id}.
   ListFittings(request: ListFittingsRequest): Promise<ListFittingsResponse>;
+  // CreateTechCard creates a new tech card (техкарта) with its nested sections.
+  CreateTechCard(request: CreateTechCardRequest): Promise<CreateTechCardResponse>;
+  // GetTechCard returns a tech card by id with its nested sections resolved.
+  GetTechCard(request: GetTechCardRequest): Promise<GetTechCardResponse>;
+  // UpdateTechCard updates a tech card, replacing its nested sections.
+  UpdateTechCard(request: UpdateTechCardRequest): Promise<UpdateTechCardResponse>;
+  // DeleteTechCard deletes a tech card by id (nested sections cascade).
+  DeleteTechCard(request: DeleteTechCardRequest): Promise<DeleteTechCardResponse>;
+  // ListTechCards lists tech cards (paged, optional filters). Declared AFTER
+  // GetTechCard so the mux (which prepends handlers, first-match wins) checks
+  // /tech-card/list before /tech-card/{id}. Guarded by
+  // TestTechCardListRouteNotShadowed.
+  ListTechCards(request: ListTechCardsRequest): Promise<ListTechCardsResponse>;
   UpdateSettings(request: UpdateSettingsRequest): Promise<UpdateSettingsResponse>;
   GetBackgroundHeroColor(request: GetBackgroundHeroColorRequest): Promise<GetBackgroundHeroColorResponse>;
   SetBackgroundHeroColor(request: SetBackgroundHeroColorRequest): Promise<SetBackgroundHeroColorResponse>;
@@ -3540,6 +4037,9 @@ export function createAdminServiceClient(
       if (request.modelId) {
         queryParams.push(`modelId=${encodeURIComponent(request.modelId.toString())}`)
       }
+      if (request.techCardId) {
+        queryParams.push(`techCardId=${encodeURIComponent(request.techCardId.toString())}`)
+      }
       let uri = path;
       if (queryParams.length > 0) {
         uri += `?${queryParams.join("&")}`
@@ -3552,6 +4052,124 @@ export function createAdminServiceClient(
         service: "AdminService",
         method: "ListFittings",
       }) as Promise<ListFittingsResponse>;
+    },
+    CreateTechCard(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/tech-card/add`; // eslint-disable-line quotes
+      const body = JSON.stringify(request);
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "POST",
+        body,
+      }, {
+        service: "AdminService",
+        method: "CreateTechCard",
+      }) as Promise<CreateTechCardResponse>;
+    },
+    GetTechCard(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      if (!request.id) {
+        throw new Error("missing required field request.id");
+      }
+      const path = `api/admin/tech-card/${request.id}`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "GET",
+        body,
+      }, {
+        service: "AdminService",
+        method: "GetTechCard",
+      }) as Promise<GetTechCardResponse>;
+    },
+    UpdateTechCard(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/tech-card/update`; // eslint-disable-line quotes
+      const body = JSON.stringify(request);
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "POST",
+        body,
+      }, {
+        service: "AdminService",
+        method: "UpdateTechCard",
+      }) as Promise<UpdateTechCardResponse>;
+    },
+    DeleteTechCard(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      if (!request.id) {
+        throw new Error("missing required field request.id");
+      }
+      const path = `api/admin/tech-card/${request.id}`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "DELETE",
+        body,
+      }, {
+        service: "AdminService",
+        method: "DeleteTechCard",
+      }) as Promise<DeleteTechCardResponse>;
+    },
+    ListTechCards(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/tech-card/list`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      if (request.limit) {
+        queryParams.push(`limit=${encodeURIComponent(request.limit.toString())}`)
+      }
+      if (request.offset) {
+        queryParams.push(`offset=${encodeURIComponent(request.offset.toString())}`)
+      }
+      if (request.orderFactor) {
+        queryParams.push(`orderFactor=${encodeURIComponent(request.orderFactor.toString())}`)
+      }
+      if (request.stage) {
+        queryParams.push(`stage=${encodeURIComponent(request.stage.toString())}`)
+      }
+      if (request.gender) {
+        queryParams.push(`gender=${encodeURIComponent(request.gender.toString())}`)
+      }
+      if (request.brand) {
+        queryParams.push(`brand=${encodeURIComponent(request.brand.toString())}`)
+      }
+      if (request.season) {
+        queryParams.push(`season=${encodeURIComponent(request.season.toString())}`)
+      }
+      if (request.name) {
+        queryParams.push(`name=${encodeURIComponent(request.name.toString())}`)
+      }
+      if (request.productId) {
+        queryParams.push(`productId=${encodeURIComponent(request.productId.toString())}`)
+      }
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "GET",
+        body,
+      }, {
+        service: "AdminService",
+        method: "ListTechCards",
+      }) as Promise<ListTechCardsResponse>;
     },
     UpdateSettings(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
       const path = `api/admin/settings/update`; // eslint-disable-line quotes

--- a/src/api/proto-http/common/index.ts
+++ b/src/api/proto-http/common/index.ts
@@ -778,7 +778,9 @@ export type FittingSizeInsert = {
   fitNote: string | undefined;
 };
 
-// FittingInsert is the writable payload for a fitting session.
+// FittingInsert is the writable payload for a fitting session. A fitting anchors
+// to a tech card (the style) and/or a specific product (the colour/SKU sample);
+// at least one of tech_card_id / product_id must be set.
 export type FittingInsert = {
   productId: number | undefined;
   modelId: number | undefined;
@@ -789,6 +791,7 @@ export type FittingInsert = {
   recordedBy: string | undefined;
   sizes: FittingSizeInsert[] | undefined;
   mediaIds: number[] | undefined;
+  techCardId: number | undefined;
 };
 
 // Fitting is a stored try-on session with resolved media for display.
@@ -1038,6 +1041,437 @@ export type SupportTicket = {
   category: string | undefined;
   priority: SupportTicketPriority | undefined;
   internalNotes: string | undefined;
+};
+
+// TechCardStage is the development stage of a tech pack: prototype, fit sample,
+// salesman sample, pre-production, production.
+export type TechCardStage =
+  | "TECH_CARD_STAGE_UNKNOWN"
+  | "TECH_CARD_STAGE_PROTO"
+  | "TECH_CARD_STAGE_FIT"
+  | "TECH_CARD_STAGE_SMS"
+  | "TECH_CARD_STAGE_PP"
+  | "TECH_CARD_STAGE_PROD";
+// TechCardApprovalState is the gating release state of a tech card, orthogonal to
+// TechCardStage (which tracks development progress). A factory must only receive a
+// card in the RELEASED state.
+export type TechCardApprovalState =
+  | "TECH_CARD_APPROVAL_STATE_UNKNOWN"
+  | "TECH_CARD_APPROVAL_STATE_DRAFT"
+  | "TECH_CARD_APPROVAL_STATE_IN_REVIEW"
+  | "TECH_CARD_APPROVAL_STATE_APPROVED"
+  | "TECH_CARD_APPROVAL_STATE_RELEASED"
+  | "TECH_CARD_APPROVAL_STATE_OBSOLETE";
+// TechCardMeasurementUnit is the unit for the card's geometry (callout dimensions
+// and the POM chart). Metric only — the brand works in cm and mm, never inches.
+export type TechCardMeasurementUnit =
+  | "TECH_CARD_MEASUREMENT_UNIT_UNKNOWN"
+  | "TECH_CARD_MEASUREMENT_UNIT_CM"
+  | "TECH_CARD_MEASUREMENT_UNIT_MM";
+// TechCardMediaKind classifies a tech-card sketch image.
+export type TechCardMediaKind =
+  | "TECH_CARD_MEDIA_KIND_UNKNOWN"
+  | "TECH_CARD_MEDIA_KIND_FRONT"
+  | "TECH_CARD_MEDIA_KIND_BACK"
+  | "TECH_CARD_MEDIA_KIND_DETAIL"
+  | "TECH_CARD_MEDIA_KIND_LINING"
+  | "TECH_CARD_MEDIA_KIND_PREVIEW"
+  | "TECH_CARD_MEDIA_KIND_MOODBOARD"
+  | "TECH_CARD_MEDIA_KIND_REFERENCE"
+  | "TECH_CARD_MEDIA_KIND_SWATCH";
+// TechCardBomSection groups a BOM line by material family (Sheet «Спецификация»).
+export type TechCardBomSection =
+  | "TECH_CARD_BOM_SECTION_UNKNOWN"
+  | "TECH_CARD_BOM_SECTION_FABRIC"
+  | "TECH_CARD_BOM_SECTION_LINING"
+  | "TECH_CARD_BOM_SECTION_INTERLINING"
+  | "TECH_CARD_BOM_SECTION_INSULATION"
+  | "TECH_CARD_BOM_SECTION_HARDWARE"
+  | "TECH_CARD_BOM_SECTION_THREAD"
+  | "TECH_CARD_BOM_SECTION_LABEL"
+  | "TECH_CARD_BOM_SECTION_PACKAGING";
+// TechCardLabDipStatus is the lab-dip approval lifecycle of a colourway.
+export type TechCardLabDipStatus =
+  | "TECH_CARD_LAB_DIP_STATUS_UNKNOWN"
+  | "TECH_CARD_LAB_DIP_STATUS_PENDING"
+  | "TECH_CARD_LAB_DIP_STATUS_SUBMITTED"
+  | "TECH_CARD_LAB_DIP_STATUS_APPROVED"
+  | "TECH_CARD_LAB_DIP_STATUS_REJECTED";
+// TechCardFabricDirection is the cutting layout a fabric requires.
+export type TechCardFabricDirection =
+  | "TECH_CARD_FABRIC_DIRECTION_UNKNOWN"
+  | "TECH_CARD_FABRIC_DIRECTION_ANY"
+  | "TECH_CARD_FABRIC_DIRECTION_ONE_WAY"
+  | "TECH_CARD_FABRIC_DIRECTION_TWO_WAY";
+// TechCardPomVerdict is the computed in/out-of-tolerance result of an actual.
+export type TechCardPomVerdict =
+  | "TECH_CARD_POM_VERDICT_UNKNOWN"
+  | "TECH_CARD_POM_VERDICT_IN_TOLERANCE"
+  | "TECH_CARD_POM_VERDICT_OVER"
+  | "TECH_CARD_POM_VERDICT_UNDER";
+// TechCardLabelType classifies a label / tag (Sheet «Этикетки и упаковка»).
+export type TechCardLabelType =
+  | "TECH_CARD_LABEL_TYPE_UNKNOWN"
+  | "TECH_CARD_LABEL_TYPE_MAIN"
+  | "TECH_CARD_LABEL_TYPE_SIZE"
+  | "TECH_CARD_LABEL_TYPE_CARE"
+  | "TECH_CARD_LABEL_TYPE_ORIGIN"
+  | "TECH_CARD_LABEL_TYPE_FLAG"
+  | "TECH_CARD_LABEL_TYPE_HANGTAG"
+  | "TECH_CARD_LABEL_TYPE_BARCODE"
+  | "TECH_CARD_LABEL_TYPE_SPECIAL";
+// TechCardIssueSeverity ranks a flagged construction issue.
+export type TechCardIssueSeverity =
+  | "TECH_CARD_ISSUE_SEVERITY_UNKNOWN"
+  | "TECH_CARD_ISSUE_SEVERITY_LOW"
+  | "TECH_CARD_ISSUE_SEVERITY_MEDIUM"
+  | "TECH_CARD_ISSUE_SEVERITY_HIGH";
+// TechCardIssueStatus is the resolution state of a flagged issue.
+export type TechCardIssueStatus =
+  | "TECH_CARD_ISSUE_STATUS_UNKNOWN"
+  | "TECH_CARD_ISSUE_STATUS_OPEN"
+  | "TECH_CARD_ISSUE_STATUS_RESOLVED"
+  | "TECH_CARD_ISSUE_STATUS_WONTFIX";
+// TechCardInsert is the writable payload for a tech card. Nested lists are full
+// replacements on update (like ProductNew).
+// TechCardSignoffSection is the sheet a sign-off covers.
+export type TechCardSignoffSection =
+  | "TECH_CARD_SIGNOFF_SECTION_UNKNOWN"
+  | "TECH_CARD_SIGNOFF_SECTION_DESIGN"
+  | "TECH_CARD_SIGNOFF_SECTION_CONSTRUCTION"
+  | "TECH_CARD_SIGNOFF_SECTION_POM"
+  | "TECH_CARD_SIGNOFF_SECTION_MATERIALS"
+  | "TECH_CARD_SIGNOFF_SECTION_COLOUR"
+  | "TECH_CARD_SIGNOFF_SECTION_LABELS"
+  | "TECH_CARD_SIGNOFF_SECTION_PACKAGING"
+  | "TECH_CARD_SIGNOFF_SECTION_COSTING";
+// TechCardSignoffState is the sign-off decision for a section.
+export type TechCardSignoffState =
+  | "TECH_CARD_SIGNOFF_STATE_UNKNOWN"
+  | "TECH_CARD_SIGNOFF_STATE_PENDING"
+  | "TECH_CARD_SIGNOFF_STATE_APPROVED"
+  | "TECH_CARD_SIGNOFF_STATE_REJECTED";
+// TechCardMediaItem is a writable sketch-media reference (id + kind).
+export type TechCardMediaItem = {
+  mediaId: number | undefined;
+  kind: TechCardMediaKind | undefined;
+  caption: string | undefined;
+};
+
+// TechCardMediaFull is a resolved sketch-media reference for display.
+export type TechCardMediaFull = {
+  media: MediaFull | undefined;
+  kind: TechCardMediaKind | undefined;
+};
+
+// TechCardCallout is a numbered detail note pointing at the technical sketch.
+export type TechCardCallout = {
+  number: number | undefined;
+  part: string | undefined;
+  description: string | undefined;
+  dimensions: string | undefined;
+  mediaId: number | undefined;
+  posX: googletype_Decimal | undefined;
+  posY: googletype_Decimal | undefined;
+};
+
+// TechCardRevision is one entry in the spec-document changelog (what changed in
+// which section, by whom). This is NOT fit history — fitting verdicts and
+// measurements live in the separate fitting feature.
+export type TechCardRevision = {
+  version: string | undefined;
+  revisionDate: wellKnownTimestamp | undefined;
+  author: string | undefined;
+  section: string | undefined;
+  changeNote: string | undefined;
+};
+
+// TechCardColorway is a development colourway (Sheet «Колористика» columns). It is
+// distinct from tech_card_product (published catalog SKUs); product_id optionally
+// links the published SKU that realises this colourway.
+export type TechCardColorway = {
+  code: string | undefined;
+  name: string | undefined;
+  labDipStatus: TechCardLabDipStatus | undefined;
+  productId: number | undefined;
+  comment: string | undefined;
+  pantone: string | undefined;
+  pantoneSystem: string | undefined;
+  hex: string | undefined;
+  swatchMediaId: number | undefined;
+  labDipRound: number | undefined;
+  labDipSubmittedAt: wellKnownTimestamp | undefined;
+  labDipDecidedAt: wellKnownTimestamp | undefined;
+  labDipDecidedBy: string | undefined;
+  labDipRejectReason: string | undefined;
+};
+
+// TechCardBomColorwayColor is one «Колористика» matrix cell: the colour of a BOM
+// material in a colourway. colorway_index points into TechCardInsert.colorways — a
+// full-replace upsert has no stable colourway ids to reference on write.
+export type TechCardBomColorwayColor = {
+  colorwayIndex: number | undefined;
+  color: string | undefined;
+  pantone: string | undefined;
+};
+
+// TechCardBomItem is one bill-of-materials line (Sheet «Спецификация»).
+export type TechCardBomItem = {
+  section: TechCardBomSection | undefined;
+  name: string | undefined;
+  placement: string | undefined;
+  supplier: string | undefined;
+  supplierRef: string | undefined;
+  color: string | undefined;
+  composition: string | undefined;
+  spec: string | undefined;
+  // consumption vs quantity: fill ONE per line. consumption = per-garment rate of
+  // a measured material (fabric/lining/interlining/insulation/thread) in `unit`
+  // (м/см/г); quantity = discrete count of a countable trim (hardware/label/
+  // packaging), `unit` then = pcs. line_total uses quantity when set, else consumption.
+  consumption: googletype_Decimal | undefined;
+  unit: string | undefined;
+  quantity: googletype_Decimal | undefined;
+  unitPrice: googletype_Decimal | undefined;
+  currency: string | undefined;
+  comment: string | undefined;
+  colorwayColors: TechCardBomColorwayColor[] | undefined;
+  lineTotal: googletype_Decimal | undefined;
+  // fabric data for the cutter / marker (Phase 3.5c)
+  fabricWidth: googletype_Decimal | undefined;
+  fabricWeightGsm: googletype_Decimal | undefined;
+  fabricDirection: TechCardFabricDirection | undefined;
+  wastagePercent: googletype_Decimal | undefined;
+};
+
+// TechCardSizeQuantity is the production order quantity for a size (size run).
+export type TechCardSizeQuantity = {
+  sizeId: number | undefined;
+  orderQty: number | undefined;
+};
+
+// TechCardPomGrade is the graded value of a POM point for one size.
+export type TechCardPomGrade = {
+  sizeId: number | undefined;
+  value: googletype_Decimal | undefined;
+};
+
+// TechCardPomActual is an actual measured value, optionally taken in a fitting and
+// at a specific size (so QC can compare it to that size's grade ± tolerance).
+export type TechCardPomActual = {
+  fittingId: number | undefined;
+  label: string | undefined;
+  value: googletype_Decimal | undefined;
+  sizeId: number | undefined;
+  // OUTPUT-ONLY: deviation = value - target (grade at size_id, else base_value);
+  // verdict compares the deviation against tolerance_plus / tolerance_minus.
+  deviation: googletype_Decimal | undefined;
+  verdict: TechCardPomVerdict | undefined;
+};
+
+// TechCardPomPoint is a point of measure with its grade and actuals (Sheet «Измерения»).
+// Values are in TechCardInsert.measurement_unit.
+export type TechCardPomPoint = {
+  section: string | undefined;
+  code: string | undefined;
+  name: string | undefined;
+  howToMeasure: string | undefined;
+  baseValue: googletype_Decimal | undefined;
+  tolerancePlus: googletype_Decimal | undefined;
+  toleranceMinus: googletype_Decimal | undefined;
+  grades: TechCardPomGrade[] | undefined;
+  actuals: TechCardPomActual[] | undefined;
+};
+
+// TechCardConstruction holds general workmanship parameters (Sheet «Обработка»).
+export type TechCardConstruction = {
+  mainStitchType: string | undefined;
+  stitchDensity: string | undefined;
+  overlockThreads: string | undefined;
+  seamAllowances: string | undefined;
+  hemFinish: string | undefined;
+  pressing: string | undefined;
+  machineClass: string | undefined;
+  notes: string | undefined;
+  labourRate: googletype_Decimal | undefined;
+  labourRateCurrency: string | undefined;
+};
+
+// TechCardOperation is one per-node sewing operation (Sheet «Обработка»).
+export type TechCardOperation = {
+  node: string | undefined;
+  description: string | undefined;
+  seamType: string | undefined;
+  stitchesPerCm: googletype_Decimal | undefined;
+  topstitchWidth: string | undefined;
+  thread: string | undefined;
+  note: string | undefined;
+  operationNumber: number | undefined;
+  machine: string | undefined;
+  seamAllowance: string | undefined;
+  needle: string | undefined;
+  timeNorm: googletype_Decimal | undefined;
+};
+
+// TechCardIssue is a maker-flagged problem ("this seam is impossible") against an
+// operation or callout (Sheet «Обработка» / «Тех. эскиз»).
+export type TechCardIssue = {
+  operationNumber: number | undefined;
+  calloutNumber: number | undefined;
+  raisedBy: string | undefined;
+  severity: TechCardIssueSeverity | undefined;
+  status: TechCardIssueStatus | undefined;
+  description: string | undefined;
+  resolutionNote: string | undefined;
+};
+
+// TechCardLabel is one label / tag spec (Sheet «Этикетки и упаковка»).
+export type TechCardLabel = {
+  labelType: TechCardLabelType | undefined;
+  content: string | undefined;
+  placement: string | undefined;
+  attachment: string | undefined;
+  size: string | undefined;
+  note: string | undefined;
+};
+
+// TechCardPackaging holds the packaging spec (Sheet «Этикетки и упаковка»).
+export type TechCardPackaging = {
+  foldingMethod: string | undefined;
+  polybag: string | undefined;
+  bagSticker: string | undefined;
+  inserts: string | undefined;
+  unitsPerBox: number | undefined;
+  boxMarking: string | undefined;
+  boxDimensions: string | undefined;
+  weightNet: googletype_Decimal | undefined;
+  weightGross: googletype_Decimal | undefined;
+  notes: string | undefined;
+};
+
+// TechCardCostLine is one currency bucket of the materials rollup.
+export type TechCardCostLine = {
+  currency: string | undefined;
+  amount: googletype_Decimal | undefined;
+};
+
+// TechCardCosting holds the manually-entered cost articles (Sheet «Калькуляция»).
+// The materials rollup and total are COMPUTED on read from the BOM; they are
+// output-only (ignored on write) and never converted across currencies.
+export type TechCardCosting = {
+  cmtCost: googletype_Decimal | undefined;
+  hardwareCost: googletype_Decimal | undefined;
+  packagingCost: googletype_Decimal | undefined;
+  logisticsCost: googletype_Decimal | undefined;
+  overheadCost: googletype_Decimal | undefined;
+  defectPercent: googletype_Decimal | undefined;
+  markupMultiplier: googletype_Decimal | undefined;
+  wholesalePrice: googletype_Decimal | undefined;
+  retailPrice: googletype_Decimal | undefined;
+  currency: string | undefined;
+  notes: string | undefined;
+  // OUTPUT-ONLY computed rollup (ignored on write; no currency conversion).
+  materialsTotal: TechCardCostLine[] | undefined;
+  materialsCost: googletype_Decimal | undefined;
+  totalCost: googletype_Decimal | undefined;
+  hasUnconvertedCurrencies: boolean | undefined;
+  totalSam: googletype_Decimal | undefined;
+  labourCost: googletype_Decimal | undefined;
+};
+
+// TechCardSignoff records one responsible role's sign-off of a sheet, so the
+// header approval_state isn't the only gate (Sheet «Титул» coordination).
+export type TechCardSignoff = {
+  section: TechCardSignoffSection | undefined;
+  state: TechCardSignoffState | undefined;
+  signedBy: string | undefined;
+  signedAt: wellKnownTimestamp | undefined;
+  note: string | undefined;
+};
+
+export type TechCardInsert = {
+  // identification (Sheet «Титул»)
+  styleNumber: string | undefined;
+  name: string | undefined;
+  brand: string | undefined;
+  season: string | undefined;
+  collection: string | undefined;
+  categoryId: number | undefined;
+  targetGender: GenderEnum | undefined;
+  stage: TechCardStage | undefined;
+  status: string | undefined;
+  approvalState: TechCardApprovalState | undefined;
+  approvedBy: string | undefined;
+  releasedAt: wellKnownTimestamp | undefined;
+  measurementUnit: TechCardMeasurementUnit | undefined;
+  version: string | undefined;
+  revisionDate: wellKnownTimestamp | undefined;
+  baseModelId: number | undefined;
+  baseSampleSizeId: number | undefined;
+  designer: string | undefined;
+  constructor: string | undefined;
+  technologist: string | undefined;
+  targetCost: googletype_Decimal | undefined;
+  targetRetailPrice: googletype_Decimal | undefined;
+  currency: string | undefined;
+  // construction description (lower block of Sheet «Титул»)
+  description: string | undefined;
+  silhouette: string | undefined;
+  collar: string | undefined;
+  fastening: string | undefined;
+  pockets: string | undefined;
+  sleeveCuff: string | undefined;
+  extraDetails: string | undefined;
+  topstitching: string | undefined;
+  auxMaterials: string | undefined;
+  notes: string | undefined;
+  // children (full-replace on update)
+  sizeIds: number[] | undefined;
+  productIds: number[] | undefined;
+  media: TechCardMediaItem[] | undefined;
+  callouts: TechCardCallout[] | undefined;
+  revisions: TechCardRevision[] | undefined;
+  // materials (Phase 2): bill of materials, colourways, points of measure.
+  bomItems: TechCardBomItem[] | undefined;
+  colorways: TechCardColorway[] | undefined;
+  pomPoints: TechCardPomPoint[] | undefined;
+  // production (Phase 3): construction, operations, labels, packaging, costing.
+  construction: TechCardConstruction | undefined;
+  operations: TechCardOperation[] | undefined;
+  labels: TechCardLabel[] | undefined;
+  packaging: TechCardPackaging | undefined;
+  costing: TechCardCosting | undefined;
+  // hardening (Phase 3.5a)
+  approvedAt: wellKnownTimestamp | undefined;
+  concept: string | undefined;
+  issues: TechCardIssue[] | undefined;
+  sizeQuantities: TechCardSizeQuantity[] | undefined;
+  signoffs: TechCardSignoff[] | undefined;
+};
+
+// TechCard is a stored tech card with resolved sketch media.
+export type TechCard = {
+  id: number | undefined;
+  techCard: TechCardInsert | undefined;
+  createdAt: wellKnownTimestamp | undefined;
+  updatedAt: wellKnownTimestamp | undefined;
+  resolvedMedia: TechCardMediaFull[] | undefined;
+  lockVersion: number | undefined;
+};
+
+// TechCardListItem is a lightweight tech-card header for list views.
+export type TechCardListItem = {
+  id: number | undefined;
+  styleNumber: string | undefined;
+  name: string | undefined;
+  brand: string | undefined;
+  stage: TechCardStage | undefined;
+  status: string | undefined;
+  targetGender: GenderEnum | undefined;
+  season: string | undefined;
+  createdAt: wellKnownTimestamp | undefined;
+  updatedAt: wellKnownTimestamp | undefined;
+  approvalState: TechCardApprovalState | undefined;
 };
 
 

--- a/src/components/managers/tech-card/components/bom-field.tsx
+++ b/src/components/managers/tech-card/components/bom-field.tsx
@@ -1,0 +1,186 @@
+import { techCardBomSectionOptions, techCardFabricDirectionOptions } from 'constants/filter';
+import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
+import { Button } from 'ui/components/button';
+import Text from 'ui/components/text';
+import InputField from 'ui/form/fields/input-field';
+import SelectField from 'ui/form/fields/select-field';
+import TextareaField from 'ui/form/fields/textarea-field';
+import { multiplyDecimalInputs } from 'utils/decimal';
+import { TechCardFormData } from './schema';
+
+const emptyBomItem = {
+  section: 'TECH_CARD_BOM_SECTION_FABRIC',
+  name: '',
+  placement: '',
+  supplier: '',
+  supplierRef: '',
+  color: '',
+  composition: '',
+  spec: '',
+  consumption: '',
+  unit: '',
+  quantity: '',
+  unitPrice: '',
+  currency: '',
+  comment: '',
+  colorwayColors: [],
+};
+
+// One BOM line (Sheet «Спецификация»). Decimals (consumption/quantity/unit_price) are
+// edited as strings. line_total is server-computed (output-only) — shown here only as a
+// live client preview. Per-colourway colour cells reference colourways by index.
+function BomItemRow({ index, onRemove }: { index: number; onRemove: () => void }) {
+  const { control } = useFormContext<TechCardFormData>();
+  const colorwayColors = useFieldArray({
+    control,
+    name: `bomItems.${index}.colorwayColors` as `bomItems.${number}.colorwayColors`,
+  });
+  const colorways = (useWatch({ control, name: 'colorways' }) ?? []) as Array<{
+    name?: string;
+    code?: string;
+  }>;
+
+  const consumption = useWatch({ control, name: `bomItems.${index}.consumption` }) as string;
+  const quantity = useWatch({ control, name: `bomItems.${index}.quantity` }) as string;
+  const unitPrice = useWatch({ control, name: `bomItems.${index}.unitPrice` }) as string;
+  // proto: line_total = quantity*unit_price (else consumption*unit_price)
+  const lineTotal = multiplyDecimalInputs(quantity?.trim() ? quantity : consumption, unitPrice);
+
+  const colorwayOptions = colorways.map((c, i) => ({
+    value: i,
+    label: c.name ? `${c.name}${c.code ? ` (${c.code})` : ''}` : `colourway ${i + 1}`,
+  }));
+
+  return (
+    <div className='space-y-3 border border-textInactiveColor p-3'>
+      <div className='flex items-center justify-between'>
+        <Text variant='uppercase' size='small'>
+          line {index + 1}
+        </Text>
+        <Button type='button' variant='secondary' aria-label='remove BOM line' onClick={onRemove}>
+          ✕
+        </Button>
+      </div>
+
+      <div className='grid grid-cols-1 gap-3 lg:grid-cols-3'>
+        <SelectField
+          name={`bomItems.${index}.section`}
+          label='section *'
+          items={techCardBomSectionOptions}
+        />
+        <InputField name={`bomItems.${index}.name`} label='name *' />
+        <InputField name={`bomItems.${index}.placement`} label='placement' />
+        <InputField name={`bomItems.${index}.supplier`} label='supplier' />
+        <InputField name={`bomItems.${index}.supplierRef`} label='supplier ref' />
+        <InputField name={`bomItems.${index}.color`} label='color' />
+        <InputField name={`bomItems.${index}.composition`} label='composition' />
+        <InputField name={`bomItems.${index}.spec`} label='spec (width / weight)' />
+        <InputField name={`bomItems.${index}.unit`} label='unit' placeholder='m / pcs' />
+      </div>
+
+      <div className='grid grid-cols-2 items-end gap-3 lg:grid-cols-5'>
+        <InputField name={`bomItems.${index}.consumption`} label='consumption' />
+        <InputField name={`bomItems.${index}.quantity`} label='quantity' />
+        <InputField name={`bomItems.${index}.unitPrice`} label='unit price' />
+        <InputField name={`bomItems.${index}.currency`} label='currency' placeholder='EUR' />
+        <div className='space-y-1'>
+          <Text variant='uppercase' size='small'>
+            line total
+          </Text>
+          <Text variant='inactive'>{lineTotal || '—'}</Text>
+        </div>
+      </div>
+
+      <TextareaField name={`bomItems.${index}.comment`} label='comment' rows={2} maxLength={1000} />
+
+      <div className='space-y-2 border-t border-textInactiveColor pt-3'>
+        <Text variant='uppercase' size='small'>
+          fabric data (for the cutter)
+        </Text>
+        <div className='grid grid-cols-2 gap-3 lg:grid-cols-4'>
+          <InputField name={`bomItems.${index}.fabricWidth`} label='width (cm)' />
+          <InputField name={`bomItems.${index}.fabricWeightGsm`} label='weight (g/m²)' />
+          <SelectField
+            name={`bomItems.${index}.fabricDirection`}
+            label='direction'
+            items={techCardFabricDirectionOptions}
+          />
+          <InputField name={`bomItems.${index}.wastagePercent`} label='wastage %' />
+        </div>
+      </div>
+
+      <div className='space-y-2 border-t border-textInactiveColor pt-3'>
+        <Text variant='uppercase' size='small'>
+          colourway colours
+        </Text>
+        {colorways.length === 0 ? (
+          <Text variant='inactive' size='small'>
+            define colourways above to assign per-colourway colours
+          </Text>
+        ) : (
+          <>
+            {colorwayColors.fields.map((f, j) => (
+              <div key={f.id} className='grid grid-cols-1 items-end gap-2 lg:grid-cols-4'>
+                <SelectField
+                  name={`bomItems.${index}.colorwayColors.${j}.colorwayIndex`}
+                  label='colourway'
+                  items={colorwayOptions}
+                  valueAsNumber
+                />
+                <InputField name={`bomItems.${index}.colorwayColors.${j}.color`} label='color' />
+                <InputField
+                  name={`bomItems.${index}.colorwayColors.${j}.pantone`}
+                  label='pantone'
+                />
+                <Button
+                  type='button'
+                  variant='secondary'
+                  aria-label='remove colour'
+                  onClick={() => colorwayColors.remove(j)}
+                >
+                  ✕
+                </Button>
+              </div>
+            ))}
+            <Button
+              type='button'
+              className='uppercase'
+              onClick={() => colorwayColors.append({ colorwayIndex: 0, color: '', pantone: '' })}
+            >
+              add colour
+            </Button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// Bill of materials (Sheet «Спецификация»).
+export function BomField() {
+  const { control } = useFormContext<TechCardFormData>();
+  const { fields, append, remove } = useFieldArray({ control, name: 'bomItems' });
+
+  return (
+    <div className='space-y-4'>
+      {fields.length === 0 ? (
+        <Text variant='inactive' size='small'>
+          no BOM lines
+        </Text>
+      ) : (
+        fields.map((f, index) => (
+          <BomItemRow key={f.id} index={index} onRemove={() => remove(index)} />
+        ))
+      )}
+
+      <Button
+        type='button'
+        variant='main'
+        className='uppercase'
+        onClick={() => append({ ...emptyBomItem })}
+      >
+        add BOM line
+      </Button>
+    </div>
+  );
+}

--- a/src/components/managers/tech-card/components/colorways-field.tsx
+++ b/src/components/managers/tech-card/components/colorways-field.tsx
@@ -1,0 +1,215 @@
+import { common_MediaFull, common_Product } from 'api/proto-http/admin';
+import { MediaSelector } from 'components/managers/media/components/media-selector';
+import { useProductsByIds } from 'components/managers/fittings/components/useResolvers';
+import { techCardLabDipStatusOptions } from 'constants/filter';
+import { useState } from 'react';
+import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
+import { Button } from 'ui/components/button';
+import Media from 'ui/components/media';
+import Text from 'ui/components/text';
+import InputField from 'ui/form/fields/input-field';
+import SelectField from 'ui/form/fields/select-field';
+import TextareaField from 'ui/form/fields/textarea-field';
+import { TechCardFormData } from './schema';
+
+const REJECTED = 'TECH_CARD_LAB_DIP_STATUS_REJECTED';
+
+const emptyColorway = {
+  code: '',
+  name: '',
+  labDipStatus: 'TECH_CARD_LAB_DIP_STATUS_PENDING',
+  productId: 0,
+  comment: '',
+  pantone: '',
+  pantoneSystem: '',
+  hex: '',
+  swatchMediaId: 0,
+  labDipRound: 0,
+  labDipSubmittedAt: '',
+  labDipDecidedAt: '',
+  labDipDecidedBy: '',
+  labDipRejectReason: '',
+};
+
+function productName(product?: common_Product): string {
+  return product?.productDisplay?.productBody?.translations?.[0]?.name ?? '';
+}
+
+function ColorwayRow({
+  index,
+  productOptions,
+  onRemove,
+}: {
+  index: number;
+  productOptions: Array<{ value: number; label: string }>;
+  onRemove: () => void;
+}) {
+  const { control, setValue } = useFormContext<TechCardFormData>();
+  const status = useWatch({ control, name: `colorways.${index}.labDipStatus` }) as string;
+  const hex = (useWatch({ control, name: `colorways.${index}.hex` }) as string) || '';
+  const swatchMediaId = useWatch({ control, name: `colorways.${index}.swatchMediaId` }) as number;
+  const [pickedSwatch, setPickedSwatch] = useState<common_MediaFull | undefined>();
+
+  const hexValid = /^#?[0-9a-fA-F]{3,8}$/.test(hex.trim());
+  const swatchUrl =
+    pickedSwatch?.media?.thumbnail?.mediaUrl || pickedSwatch?.media?.fullSize?.mediaUrl || '';
+
+  function handleSwatch(picked: common_MediaFull[]) {
+    const m = picked[0];
+    setValue(`colorways.${index}.swatchMediaId`, m?.id ?? 0, { shouldDirty: true });
+    setPickedSwatch(m);
+  }
+
+  return (
+    <div className='space-y-3 border border-textInactiveColor p-3'>
+      <div className='flex items-center justify-between'>
+        <Text variant='uppercase' size='small'>
+          colourway {index + 1}
+        </Text>
+        <Button type='button' variant='secondary' aria-label='remove colourway' onClick={onRemove}>
+          ✕
+        </Button>
+      </div>
+
+      <div className='grid grid-cols-1 gap-3 lg:grid-cols-4'>
+        <InputField name={`colorways.${index}.code`} label='code' placeholder='BLK' />
+        <InputField name={`colorways.${index}.name`} label='name *' />
+        <SelectField
+          name={`colorways.${index}.labDipStatus`}
+          label='lab dip'
+          items={techCardLabDipStatusOptions}
+        />
+        <SelectField
+          name={`colorways.${index}.productId`}
+          label='linked product'
+          items={productOptions}
+          valueAsNumber
+        />
+      </div>
+
+      {/* colour identity */}
+      <div className='grid grid-cols-1 items-end gap-3 lg:grid-cols-4'>
+        <InputField name={`colorways.${index}.pantone`} label='pantone' placeholder='19-4005' />
+        <InputField
+          name={`colorways.${index}.pantoneSystem`}
+          label='pantone system'
+          placeholder='TCX'
+        />
+        <div className='flex items-end gap-2'>
+          <div className='flex-1'>
+            <InputField name={`colorways.${index}.hex`} label='hex' placeholder='#101010' />
+          </div>
+          <div
+            className='size-8 shrink-0 border border-textColor'
+            style={
+              hexValid ? { backgroundColor: hex.startsWith('#') ? hex : `#${hex}` } : undefined
+            }
+            aria-label='hex preview'
+          />
+        </div>
+        <div className='space-y-1'>
+          <Text variant='uppercase' size='small'>
+            swatch
+          </Text>
+          <div className='flex items-center gap-2'>
+            {swatchUrl ? (
+              <div className='size-10 shrink-0 border border-textColor'>
+                <Media src={swatchUrl} alt='swatch' aspectRatio='1/1' fit='cover' />
+              </div>
+            ) : swatchMediaId ? (
+              <Text variant='inactive' size='small'>
+                #{swatchMediaId}
+              </Text>
+            ) : null}
+            <MediaSelector
+              label='swatch'
+              purpose='colour swatch'
+              aspectRatio={['Custom']}
+              allowMultiple={false}
+              showVideos={false}
+              saveSelectedMedia={handleSwatch}
+              triggerClassName='px-2 py-1 uppercase'
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* lab-dip lifecycle */}
+      <div className='grid grid-cols-1 gap-3 lg:grid-cols-4'>
+        <InputField
+          name={`colorways.${index}.labDipRound`}
+          type='number'
+          valueAsNumber
+          label='lab-dip round'
+        />
+        <InputField name={`colorways.${index}.labDipSubmittedAt`} type='date' label='submitted' />
+        <InputField name={`colorways.${index}.labDipDecidedAt`} type='date' label='decided' />
+        <InputField name={`colorways.${index}.labDipDecidedBy`} label='decided by' />
+      </div>
+
+      {status === REJECTED && (
+        <TextareaField
+          name={`colorways.${index}.labDipRejectReason`}
+          label='reject reason'
+          rows={2}
+          maxLength={1000}
+        />
+      )}
+
+      <TextareaField
+        name={`colorways.${index}.comment`}
+        label='comment'
+        rows={2}
+        maxLength={1000}
+      />
+    </div>
+  );
+}
+
+// Development colourways (Sheet «Колористика») with the full lab-dip lifecycle. BOM
+// colour cells reference these by index. `productId` is restricted to the card's linked
+// products (cross-validated server-side: colorway.product_id ∈ product_ids).
+export function ColorwaysField() {
+  const { control } = useFormContext<TechCardFormData>();
+  const { fields, append, remove } = useFieldArray({ control, name: 'colorways' });
+  const productIds = (useWatch({ control, name: 'productIds' }) ?? []) as number[];
+  const productMap = useProductsByIds(productIds);
+
+  const productOptions = [
+    { value: 0, label: '— none —' },
+    ...productIds.map((id) => {
+      const name = productName(productMap.get(id));
+      return { value: id, label: name ? `${name} (#${id})` : `#${id}` };
+    }),
+  ];
+
+  return (
+    <div className='space-y-3'>
+      {fields.length === 0 ? (
+        <Text variant='inactive' size='small'>
+          no colourways
+        </Text>
+      ) : (
+        <div className='space-y-3'>
+          {fields.map((f, index) => (
+            <ColorwayRow
+              key={f.id}
+              index={index}
+              productOptions={productOptions}
+              onRemove={() => remove(index)}
+            />
+          ))}
+        </div>
+      )}
+
+      <Button
+        type='button'
+        variant='main'
+        className='uppercase'
+        onClick={() => append({ ...emptyColorway })}
+      >
+        add colourway
+      </Button>
+    </div>
+  );
+}

--- a/src/components/managers/tech-card/components/construction-field.tsx
+++ b/src/components/managers/tech-card/components/construction-field.tsx
@@ -1,0 +1,31 @@
+import InputField from 'ui/form/fields/input-field';
+import TextareaField from 'ui/form/fields/textarea-field';
+
+// General workmanship parameters (Sheet «Обработка», upper block). 1:1 — sent as
+// unset when every field is blank (see mapConstructionOut).
+export function ConstructionField() {
+  return (
+    <div className='space-y-3'>
+      <div className='grid grid-cols-1 gap-3 lg:grid-cols-2'>
+        <InputField name='construction.mainStitchType' label='main stitch type' />
+        <InputField name='construction.stitchDensity' label='stitch density (st/cm)' />
+        <InputField name='construction.overlockThreads' label='overlock threads' />
+        <InputField name='construction.seamAllowances' label='seam allowances' />
+        <InputField name='construction.hemFinish' label='hem finish' />
+        <InputField name='construction.pressing' label='pressing / finish' />
+        <InputField name='construction.machineClass' label='machine class' />
+        <InputField
+          name='construction.labourRate'
+          label='labour rate (cost / min)'
+          placeholder='0.50'
+        />
+        <InputField
+          name='construction.labourRateCurrency'
+          label='labour currency'
+          placeholder='EUR'
+        />
+      </div>
+      <TextareaField name='construction.notes' label='notes' rows={2} maxLength={2000} />
+    </div>
+  );
+}

--- a/src/components/managers/tech-card/components/costing-field.tsx
+++ b/src/components/managers/tech-card/components/costing-field.tsx
@@ -1,0 +1,71 @@
+import { common_TechCard } from 'api/proto-http/admin';
+import Text from 'ui/components/text';
+import InputField from 'ui/form/fields/input-field';
+import TextareaField from 'ui/form/fields/textarea-field';
+import { decimalToInput } from 'utils/decimal';
+
+// Manual cost articles (Sheet «Калькуляция»). 1:1 — sent as unset when blank. The
+// materials rollup + totals are computed server-side from the BOM (output-only): shown
+// read-only here from the last GetTechCard, never sent on write.
+export function CostingField({ techCard }: { techCard?: common_TechCard }) {
+  const rollup = techCard?.techCard?.costing;
+  const materialsTotal = rollup?.materialsTotal ?? [];
+  const hasRollup =
+    materialsTotal.length > 0 ||
+    !!rollup?.materialsCost?.value ||
+    !!rollup?.totalCost?.value ||
+    !!rollup?.totalSam?.value ||
+    !!rollup?.labourCost?.value;
+
+  return (
+    <div className='space-y-3'>
+      <div className='grid grid-cols-2 gap-3 lg:grid-cols-3'>
+        <InputField name='costing.cmtCost' label='CMT cost' />
+        <InputField name='costing.hardwareCost' label='hardware cost' />
+        <InputField name='costing.packagingCost' label='packaging cost' />
+        <InputField name='costing.logisticsCost' label='logistics cost' />
+        <InputField name='costing.overheadCost' label='overhead cost' />
+        <InputField name='costing.defectPercent' label='defect %' />
+        <InputField name='costing.markupMultiplier' label='markup ×' />
+        <InputField name='costing.wholesalePrice' label='wholesale price' />
+        <InputField name='costing.retailPrice' label='retail price' />
+        <InputField name='costing.currency' label='currency' placeholder='EUR' />
+      </div>
+      <TextareaField name='costing.notes' label='notes' rows={2} maxLength={2000} />
+
+      <div className='space-y-1 border-t border-textInactiveColor pt-3'>
+        <Text variant='uppercase' size='small'>
+          materials rollup (computed server-side)
+        </Text>
+        {hasRollup ? (
+          <>
+            {materialsTotal.map((line, i) => (
+              <Text key={i} variant='inactive' size='small'>
+                materials ({line.currency || 'no currency'}): {decimalToInput(line.amount) || '—'}
+              </Text>
+            ))}
+            <Text variant='inactive' size='small'>
+              materials cost: {decimalToInput(rollup?.materialsCost) || '—'}
+            </Text>
+            <Text variant='inactive' size='small'>
+              labour: Σ SAM {decimalToInput(rollup?.totalSam) || '—'} min →{' '}
+              {decimalToInput(rollup?.labourCost) || '—'}
+            </Text>
+            <Text variant='inactive' size='small'>
+              total cost: {decimalToInput(rollup?.totalCost) || '—'}
+            </Text>
+            {rollup?.hasUnconvertedCurrencies && (
+              <Text variant='inactive' size='small'>
+                ⚠ some BOM/labour lines are in another currency — excluded from total (no FX)
+              </Text>
+            )}
+          </>
+        ) : (
+          <Text variant='inactive' size='small'>
+            computed from BOM on save — reload to refresh
+          </Text>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/managers/tech-card/components/header-meta-fields.tsx
+++ b/src/components/managers/tech-card/components/header-meta-fields.tsx
@@ -1,0 +1,80 @@
+import { formatSizeName } from 'components/managers/product/utility/sizes';
+import { useAllModels } from 'components/managers/models/components/useModelQuery';
+import { useDictionary } from 'lib/providers/dictionary-provider';
+import { useMemo } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+import InputField from 'ui/form/fields/input-field';
+import SelectField from 'ui/form/fields/select-field';
+import { TechCardFormData } from './schema';
+
+const UNSET = { value: 0, label: '— unset —' };
+
+// Header classification FKs (category / base model / base sample size) and cost
+// targets. base_sample_size_id is restricted to the card's size range (cross-validated
+// server-side: base_sample_size_id ∈ size_ids).
+export function HeaderMetaFields() {
+  const { control } = useFormContext<TechCardFormData>();
+  const { dictionary } = useDictionary();
+  const { data: models, isLoading: modelsLoading } = useAllModels();
+
+  const sizeIds = (useWatch({ control, name: 'sizeIds' }) ?? []) as number[];
+
+  const sizeById = useMemo(() => {
+    const m = new Map<number, string>();
+    for (const s of dictionary?.sizes ?? []) if (s.id != null) m.set(s.id, s.name ?? `#${s.id}`);
+    return m;
+  }, [dictionary?.sizes]);
+
+  const categoryOptions = useMemo(
+    () => [
+      UNSET,
+      ...(dictionary?.categories ?? []).map((c) => ({
+        value: c.id ?? 0,
+        label: `${c.name ?? `#${c.id}`}${c.level ? ` · ${c.level.replace('_category', '')}` : ''}`,
+      })),
+    ],
+    [dictionary?.categories],
+  );
+
+  const modelOptions = useMemo(
+    () => [
+      UNSET,
+      ...(models ?? []).map((m) => ({
+        value: m.id ?? 0,
+        label: m.model?.name ? `${m.model.name} (#${m.id})` : `#${m.id}`,
+      })),
+    ],
+    [models],
+  );
+
+  const sampleSizeOptions = [
+    UNSET,
+    ...sizeIds.map((id) => ({ value: id, label: formatSizeName(sizeById.get(id) ?? `#${id}`) })),
+  ];
+
+  return (
+    <div className='space-y-3'>
+      <div className='grid grid-cols-1 gap-3 lg:grid-cols-3'>
+        <SelectField name='categoryId' label='category' items={categoryOptions} valueAsNumber />
+        <SelectField
+          name='baseModelId'
+          label='base model'
+          items={modelOptions}
+          valueAsNumber
+          loading={modelsLoading}
+        />
+        <SelectField
+          name='baseSampleSizeId'
+          label='base sample size'
+          items={sampleSizeOptions}
+          valueAsNumber
+        />
+      </div>
+      <div className='grid grid-cols-1 gap-3 lg:grid-cols-3'>
+        <InputField name='targetCost' label='target cost' />
+        <InputField name='targetRetailPrice' label='target retail price' />
+        <InputField name='currency' label='currency' placeholder='EUR' />
+      </div>
+    </div>
+  );
+}

--- a/src/components/managers/tech-card/components/index.tsx
+++ b/src/components/managers/tech-card/components/index.tsx
@@ -1,0 +1,495 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { common_TechCard } from 'api/proto-http/admin';
+import { formatFittingDate } from 'components/managers/fittings/components/utils';
+import {
+  useCreateTechCard,
+  useTechCardFittings,
+  useUpdateTechCard,
+} from 'components/managers/tech-cards/components/useTechCardQuery';
+import {
+  formatTechCardDate,
+  techCardErrorMessage,
+} from 'components/managers/tech-cards/components/utils';
+import {
+  techCardApprovalStateOptions,
+  techCardGenderOptions,
+  techCardMeasurementUnitOptions,
+  techCardStageOptions,
+} from 'constants/filter';
+import { ROUTES } from 'constants/routes';
+import { useSnackBarStore } from 'lib/stores/store';
+import { useMemo, useState } from 'react';
+import { useForm, useWatch } from 'react-hook-form';
+import { Link, useNavigate } from 'react-router-dom';
+import { Button } from 'ui/components/button';
+import Text from 'ui/components/text';
+import { Form } from 'ui/form';
+import InputField from 'ui/form/fields/input-field';
+import SelectField from 'ui/form/fields/select-field';
+import TextareaField from 'ui/form/fields/textarea-field';
+import { BomField } from './bom-field';
+import { ColorwaysField } from './colorways-field';
+import { ConstructionField } from './construction-field';
+import { CostingField } from './costing-field';
+import { HeaderMetaFields } from './header-meta-fields';
+import { IssuesField } from './issues-field';
+import { LabelsField } from './labels-field';
+import { OperationsField } from './operations-field';
+import { PackagingField } from './packaging-field';
+import { PomField } from './pom-field';
+import { ProductIdsField } from './product-ids-field';
+import { RevisionsField } from './revisions-field';
+import { SignoffsField } from './signoffs-field';
+import { SizeQuantitiesField } from './size-quantities-field';
+import { SketchTab } from './sketch-tab';
+import {
+  TechCardFormData,
+  mapFormToTechCardInsert,
+  mapTechCardToForm,
+  techCardDefaultData,
+  techCardSchema,
+} from './schema';
+import { SizeIdsField } from './size-ids-field';
+import { TechCardFittings } from './tech-card-fittings';
+
+const TABS = [
+  { id: 'header', label: 'header' },
+  { id: 'sketch', label: 'sketch' },
+  { id: 'bom', label: 'BOM' },
+  { id: 'colorways', label: 'colorways' },
+  { id: 'pom', label: 'POM' },
+  { id: 'construction', label: 'construction' },
+  { id: 'labels', label: 'labels & pkg' },
+  { id: 'costing', label: 'costing' },
+  { id: 'issues', label: 'issues' },
+  { id: 'signoff', label: 'sign-off' },
+  { id: 'history', label: 'history' },
+] as const;
+type TabId = (typeof TABS)[number]['id'];
+
+// Maps a form-error root key to the tab that owns it; unmapped keys are header fields.
+const ERROR_TAB: Record<string, TabId> = {
+  media: 'sketch',
+  callouts: 'sketch',
+  bomItems: 'bom',
+  colorways: 'colorways',
+  pomPoints: 'pom',
+  construction: 'construction',
+  operations: 'construction',
+  labels: 'labels',
+  packaging: 'labels',
+  costing: 'costing',
+  issues: 'issues',
+  signoffs: 'signoff',
+  revisions: 'history',
+};
+
+const RELEASED = 'TECH_CARD_APPROVAL_STATE_RELEASED';
+const DRAFT = 'TECH_CARD_APPROVAL_STATE_DRAFT';
+const LAB_DIP_APPROVED = 'TECH_CARD_LAB_DIP_STATUS_APPROVED';
+
+function Section({
+  title,
+  className,
+  children,
+}: {
+  title: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className={`space-y-4 border border-textColor p-4 ${className ?? ''}`}>
+      <Text variant='uppercase' size='large'>
+        {title}
+      </Text>
+      {children}
+    </section>
+  );
+}
+
+export function TechCardForm({
+  isEditMode,
+  id,
+  techCard,
+}: {
+  isEditMode: boolean;
+  id?: string;
+  techCard?: common_TechCard;
+}) {
+  const { showMessage } = useSnackBarStore();
+  const navigate = useNavigate();
+  const createTechCard = useCreateTechCard();
+  const updateTechCard = useUpdateTechCard();
+
+  const numId = id ? parseInt(id, 10) : undefined;
+  const { data: fittings } = useTechCardFittings(numId);
+  const fittingOptions = useMemo(
+    () =>
+      (fittings ?? []).map((f) => ({
+        value: f.id ?? 0,
+        label: `#${f.id} · ${formatFittingDate(f.fitting?.fittingDate)}`,
+      })),
+    [fittings],
+  );
+
+  const form = useForm<TechCardFormData>({
+    resolver: zodResolver(techCardSchema),
+    defaultValues: techCard ? mapTechCardToForm(techCard) : techCardDefaultData,
+    mode: 'onSubmit',
+  });
+
+  const [activeTab, setActiveTab] = useState<TabId>('header');
+  const [conflict, setConflict] = useState(false);
+
+  // The loaded card's server state freezes the body; the user's in-form approval value
+  // drives the Release gate. Lab-dips must all be approved to release (empty = allowed).
+  const frozen = techCard?.techCard?.approvalState === RELEASED;
+  const styleNumber = useWatch({ control: form.control, name: 'styleNumber' });
+  const name = useWatch({ control: form.control, name: 'name' });
+  const colorways = (useWatch({ control: form.control, name: 'colorways' }) ?? []) as Array<{
+    labDipStatus?: string;
+  }>;
+  const canRelease = colorways.every((c) => c.labDipStatus === LAB_DIP_APPROVED);
+
+  const issues = (useWatch({ control: form.control, name: 'issues' }) ?? []) as Array<{
+    status?: string;
+  }>;
+  const openIssues = issues.filter((i) => i.status === 'TECH_CARD_ISSUE_STATUS_OPEN').length;
+
+  const errorTabs = new Set(
+    Object.keys(form.formState.errors).map((k) => ERROR_TAB[k] ?? 'header'),
+  );
+
+  async function doSubmit(data: TechCardFormData) {
+    setConflict(false);
+    const techCardInsert = mapFormToTechCardInsert(data, techCard?.techCard);
+    try {
+      if (isEditMode) {
+        await updateTechCard.mutateAsync({
+          id: parseInt(id || '0', 10),
+          techCard: techCardInsert,
+          expectedLockVersion: techCard?.lockVersion ?? 0,
+        });
+        showMessage('tech card updated', 'success');
+        form.reset(data);
+      } else {
+        await createTechCard.mutateAsync(techCardInsert);
+        showMessage('tech card created', 'success');
+        navigate(ROUTES.techCards);
+      }
+    } catch (error) {
+      if ((error as { status?: number })?.status === 409) setConflict(true);
+      showMessage(techCardErrorMessage(error, 'Failed to submit tech card'), 'error');
+      console.error('Failed to submit tech card', error);
+    }
+  }
+
+  const save = () => form.handleSubmit(doSubmit)();
+  const submitWithApproval = (next: string) => {
+    form.setValue('approvalState', next, { shouldDirty: true });
+    form.handleSubmit(doSubmit)();
+  };
+
+  const saving = form.formState.isSubmitting;
+
+  return (
+    <Form {...form}>
+      {/* sticky lifecycle bar + tabs as one block (top-16 clears the fixed Layout nav;
+          -mx-2.5 cancels the Layout content px-2.5 so the bar spans full width) */}
+      <div className='sticky top-16 z-30 -mx-2.5 bg-bgColor'>
+        <div className='flex flex-wrap items-center justify-between gap-3 border-b border-textColor px-2.5 py-2'>
+          <div className='flex min-w-0 items-center gap-3'>
+            <Button asChild variant='secondary' size='lg'>
+              <Link to={ROUTES.techCards}>←</Link>
+            </Button>
+            <div className='min-w-0'>
+              <Text variant='uppercase' className='truncate'>
+                {styleNumber || (isEditMode ? 'tech card' : 'new tech card')}
+              </Text>
+              <Text variant='inactive' size='small' className='truncate'>
+                {name || '—'}
+                {isEditMode && techCard
+                  ? ` · v${techCard.lockVersion ?? 0} · ${formatTechCardDate(techCard.updatedAt)}`
+                  : ''}
+              </Text>
+            </div>
+          </div>
+
+          <div className='flex flex-wrap items-end gap-2'>
+            <div className='w-32'>
+              <SelectField
+                name='stage'
+                label='stage'
+                items={techCardStageOptions}
+                disabled={frozen}
+              />
+            </div>
+            <div className='w-36'>
+              <SelectField
+                name='approvalState'
+                label='approval'
+                items={techCardApprovalStateOptions}
+                disabled={frozen}
+              />
+            </div>
+            {frozen ? (
+              <Button
+                type='button'
+                variant='main'
+                size='lg'
+                className='uppercase'
+                loading={saving}
+                onClick={() => submitWithApproval(DRAFT)}
+              >
+                re-open to draft
+              </Button>
+            ) : (
+              <>
+                <Button
+                  type='button'
+                  variant='secondary'
+                  size='lg'
+                  className='uppercase'
+                  title={canRelease ? '' : 'Approve every colourway lab-dip before release'}
+                  disabled={!canRelease || saving}
+                  onClick={() => submitWithApproval(RELEASED)}
+                >
+                  release ▸
+                </Button>
+                <Button
+                  type='button'
+                  variant='main'
+                  size='lg'
+                  className='uppercase'
+                  disabled={(isEditMode && !form.formState.isDirty) || saving}
+                  loading={saving}
+                  onClick={save}
+                >
+                  {isEditMode ? 'save' : 'add'}
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+
+        <nav
+          className='flex gap-1 overflow-x-auto border-b border-textInactiveColor px-2.5'
+          aria-label='Tech card sections'
+        >
+          {TABS.map((tab) => {
+            const active = activeTab === tab.id;
+            const hasError = errorTabs.has(tab.id);
+            return (
+              <button
+                key={tab.id}
+                type='button'
+                onClick={() => setActiveTab(tab.id)}
+                className={`flex items-center gap-1.5 whitespace-nowrap border-b-2 px-3 py-2.5 text-sm uppercase transition-colors ${
+                  active
+                    ? 'border-textColor text-textColor'
+                    : 'border-transparent text-textInactiveColor hover:text-textColor'
+                }`}
+              >
+                {tab.label}
+                {tab.id === 'issues' && openIssues > 0 && (
+                  <span className='border border-textColor px-1 text-xs leading-none'>
+                    {openIssues}
+                  </span>
+                )}
+                {hasError && <span className='size-1.5 rounded-full bg-red-600' aria-hidden />}
+              </button>
+            );
+          })}
+        </nav>
+      </div>
+
+      {conflict && (
+        <div className='mt-3 flex flex-wrap items-center justify-between gap-3 border border-textColor bg-highlightColor/10 p-3'>
+          <Text size='small'>
+            This card was saved by someone else. Reload to get the latest version, then re-apply
+            your changes.
+          </Text>
+          <Button
+            type='button'
+            variant='main'
+            size='lg'
+            className='uppercase'
+            onClick={() => window.location.reload()}
+          >
+            reload
+          </Button>
+        </div>
+      )}
+
+      {frozen && (
+        <div className='mt-3 border border-textColor bg-highlightColor/10 p-3'>
+          <Text size='small'>
+            Released and frozen — the factory spec is locked. Use “Re-open to draft” to edit.
+          </Text>
+        </div>
+      )}
+
+      <form className='pt-4 pb-24' onSubmit={form.handleSubmit(doSubmit)}>
+        <fieldset disabled={frozen} className='m-0 min-w-0 border-0 p-0'>
+          {/* HEADER */}
+          <div hidden={activeTab !== 'header'} className='flex flex-col gap-6'>
+            <div className='flex flex-col gap-6 lg:flex-row lg:items-start'>
+              <Section title='identification' className='w-full lg:w-1/2'>
+                <InputField name='styleNumber' label='style number *' placeholder='артикул' />
+                <InputField name='name' label='name *' placeholder='название изделия' />
+                <InputField name='brand' label='brand' />
+                <InputField name='season' label='season' />
+                <InputField name='collection' label='collection' />
+                <InputField name='version' label='version' />
+                <InputField name='designer' label='designer' />
+                <InputField name='constructorName' label='constructor' />
+                <InputField name='technologist' label='technologist' />
+                <InputField name='status' label='status (freeform note)' />
+              </Section>
+
+              <Section title='classification' className='w-full lg:w-1/2'>
+                <SelectField
+                  name='targetGender'
+                  label='target gender'
+                  items={techCardGenderOptions}
+                />
+                <SelectField
+                  name='measurementUnit'
+                  label='measurement unit'
+                  items={techCardMeasurementUnitOptions}
+                />
+                <InputField name='approvedBy' label='approved by' />
+              </Section>
+            </div>
+
+            <Section title='classification & targets'>
+              <HeaderMetaFields />
+            </Section>
+
+            <Section title='construction description'>
+              <div className='grid grid-cols-1 gap-4 lg:grid-cols-2'>
+                <TextareaField name='description' label='description' rows={3} maxLength={2000} />
+                <TextareaField name='silhouette' label='silhouette' rows={3} maxLength={1000} />
+                <TextareaField name='collar' label='collar' rows={2} maxLength={1000} />
+                <TextareaField name='fastening' label='fastening' rows={2} maxLength={1000} />
+                <TextareaField name='pockets' label='pockets' rows={2} maxLength={1000} />
+                <TextareaField name='sleeveCuff' label='sleeve / cuff' rows={2} maxLength={1000} />
+                <TextareaField
+                  name='extraDetails'
+                  label='extra details'
+                  rows={2}
+                  maxLength={1000}
+                />
+                <TextareaField name='topstitching' label='topstitching' rows={2} maxLength={1000} />
+                <TextareaField
+                  name='auxMaterials'
+                  label='aux materials'
+                  rows={2}
+                  maxLength={1000}
+                />
+                <TextareaField name='notes' label='notes' rows={2} maxLength={2000} />
+              </div>
+            </Section>
+
+            <div className='flex flex-col gap-6 lg:flex-row lg:items-start'>
+              <Section title='size range' className='w-full lg:w-1/2'>
+                <SizeIdsField />
+                <div className='space-y-2 border-t border-textInactiveColor pt-3'>
+                  <Text variant='uppercase' size='small'>
+                    size run (order qty)
+                  </Text>
+                  <SizeQuantitiesField />
+                </div>
+              </Section>
+              <Section title='linked products' className='w-full lg:w-1/2'>
+                <ProductIdsField />
+              </Section>
+            </div>
+          </div>
+
+          {/* SKETCH */}
+          <div hidden={activeTab !== 'sketch'}>
+            <SketchTab techCard={techCard} />
+          </div>
+
+          {/* BOM */}
+          <div hidden={activeTab !== 'bom'}>
+            <Section title='bill of materials'>
+              <BomField />
+            </Section>
+          </div>
+
+          {/* COLORWAYS */}
+          <div hidden={activeTab !== 'colorways'}>
+            <Section title='colourways'>
+              <ColorwaysField />
+            </Section>
+          </div>
+
+          {/* POM */}
+          <div hidden={activeTab !== 'pom'}>
+            <Section title='points of measure'>
+              <PomField fittingOptions={fittingOptions} techCard={techCard} />
+            </Section>
+          </div>
+
+          {/* CONSTRUCTION */}
+          <div hidden={activeTab !== 'construction'} className='flex flex-col gap-6'>
+            <Section title='construction'>
+              <ConstructionField />
+            </Section>
+            <Section title='operations'>
+              <OperationsField />
+            </Section>
+          </div>
+
+          {/* LABELS & PACKAGING */}
+          <div
+            hidden={activeTab !== 'labels'}
+            className='flex flex-col gap-6 lg:flex-row lg:items-start'
+          >
+            <Section title='labels' className='w-full lg:w-1/2'>
+              <LabelsField />
+            </Section>
+            <Section title='packaging' className='w-full lg:w-1/2'>
+              <PackagingField />
+            </Section>
+          </div>
+
+          {/* COSTING */}
+          <div hidden={activeTab !== 'costing'}>
+            <Section title='costing'>
+              <CostingField techCard={techCard} />
+            </Section>
+          </div>
+
+          {/* ISSUES */}
+          <div hidden={activeTab !== 'issues'}>
+            <Section title='issues (maker flags)'>
+              <IssuesField />
+            </Section>
+          </div>
+
+          {/* SIGN-OFF */}
+          <div hidden={activeTab !== 'signoff'}>
+            <Section title='section sign-off'>
+              <SignoffsField />
+            </Section>
+          </div>
+
+          {/* HISTORY */}
+          <div hidden={activeTab !== 'history'} className='flex flex-col gap-6'>
+            {isEditMode && numId ? (
+              <Section title='fittings'>
+                <TechCardFittings techCardId={numId} />
+              </Section>
+            ) : null}
+            <Section title='revision log'>
+              <RevisionsField />
+            </Section>
+          </div>
+        </fieldset>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/managers/tech-card/components/issues-field.tsx
+++ b/src/components/managers/tech-card/components/issues-field.tsx
@@ -1,0 +1,102 @@
+import { techCardIssueSeverityOptions, techCardIssueStatusOptions } from 'constants/filter';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import { Button } from 'ui/components/button';
+import Text from 'ui/components/text';
+import InputField from 'ui/form/fields/input-field';
+import SelectField from 'ui/form/fields/select-field';
+import TextareaField from 'ui/form/fields/textarea-field';
+import { TechCardFormData } from './schema';
+
+const emptyIssue = {
+  operationNumber: 0,
+  calloutNumber: 0,
+  raisedBy: '',
+  severity: 'TECH_CARD_ISSUE_SEVERITY_MEDIUM',
+  status: 'TECH_CARD_ISSUE_STATUS_OPEN',
+  description: '',
+  resolutionNote: '',
+};
+
+// Maker-flagged construction issues ("this seam is impossible"), pinned to an operation
+// number and/or a sketch callout number. Raised by the seamstress, resolved by the
+// technologist / manager.
+export function IssuesField() {
+  const { control } = useFormContext<TechCardFormData>();
+  const { fields, append, remove } = useFieldArray({ control, name: 'issues' });
+
+  return (
+    <div className='space-y-3'>
+      {fields.length === 0 ? (
+        <Text variant='inactive' size='small'>
+          no issues flagged
+        </Text>
+      ) : (
+        <div className='space-y-3'>
+          {fields.map((f, index) => (
+            <div key={f.id} className='space-y-3 border border-textInactiveColor p-3'>
+              <div className='flex items-center justify-between'>
+                <Text variant='uppercase' size='small'>
+                  issue {index + 1}
+                </Text>
+                <Button
+                  type='button'
+                  variant='secondary'
+                  aria-label='remove issue'
+                  onClick={() => remove(index)}
+                >
+                  ✕
+                </Button>
+              </div>
+              <div className='grid grid-cols-2 gap-3 lg:grid-cols-5'>
+                <SelectField
+                  name={`issues.${index}.severity`}
+                  label='severity'
+                  items={techCardIssueSeverityOptions}
+                />
+                <SelectField
+                  name={`issues.${index}.status`}
+                  label='status'
+                  items={techCardIssueStatusOptions}
+                />
+                <InputField name={`issues.${index}.raisedBy`} label='raised by' />
+                <InputField
+                  name={`issues.${index}.operationNumber`}
+                  type='number'
+                  valueAsNumber
+                  label='op # (0 = none)'
+                />
+                <InputField
+                  name={`issues.${index}.calloutNumber`}
+                  type='number'
+                  valueAsNumber
+                  label='callout # (0 = none)'
+                />
+              </div>
+              <TextareaField
+                name={`issues.${index}.description`}
+                label='description *'
+                rows={2}
+                maxLength={2000}
+              />
+              <TextareaField
+                name={`issues.${index}.resolutionNote`}
+                label='resolution note'
+                rows={2}
+                maxLength={2000}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Button
+        type='button'
+        variant='main'
+        className='uppercase'
+        onClick={() => append({ ...emptyIssue })}
+      >
+        flag an issue
+      </Button>
+    </div>
+  );
+}

--- a/src/components/managers/tech-card/components/labels-field.tsx
+++ b/src/components/managers/tech-card/components/labels-field.tsx
@@ -1,0 +1,73 @@
+import { techCardLabelTypeOptions } from 'constants/filter';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import { Button } from 'ui/components/button';
+import Text from 'ui/components/text';
+import InputField from 'ui/form/fields/input-field';
+import SelectField from 'ui/form/fields/select-field';
+import { TechCardFormData } from './schema';
+
+const emptyLabel = {
+  labelType: 'TECH_CARD_LABEL_TYPE_MAIN',
+  content: '',
+  placement: '',
+  attachment: '',
+  size: '',
+  note: '',
+};
+
+// Labels / tags (Sheet «Этикетки и упаковка»). label_type is required on each.
+export function LabelsField() {
+  const { control } = useFormContext<TechCardFormData>();
+  const { fields, append, remove } = useFieldArray({ control, name: 'labels' });
+
+  return (
+    <div className='space-y-3'>
+      {fields.length === 0 ? (
+        <Text variant='inactive' size='small'>
+          no labels
+        </Text>
+      ) : (
+        <div className='space-y-3'>
+          {fields.map((f, index) => (
+            <div key={f.id} className='space-y-3 border border-textInactiveColor p-3'>
+              <div className='flex items-center justify-between'>
+                <Text variant='uppercase' size='small'>
+                  label {index + 1}
+                </Text>
+                <Button
+                  type='button'
+                  variant='secondary'
+                  aria-label='remove label'
+                  onClick={() => remove(index)}
+                >
+                  ✕
+                </Button>
+              </div>
+              <div className='grid grid-cols-1 gap-3 lg:grid-cols-3'>
+                <SelectField
+                  name={`labels.${index}.labelType`}
+                  label='type *'
+                  items={techCardLabelTypeOptions}
+                />
+                <InputField name={`labels.${index}.content`} label='content / ref' />
+                <InputField name={`labels.${index}.placement`} label='placement' />
+                <InputField name={`labels.${index}.attachment`} label='attachment' />
+                <InputField name={`labels.${index}.size`} label='size' />
+                <InputField name={`labels.${index}.note`} label='note' />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Button
+        type='button'
+        variant='main'
+        className='uppercase'
+        onClick={() => append({ ...emptyLabel })}
+      >
+        add label
+      </Button>
+    </div>
+  );
+}

--- a/src/components/managers/tech-card/components/media-field.tsx
+++ b/src/components/managers/tech-card/components/media-field.tsx
@@ -1,0 +1,99 @@
+import { common_MediaFull } from 'api/proto-http/admin';
+import { MediaSelector } from 'components/managers/media/components/media-selector';
+import { techCardMediaKindOptions } from 'constants/filter';
+import { isVideo } from 'lib/features/filterContentType';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import { Button } from 'ui/components/button';
+import Media from 'ui/components/media';
+import Text from 'ui/components/text';
+import InputField from 'ui/form/fields/input-field';
+import SelectField from 'ui/form/fields/select-field';
+import { TechCardFormData } from './schema';
+
+// Technical sketch media. Each item carries a `kind` + `caption`; the form only stores
+// { mediaId, kind, caption }. The resolved MediaFull map (for thumbnails) is owned by
+// the parent SketchTab and shared with the callout canvas.
+export function MediaField({
+  mediaById,
+  onPickedMedia,
+}: {
+  mediaById: Map<number, common_MediaFull>;
+  onPickedMedia: (items: common_MediaFull[]) => void;
+}) {
+  const { control } = useFormContext<TechCardFormData>();
+  const { fields, append, remove } = useFieldArray({ control, name: 'media' });
+  const selectedIds = fields.map((f) => f.mediaId);
+
+  function handleAdd(items: common_MediaFull[]) {
+    const fresh = items.filter((it) => it.id != null && !selectedIds.includes(it.id));
+    if (!fresh.length) return;
+    onPickedMedia(fresh);
+    for (const it of fresh) {
+      append({ mediaId: it.id as number, kind: 'TECH_CARD_MEDIA_KIND_FRONT' });
+    }
+  }
+
+  return (
+    <div className='space-y-3'>
+      {fields.length === 0 ? (
+        <Text variant='inactive' size='small'>
+          no sketches
+        </Text>
+      ) : (
+        <div className='grid grid-cols-2 gap-3 md:grid-cols-3'>
+          {fields.map((f, index) => {
+            const full = mediaById.get(f.mediaId);
+            const url = full?.media?.thumbnail?.mediaUrl || full?.media?.fullSize?.mediaUrl || '';
+            const video = isVideo(full?.media?.fullSize?.mediaUrl) || isVideo(url);
+            return (
+              <div key={f.id} className='space-y-2 border border-textInactiveColor p-2'>
+                <div
+                  className='relative overflow-hidden border border-textColor'
+                  style={{ aspectRatio: '3/4' }}
+                >
+                  <Media
+                    type={video ? 'video' : 'image'}
+                    src={url}
+                    alt={full?.media?.blurhash || ''}
+                    fit='cover'
+                    controls={video}
+                    aspectRatio='auto'
+                  />
+                  <span className='absolute left-1 top-1 z-20 bg-textColor px-1.5 py-0.5'>
+                    <Text className='!text-bgColor' size='small' variant='uppercase'>
+                      {index + 1}
+                    </Text>
+                  </span>
+                  <Button
+                    type='button'
+                    aria-label='remove sketch'
+                    onClick={() => remove(index)}
+                    className='absolute right-1 top-1 z-20 border border-textColor bg-bgColor px-1 leading-none'
+                  >
+                    [x]
+                  </Button>
+                </div>
+                <SelectField
+                  name={`media.${index}.kind`}
+                  label='kind'
+                  items={techCardMediaKindOptions}
+                />
+                <InputField name={`media.${index}.caption`} label='caption' />
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <MediaSelector
+        label='add sketch'
+        purpose='tech sketch'
+        aspectRatio={['Custom']}
+        allowMultiple
+        showVideos
+        saveSelectedMedia={handleAdd}
+        triggerClassName='uppercase px-3 py-1.5'
+      />
+    </div>
+  );
+}

--- a/src/components/managers/tech-card/components/operations-field.tsx
+++ b/src/components/managers/tech-card/components/operations-field.tsx
@@ -1,0 +1,94 @@
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import { Button } from 'ui/components/button';
+import Text from 'ui/components/text';
+import InputField from 'ui/form/fields/input-field';
+import TextareaField from 'ui/form/fields/textarea-field';
+import { TechCardFormData } from './schema';
+
+const emptyOperation = {
+  node: '',
+  description: '',
+  seamType: '',
+  stitchesPerCm: '',
+  topstitchWidth: '',
+  thread: '',
+  note: '',
+};
+
+// Per-node sewing operations (Sheet «Обработка», lower block).
+export function OperationsField() {
+  const { control } = useFormContext<TechCardFormData>();
+  const { fields, append, remove } = useFieldArray({ control, name: 'operations' });
+
+  return (
+    <div className='space-y-3'>
+      {fields.length === 0 ? (
+        <Text variant='inactive' size='small'>
+          no operations
+        </Text>
+      ) : (
+        <div className='space-y-3'>
+          {fields.map((f, index) => (
+            <div key={f.id} className='space-y-3 border border-textInactiveColor p-3'>
+              <div className='flex items-center justify-between'>
+                <Text variant='uppercase' size='small'>
+                  operation {index + 1}
+                </Text>
+                <Button
+                  type='button'
+                  variant='secondary'
+                  aria-label='remove operation'
+                  onClick={() => remove(index)}
+                >
+                  ✕
+                </Button>
+              </div>
+              <div className='grid grid-cols-2 gap-3 lg:grid-cols-4'>
+                <InputField
+                  name={`operations.${index}.operationNumber`}
+                  type='number'
+                  valueAsNumber
+                  label='op # (10, 20…)'
+                />
+                <InputField name={`operations.${index}.node`} label='node *' />
+                <InputField name={`operations.${index}.machine`} label='machine' />
+                <InputField
+                  name={`operations.${index}.timeNorm`}
+                  label='SAM (min)'
+                  placeholder='1.8'
+                />
+                <InputField name={`operations.${index}.seamType`} label='seam type' />
+                <InputField name={`operations.${index}.seamAllowance`} label='seam allowance' />
+                <InputField name={`operations.${index}.stitchesPerCm`} label='stitches / cm' />
+                <InputField name={`operations.${index}.topstitchWidth`} label='topstitch width' />
+                <InputField name={`operations.${index}.needle`} label='needle' />
+                <InputField name={`operations.${index}.thread`} label='thread' />
+              </div>
+              <TextareaField
+                name={`operations.${index}.description`}
+                label='description'
+                rows={2}
+                maxLength={1000}
+              />
+              <TextareaField
+                name={`operations.${index}.note`}
+                label='note'
+                rows={2}
+                maxLength={1000}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Button
+        type='button'
+        variant='main'
+        className='uppercase'
+        onClick={() => append({ ...emptyOperation })}
+      >
+        add operation
+      </Button>
+    </div>
+  );
+}

--- a/src/components/managers/tech-card/components/packaging-field.tsx
+++ b/src/components/managers/tech-card/components/packaging-field.tsx
@@ -1,0 +1,28 @@
+import InputField from 'ui/form/fields/input-field';
+import TextareaField from 'ui/form/fields/textarea-field';
+
+// Packaging spec (Sheet «Этикетки и упаковка»). 1:1 — sent as unset when every field
+// is blank (see mapPackagingOut).
+export function PackagingField() {
+  return (
+    <div className='space-y-3'>
+      <div className='grid grid-cols-1 gap-3 lg:grid-cols-2'>
+        <InputField name='packaging.foldingMethod' label='folding method' />
+        <InputField name='packaging.polybag' label='polybag (type / size)' />
+        <InputField name='packaging.bagSticker' label='bag sticker' />
+        <InputField name='packaging.inserts' label='inserts' />
+        <InputField
+          name='packaging.unitsPerBox'
+          type='number'
+          valueAsNumber
+          label='units per box'
+        />
+        <InputField name='packaging.boxMarking' label='box marking' />
+        <InputField name='packaging.boxDimensions' label='box dimensions (L×W×H)' />
+        <InputField name='packaging.weightNet' label='weight net' />
+        <InputField name='packaging.weightGross' label='weight gross' />
+      </div>
+      <TextareaField name='packaging.notes' label='notes' rows={2} maxLength={2000} />
+    </div>
+  );
+}

--- a/src/components/managers/tech-card/components/pom-field.tsx
+++ b/src/components/managers/tech-card/components/pom-field.tsx
@@ -1,0 +1,280 @@
+import { common_TechCard, common_TechCardPomActual } from 'api/proto-http/admin';
+import { formatSizeName } from 'components/managers/product/utility/sizes';
+import { techCardMeasurementUnitOptions } from 'constants/filter';
+import { useDictionary } from 'lib/providers/dictionary-provider';
+import { useMemo } from 'react';
+import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
+import { Button } from 'ui/components/button';
+import Text from 'ui/components/text';
+import InputField from 'ui/form/fields/input-field';
+import SelectField from 'ui/form/fields/select-field';
+import TextareaField from 'ui/form/fields/textarea-field';
+import { decimalToInput } from 'utils/decimal';
+import { TechCardFormData } from './schema';
+
+const unitLabels: Record<string, string> = Object.fromEntries(
+  techCardMeasurementUnitOptions.map((o) => [o.value, o.label]),
+);
+
+const VERDICT: Record<string, { symbol: string; label: string }> = {
+  TECH_CARD_POM_VERDICT_IN_TOLERANCE: { symbol: '✓', label: 'in' },
+  TECH_CARD_POM_VERDICT_OVER: { symbol: '▲', label: 'over' },
+  TECH_CARD_POM_VERDICT_UNDER: { symbol: '▼', label: 'under' },
+};
+
+// Renders the server-computed verdict/deviation of an actual (output-only). Stale once
+// rows are reordered/added locally; refreshes on the next save + reload.
+function VerdictBadge({ actual }: { actual?: common_TechCardPomActual }) {
+  const v = actual?.verdict ? VERDICT[actual.verdict] : undefined;
+  if (!v)
+    return (
+      <Text variant='inactive' size='small'>
+        —
+      </Text>
+    );
+  const dev = decimalToInput(actual?.deviation);
+  const signed = dev && !dev.startsWith('-') ? `+${dev}` : dev;
+  return (
+    <Text size='small'>
+      {v.symbol} {signed} {v.label}
+    </Text>
+  );
+}
+
+const emptyPomPoint = {
+  section: '',
+  code: '',
+  name: '',
+  howToMeasure: '',
+  baseValue: '',
+  tolerancePlus: '',
+  toleranceMinus: '',
+  grades: [],
+  actuals: [],
+};
+
+// One point of measure (Sheet «Измерения»). Graded per size (sizeId ∈ size range);
+// values are in the card's measurement_unit. Actuals optionally link a fitting.
+function PomPointRow({
+  index,
+  unitLabel,
+  sizeOptions,
+  fittingOptions,
+  originalActuals,
+  onRemove,
+}: {
+  index: number;
+  unitLabel: string;
+  sizeOptions: Array<{ value: number; label: string }>;
+  fittingOptions: Array<{ value: number; label: string }>;
+  originalActuals: common_TechCardPomActual[];
+  onRemove: () => void;
+}) {
+  const { control } = useFormContext<TechCardFormData>();
+  const grades = useFieldArray({
+    control,
+    name: `pomPoints.${index}.grades` as `pomPoints.${number}.grades`,
+  });
+  const actuals = useFieldArray({
+    control,
+    name: `pomPoints.${index}.actuals` as `pomPoints.${number}.actuals`,
+  });
+
+  return (
+    <div className='space-y-3 border border-textInactiveColor p-3'>
+      <div className='flex items-center justify-between'>
+        <Text variant='uppercase' size='small'>
+          point {index + 1}
+        </Text>
+        <Button
+          type='button'
+          variant='secondary'
+          aria-label='remove measurement'
+          onClick={onRemove}
+        >
+          ✕
+        </Button>
+      </div>
+
+      <div className='grid grid-cols-1 gap-3 lg:grid-cols-3'>
+        <InputField
+          name={`pomPoints.${index}.section`}
+          label='section'
+          placeholder='ВЕРХ / КОРПУС'
+        />
+        <InputField name={`pomPoints.${index}.code`} label='code' />
+        <InputField name={`pomPoints.${index}.name`} label='name *' />
+      </div>
+
+      <TextareaField
+        name={`pomPoints.${index}.howToMeasure`}
+        label='how to measure'
+        rows={2}
+        maxLength={1000}
+      />
+
+      <div className='grid grid-cols-3 gap-3'>
+        <InputField name={`pomPoints.${index}.baseValue`} label={`base (${unitLabel})`} />
+        <InputField name={`pomPoints.${index}.tolerancePlus`} label='tolerance +' />
+        <InputField name={`pomPoints.${index}.toleranceMinus`} label='tolerance −' />
+      </div>
+
+      <div className='space-y-2 border-t border-textInactiveColor pt-3'>
+        <Text variant='uppercase' size='small'>
+          graded values ({unitLabel})
+        </Text>
+        {sizeOptions.length === 0 ? (
+          <Text variant='inactive' size='small'>
+            pick sizes in the size range section to grade this point
+          </Text>
+        ) : (
+          <>
+            {grades.fields.map((f, j) => (
+              <div key={f.id} className='grid grid-cols-1 items-end gap-2 lg:grid-cols-3'>
+                <SelectField
+                  name={`pomPoints.${index}.grades.${j}.sizeId`}
+                  label='size'
+                  items={sizeOptions}
+                  valueAsNumber
+                />
+                <InputField name={`pomPoints.${index}.grades.${j}.value`} label='value' />
+                <Button
+                  type='button'
+                  variant='secondary'
+                  aria-label='remove grade'
+                  onClick={() => grades.remove(j)}
+                >
+                  ✕
+                </Button>
+              </div>
+            ))}
+            <Button
+              type='button'
+              className='uppercase'
+              onClick={() => grades.append({ sizeId: sizeOptions[0]?.value ?? 0, value: '' })}
+            >
+              add size value
+            </Button>
+          </>
+        )}
+      </div>
+
+      <div className='space-y-2 border-t border-textInactiveColor pt-3'>
+        <Text variant='uppercase' size='small'>
+          actuals
+        </Text>
+        {actuals.fields.map((f, j) => (
+          <div key={f.id} className='grid grid-cols-1 items-end gap-2 lg:grid-cols-6'>
+            <InputField
+              name={`pomPoints.${index}.actuals.${j}.label`}
+              label='label'
+              placeholder='примерка 1'
+            />
+            <SelectField
+              name={`pomPoints.${index}.actuals.${j}.sizeId`}
+              label='size'
+              items={[{ value: 0, label: '— size —' }, ...sizeOptions]}
+              valueAsNumber
+            />
+            {fittingOptions.length > 0 ? (
+              <SelectField
+                name={`pomPoints.${index}.actuals.${j}.fittingId`}
+                label='fitting'
+                items={[{ value: 0, label: '— none —' }, ...fittingOptions]}
+                valueAsNumber
+              />
+            ) : (
+              <InputField
+                name={`pomPoints.${index}.actuals.${j}.fittingId`}
+                type='number'
+                valueAsNumber
+                label='fitting id'
+              />
+            )}
+            <InputField name={`pomPoints.${index}.actuals.${j}.value`} label='value' />
+            <div className='space-y-1'>
+              <Text variant='uppercase' size='small'>
+                verdict
+              </Text>
+              <VerdictBadge actual={originalActuals[j]} />
+            </div>
+            <Button
+              type='button'
+              variant='secondary'
+              aria-label='remove actual'
+              onClick={() => actuals.remove(j)}
+            >
+              ✕
+            </Button>
+          </div>
+        ))}
+        <Button
+          type='button'
+          className='uppercase'
+          onClick={() => actuals.append({ fittingId: 0, label: '', value: '', sizeId: 0 })}
+        >
+          add actual
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// Points of measure (Sheet «Измерения»).
+export function PomField({
+  fittingOptions = [],
+  techCard,
+}: {
+  fittingOptions?: Array<{ value: number; label: string }>;
+  techCard?: common_TechCard;
+}) {
+  const { control } = useFormContext<TechCardFormData>();
+  const { fields, append, remove } = useFieldArray({ control, name: 'pomPoints' });
+  const { dictionary } = useDictionary();
+
+  const sizeIds = (useWatch({ control, name: 'sizeIds' }) ?? []) as number[];
+  const measurementUnit = useWatch({ control, name: 'measurementUnit' }) as string | undefined;
+  const unitLabel = unitLabels[measurementUnit ?? ''] ?? 'cm';
+
+  const sizeById = useMemo(() => {
+    const m = new Map<number, string>();
+    for (const s of dictionary?.sizes ?? []) if (s.id != null) m.set(s.id, s.name ?? `#${s.id}`);
+    return m;
+  }, [dictionary?.sizes]);
+
+  const sizeOptions = sizeIds.map((id) => ({
+    value: id,
+    label: formatSizeName(sizeById.get(id) ?? `#${id}`),
+  }));
+
+  return (
+    <div className='space-y-4'>
+      {fields.length === 0 ? (
+        <Text variant='inactive' size='small'>
+          no measurements
+        </Text>
+      ) : (
+        fields.map((f, index) => (
+          <PomPointRow
+            key={f.id}
+            index={index}
+            unitLabel={unitLabel}
+            sizeOptions={sizeOptions}
+            fittingOptions={fittingOptions}
+            originalActuals={techCard?.techCard?.pomPoints?.[index]?.actuals ?? []}
+            onRemove={() => remove(index)}
+          />
+        ))
+      )}
+
+      <Button
+        type='button'
+        variant='main'
+        className='uppercase'
+        onClick={() => append({ ...emptyPomPoint })}
+      >
+        add measurement
+      </Button>
+    </div>
+  );
+}

--- a/src/components/managers/tech-card/components/product-ids-field.tsx
+++ b/src/components/managers/tech-card/components/product-ids-field.tsx
@@ -1,0 +1,94 @@
+import { common_Product } from 'api/proto-http/admin';
+import { ProductPicker } from 'components/managers/custom-orders/components/prodcut-picker';
+import { useProductCatalog } from 'components/managers/fittings/components/useProductCatalog';
+import { useProductsByIds } from 'components/managers/fittings/components/useResolvers';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { Button } from 'ui/components/button';
+import Media from 'ui/components/media';
+import Text from 'ui/components/text';
+import { TechCardFormData } from './schema';
+
+function productName(product?: common_Product): string {
+  return (
+    product?.productDisplay?.productBody?.translations?.[0]?.name ?? `product #${product?.id ?? ''}`
+  );
+}
+
+// Catalog products linked to this tech card (FK product ids). Multi-select via the
+// shared ProductPicker. A colourway's product_id in later phases must reference one
+// of these ids.
+export function ProductIdsField() {
+  const { control, setValue } = useFormContext<TechCardFormData>();
+  const productIds = (useWatch({ control, name: 'productIds' }) ?? []) as number[];
+
+  const { products, hasMore, loadMore } = useProductCatalog();
+  const productMap = useProductsByIds(productIds);
+
+  const selectedProducts = productIds
+    .map((id) => productMap.get(id) ?? products.find((p) => p.id === id))
+    .filter((p): p is common_Product => !!p);
+
+  const handleSave = (picked: common_Product[]) => {
+    const ids = picked.map((p) => p.id).filter((id): id is number => id != null);
+    setValue('productIds', ids, { shouldDirty: true });
+  };
+
+  const remove = (id: number) => {
+    setValue(
+      'productIds',
+      productIds.filter((x) => x !== id),
+      { shouldDirty: true },
+    );
+  };
+
+  return (
+    <div className='space-y-3'>
+      <ProductPicker
+        products={products}
+        selectedProducts={selectedProducts}
+        hasMore={hasMore}
+        loadMore={loadMore}
+        handleSaveProducts={handleSave}
+        triggerClassName='w-full uppercase'
+      />
+
+      {productIds.length === 0 ? (
+        <Text variant='inactive' size='small'>
+          no products linked
+        </Text>
+      ) : (
+        <div className='space-y-2'>
+          {productIds.map((id) => {
+            const product = productMap.get(id) ?? products.find((p) => p.id === id);
+            return (
+              <div key={id} className='flex items-center gap-3 border border-textInactiveColor p-2'>
+                <div className='w-12 shrink-0'>
+                  <Media
+                    src={product?.productDisplay?.thumbnail?.media?.thumbnail?.mediaUrl || ''}
+                    alt='thumbnail'
+                    aspectRatio='1/1'
+                    fit='contain'
+                  />
+                </div>
+                <div className='min-w-0 flex-1'>
+                  <Text>{product ? productName(product) : `#${id}`}</Text>
+                  <Text variant='inactive' size='small'>
+                    #{id}
+                  </Text>
+                </div>
+                <Button
+                  type='button'
+                  variant='secondary'
+                  aria-label='remove product'
+                  onClick={() => remove(id)}
+                >
+                  ✕
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/managers/tech-card/components/revisions-field.tsx
+++ b/src/components/managers/tech-card/components/revisions-field.tsx
@@ -1,0 +1,72 @@
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import { Button } from 'ui/components/button';
+import Text from 'ui/components/text';
+import InputField from 'ui/form/fields/input-field';
+import TextareaField from 'ui/form/fields/textarea-field';
+import { TechCardFormData } from './schema';
+
+const emptyRevision = {
+  version: '',
+  revisionDate: '',
+  author: '',
+  section: '',
+  changeNote: '',
+};
+
+// Spec-document changelog (what changed in which section, by whom). This is NOT fit
+// history — fitting verdicts/measurements live in the separate fitting feature.
+export function RevisionsField() {
+  const { control } = useFormContext<TechCardFormData>();
+  const { fields, append, remove } = useFieldArray({ control, name: 'revisions' });
+
+  return (
+    <div className='space-y-3'>
+      {fields.length === 0 ? (
+        <Text variant='inactive' size='small'>
+          no revisions
+        </Text>
+      ) : (
+        <div className='space-y-3'>
+          {fields.map((f, index) => (
+            <div key={f.id} className='space-y-3 border border-textInactiveColor p-3'>
+              <div className='flex items-center justify-between'>
+                <Text variant='uppercase' size='small'>
+                  revision {index + 1}
+                </Text>
+                <Button
+                  type='button'
+                  variant='secondary'
+                  aria-label='remove revision'
+                  onClick={() => remove(index)}
+                >
+                  ✕
+                </Button>
+              </div>
+              <div className='grid grid-cols-1 gap-3 lg:grid-cols-4'>
+                <InputField name={`revisions.${index}.version`} label='version' />
+                <InputField name={`revisions.${index}.revisionDate`} type='date' label='date' />
+                <InputField name={`revisions.${index}.author`} label='author' />
+                <InputField name={`revisions.${index}.section`} label='section' />
+              </div>
+              <TextareaField
+                name={`revisions.${index}.changeNote`}
+                label='change note'
+                rows={2}
+                maxLength={2000}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Button
+        type='button'
+        variant='main'
+        className='uppercase'
+        onClick={() => append({ ...emptyRevision })}
+      >
+        add revision
+      </Button>
+    </div>
+  );
+}

--- a/src/components/managers/tech-card/components/schema.ts
+++ b/src/components/managers/tech-card/components/schema.ts
@@ -1,0 +1,928 @@
+import {
+  common_GenderEnum,
+  common_TechCard,
+  common_TechCardApprovalState,
+  common_TechCardBomSection,
+  common_TechCardConstruction,
+  common_TechCardCosting,
+  common_TechCardFabricDirection,
+  common_TechCardInsert,
+  common_TechCardIssueSeverity,
+  common_TechCardIssueStatus,
+  common_TechCardLabDipStatus,
+  common_TechCardLabelType,
+  common_TechCardMeasurementUnit,
+  common_TechCardMediaKind,
+  common_TechCardPackaging,
+  common_TechCardSignoffSection,
+  common_TechCardSignoffState,
+  common_TechCardStage,
+} from 'api/proto-http/admin';
+import { ZERO_TIMESTAMP } from 'components/managers/tech-cards/components/utils';
+import { decimalToInput, inputToDecimal } from 'utils/decimal';
+import { z } from 'zod';
+
+// Tech-card form. Covers the full TechCardInsert: header ("Титул"), sketch media +
+// callouts, size range, linked products, colourways, BOM, POM, construction,
+// operations, labels, packaging, costing, and the revision log. The backend does a
+// full replace on update, so mapFormToTechCardInsert sends every section. Costing
+// rollups (materials_total/materials_cost/total_cost) and BOM line_total are
+// output-only — shown read-only, never sent.
+
+const DEFAULT_STAGE: common_TechCardStage = 'TECH_CARD_STAGE_PROTO';
+const DEFAULT_APPROVAL_STATE: common_TechCardApprovalState = 'TECH_CARD_APPROVAL_STATE_DRAFT';
+const DEFAULT_MEASUREMENT_UNIT: common_TechCardMeasurementUnit = 'TECH_CARD_MEASUREMENT_UNIT_CM';
+const UNSET_GENDER: common_GenderEnum = 'GENDER_ENUM_UNKNOWN';
+
+function timestampToDateInput(timestamp?: string): string {
+  if (!timestamp || timestamp === ZERO_TIMESTAMP) return '';
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toISOString().slice(0, 10);
+}
+
+function dateInputToTimestamp(value?: string): string {
+  if (!value) return ZERO_TIMESTAMP;
+  const date = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return ZERO_TIMESTAMP;
+  return date.toISOString();
+}
+
+// True if any value is meaningful (non-blank string / non-zero number). Used to send a
+// 1:1 section as undefined (unset) when the whole block is empty.
+function hasContent(values: Array<string | number | undefined>): boolean {
+  return values.some((v) => (typeof v === 'number' ? v !== 0 : !!v?.trim()));
+}
+
+const DEFAULT_MEDIA_KIND: common_TechCardMediaKind = 'TECH_CARD_MEDIA_KIND_FRONT';
+const DEFAULT_BOM_SECTION: common_TechCardBomSection = 'TECH_CARD_BOM_SECTION_FABRIC';
+const DEFAULT_LAB_DIP: common_TechCardLabDipStatus = 'TECH_CARD_LAB_DIP_STATUS_PENDING';
+
+const revisionSchema = z.object({
+  version: z.string().optional().default(''),
+  revisionDate: z.string().optional().default(''), // YYYY-MM-DD in the UI
+  author: z.string().optional().default(''),
+  section: z.string().optional().default(''),
+  changeNote: z.string().optional().default(''),
+});
+
+const sizeQuantitySchema = z.object({
+  sizeId: z.number().optional().default(0), // ∈ size_ids
+  orderQty: z.number().optional().default(0),
+});
+
+const DEFAULT_ISSUE_SEVERITY: common_TechCardIssueSeverity = 'TECH_CARD_ISSUE_SEVERITY_MEDIUM';
+const DEFAULT_ISSUE_STATUS: common_TechCardIssueStatus = 'TECH_CARD_ISSUE_STATUS_OPEN';
+const DEFAULT_SIGNOFF_SECTION: common_TechCardSignoffSection = 'TECH_CARD_SIGNOFF_SECTION_DESIGN';
+const DEFAULT_SIGNOFF_STATE: common_TechCardSignoffState = 'TECH_CARD_SIGNOFF_STATE_PENDING';
+
+const issueSchema = z.object({
+  operationNumber: z.number().optional().default(0),
+  calloutNumber: z.number().optional().default(0),
+  raisedBy: z.string().optional().default(''),
+  severity: z.string().optional().default(DEFAULT_ISSUE_SEVERITY),
+  status: z.string().optional().default(DEFAULT_ISSUE_STATUS),
+  description: z.string().min(1, 'Description is required'),
+  resolutionNote: z.string().optional().default(''),
+});
+
+const signoffSchema = z.object({
+  section: z.string().optional().default(DEFAULT_SIGNOFF_SECTION),
+  state: z.string().optional().default(DEFAULT_SIGNOFF_STATE),
+  signedBy: z.string().optional().default(''),
+  signedAt: z.string().optional().default(''), // YYYY-MM-DD in the UI
+  note: z.string().optional().default(''),
+});
+
+const mediaItemSchema = z.object({
+  mediaId: z.number(),
+  kind: z.string().optional().default(DEFAULT_MEDIA_KIND),
+  caption: z.string().optional().default(''), // carried (v2; no UI yet)
+});
+
+const calloutSchema = z.object({
+  number: z.number().optional().default(0),
+  part: z.string().optional().default(''),
+  description: z.string().optional().default(''),
+  dimensions: z.string().optional().default(''),
+  mediaId: z.number().optional().default(0), // pinned sketch (0 = unanchored)
+  posX: z.string().optional().default(''), // carried (v2; normalised 0..1 marker pos)
+  posY: z.string().optional().default(''), // carried (v2)
+});
+
+const colorwaySchema = z.object({
+  code: z.string().optional().default(''),
+  name: z.string().min(1, 'Colourway name is required'),
+  labDipStatus: z.string().optional().default(DEFAULT_LAB_DIP),
+  productId: z.number().optional().default(0), // FK product(id); 0 = not yet published
+  comment: z.string().optional().default(''),
+  // lab-dip lifecycle / colour identity (edited in ColorwaysField)
+  pantone: z.string().optional().default(''),
+  pantoneSystem: z.string().optional().default(''),
+  hex: z.string().optional().default(''),
+  swatchMediaId: z.number().optional().default(0),
+  labDipRound: z.number().optional().default(0),
+  labDipSubmittedAt: z.string().optional().default(''), // YYYY-MM-DD in the UI
+  labDipDecidedAt: z.string().optional().default(''),
+  labDipDecidedBy: z.string().optional().default(''),
+  labDipRejectReason: z.string().optional().default(''),
+});
+
+// One «Колористика» matrix cell: the colour of a BOM material in a colourway.
+// colorwayIndex points into TechCardFormData.colorways (full-replace upsert has no
+// stable colourway ids on write).
+const bomColorwayColorSchema = z.object({
+  colorwayIndex: z.number().optional().default(0),
+  color: z.string().optional().default(''),
+  pantone: z.string().optional().default(''),
+});
+
+const bomItemSchema = z.object({
+  section: z.string().optional().default(DEFAULT_BOM_SECTION),
+  name: z.string().min(1, 'Material name is required'),
+  placement: z.string().optional().default(''),
+  supplier: z.string().optional().default(''),
+  supplierRef: z.string().optional().default(''),
+  color: z.string().optional().default(''),
+  composition: z.string().optional().default(''),
+  spec: z.string().optional().default(''),
+  consumption: z.string().optional().default(''), // decimal as string
+  unit: z.string().optional().default(''),
+  quantity: z.string().optional().default(''), // decimal as string
+  unitPrice: z.string().optional().default(''), // decimal as string
+  currency: z.string().optional().default(''),
+  comment: z.string().optional().default(''),
+  colorwayColors: z.array(bomColorwayColorSchema).default([]),
+  // fabric data for the cutter (edited in BomItemRow)
+  fabricWidth: z.string().optional().default(''),
+  fabricWeightGsm: z.string().optional().default(''),
+  fabricDirection: z.string().optional().default('TECH_CARD_FABRIC_DIRECTION_UNKNOWN'),
+  wastagePercent: z.string().optional().default(''),
+});
+
+// POM grade: the graded value of a point of measure for one size. sizeId must be one
+// of TechCardFormData.sizeIds (cross-validated server-side).
+const pomGradeSchema = z.object({
+  sizeId: z.number().optional().default(0),
+  value: z.string().optional().default(''), // decimal as string
+});
+
+// POM actual: a measured value, optionally taken in a fitting.
+const pomActualSchema = z.object({
+  fittingId: z.number().optional().default(0), // FK fitting(id); 0 = none
+  label: z.string().optional().default(''),
+  value: z.string().optional().default(''), // decimal as string
+  sizeId: z.number().optional().default(0), // carried (v2; QC measured-at size; 0 = unset)
+});
+
+const pomPointSchema = z.object({
+  section: z.string().optional().default(''),
+  code: z.string().optional().default(''),
+  name: z.string().min(1, 'Measurement name is required'),
+  howToMeasure: z.string().optional().default(''),
+  baseValue: z.string().optional().default(''), // decimal as string
+  tolerancePlus: z.string().optional().default(''), // decimal as string
+  toleranceMinus: z.string().optional().default(''), // decimal as string
+  grades: z.array(pomGradeSchema).default([]),
+  actuals: z.array(pomActualSchema).default([]),
+});
+
+const DEFAULT_LABEL_TYPE: common_TechCardLabelType = 'TECH_CARD_LABEL_TYPE_MAIN';
+
+const constructionSchema = z.object({
+  mainStitchType: z.string().optional().default(''),
+  stitchDensity: z.string().optional().default(''),
+  overlockThreads: z.string().optional().default(''),
+  seamAllowances: z.string().optional().default(''),
+  hemFinish: z.string().optional().default(''),
+  pressing: z.string().optional().default(''),
+  machineClass: z.string().optional().default(''),
+  notes: z.string().optional().default(''),
+  labourRate: z.string().optional().default(''), // cost per minute, decimal as string
+  labourRateCurrency: z.string().optional().default(''),
+});
+
+const operationSchema = z.object({
+  node: z.string().min(1, 'Node is required'),
+  description: z.string().optional().default(''),
+  seamType: z.string().optional().default(''),
+  stitchesPerCm: z.string().optional().default(''), // decimal as string
+  topstitchWidth: z.string().optional().default(''),
+  thread: z.string().optional().default(''),
+  note: z.string().optional().default(''),
+  // machine / SAM detail (edited in OperationsField)
+  operationNumber: z.number().optional().default(0),
+  machine: z.string().optional().default(''),
+  seamAllowance: z.string().optional().default(''),
+  needle: z.string().optional().default(''),
+  timeNorm: z.string().optional().default(''), // SAM minutes, decimal as string
+});
+
+const labelSchema = z.object({
+  labelType: z.string().optional().default(DEFAULT_LABEL_TYPE),
+  content: z.string().optional().default(''),
+  placement: z.string().optional().default(''),
+  attachment: z.string().optional().default(''),
+  size: z.string().optional().default(''),
+  note: z.string().optional().default(''),
+});
+
+const packagingSchema = z.object({
+  foldingMethod: z.string().optional().default(''),
+  polybag: z.string().optional().default(''),
+  bagSticker: z.string().optional().default(''),
+  inserts: z.string().optional().default(''),
+  unitsPerBox: z.number().optional().default(0),
+  boxMarking: z.string().optional().default(''),
+  boxDimensions: z.string().optional().default(''),
+  weightNet: z.string().optional().default(''), // decimal as string
+  weightGross: z.string().optional().default(''), // decimal as string
+  notes: z.string().optional().default(''),
+});
+
+const costingSchema = z.object({
+  cmtCost: z.string().optional().default(''),
+  hardwareCost: z.string().optional().default(''),
+  packagingCost: z.string().optional().default(''),
+  logisticsCost: z.string().optional().default(''),
+  overheadCost: z.string().optional().default(''),
+  defectPercent: z.string().optional().default(''),
+  markupMultiplier: z.string().optional().default(''),
+  wholesalePrice: z.string().optional().default(''),
+  retailPrice: z.string().optional().default(''),
+  currency: z.string().optional().default(''),
+  notes: z.string().optional().default(''),
+});
+
+export const emptyConstruction: z.input<typeof constructionSchema> = {
+  mainStitchType: '',
+  stitchDensity: '',
+  overlockThreads: '',
+  seamAllowances: '',
+  hemFinish: '',
+  pressing: '',
+  machineClass: '',
+  notes: '',
+  labourRate: '',
+  labourRateCurrency: '',
+};
+
+export const emptyPackaging: z.input<typeof packagingSchema> = {
+  foldingMethod: '',
+  polybag: '',
+  bagSticker: '',
+  inserts: '',
+  unitsPerBox: 0,
+  boxMarking: '',
+  boxDimensions: '',
+  weightNet: '',
+  weightGross: '',
+  notes: '',
+};
+
+export const emptyCosting: z.input<typeof costingSchema> = {
+  cmtCost: '',
+  hardwareCost: '',
+  packagingCost: '',
+  logisticsCost: '',
+  overheadCost: '',
+  defectPercent: '',
+  markupMultiplier: '',
+  wholesalePrice: '',
+  retailPrice: '',
+  currency: '',
+  notes: '',
+};
+
+export const techCardSchema = z.object({
+  // identification
+  styleNumber: z.string().min(1, 'Style number is required'),
+  name: z.string().min(1, 'Name is required'),
+  brand: z.string().optional().default(''),
+  season: z.string().optional().default(''),
+  collection: z.string().optional().default(''),
+  version: z.string().optional().default(''),
+  designer: z.string().optional().default(''),
+  // NB: form key is `constructorName`, not `constructor` — RHF/dot-path get/set
+  // resolves a `constructor` key to Object.prototype.constructor (field._f undefined
+  // → crash on mount). Mapped to/from the proto's `constructor` field below.
+  constructorName: z.string().optional().default(''),
+  technologist: z.string().optional().default(''),
+  status: z.string().optional().default(''),
+  // classification FKs (0 = unset)
+  categoryId: z.number().optional().default(0),
+  baseModelId: z.number().optional().default(0),
+  baseSampleSizeId: z.number().optional().default(0),
+  // targets
+  targetCost: z.string().optional().default(''), // decimal as string
+  targetRetailPrice: z.string().optional().default(''), // decimal as string
+  currency: z.string().optional().default(''), // ISO 4217 for target cost/price
+  // classification
+  targetGender: z.string().optional().default(UNSET_GENDER),
+  stage: z.string().optional().default(DEFAULT_STAGE),
+  approvalState: z.string().optional().default(DEFAULT_APPROVAL_STATE),
+  measurementUnit: z.string().optional().default(DEFAULT_MEASUREMENT_UNIT),
+  approvedBy: z.string().optional().default(''),
+  // construction description (lower block of «Титул»)
+  description: z.string().optional().default(''),
+  silhouette: z.string().optional().default(''),
+  collar: z.string().optional().default(''),
+  fastening: z.string().optional().default(''),
+  pockets: z.string().optional().default(''),
+  sleeveCuff: z.string().optional().default(''),
+  extraDetails: z.string().optional().default(''),
+  topstitching: z.string().optional().default(''),
+  auxMaterials: z.string().optional().default(''),
+  notes: z.string().optional().default(''),
+  // children
+  sizeIds: z.array(z.number()).default([]),
+  sizeQuantities: z.array(sizeQuantitySchema).default([]),
+  productIds: z.array(z.number()).default([]),
+  media: z.array(mediaItemSchema).default([]),
+  callouts: z.array(calloutSchema).default([]),
+  colorways: z.array(colorwaySchema).default([]),
+  bomItems: z.array(bomItemSchema).default([]),
+  pomPoints: z.array(pomPointSchema).default([]),
+  construction: constructionSchema,
+  operations: z.array(operationSchema).default([]),
+  labels: z.array(labelSchema).default([]),
+  packaging: packagingSchema,
+  costing: costingSchema,
+  issues: z.array(issueSchema).default([]),
+  signoffs: z.array(signoffSchema).default([]),
+  revisions: z.array(revisionSchema).default([]),
+});
+
+export type TechCardFormData = z.input<typeof techCardSchema>;
+
+export const techCardDefaultData: TechCardFormData = {
+  styleNumber: '',
+  name: '',
+  brand: '',
+  season: '',
+  collection: '',
+  version: '',
+  designer: '',
+  constructorName: '',
+  technologist: '',
+  status: '',
+  categoryId: 0,
+  baseModelId: 0,
+  baseSampleSizeId: 0,
+  targetCost: '',
+  targetRetailPrice: '',
+  currency: '',
+  targetGender: UNSET_GENDER,
+  stage: DEFAULT_STAGE,
+  approvalState: DEFAULT_APPROVAL_STATE,
+  measurementUnit: DEFAULT_MEASUREMENT_UNIT,
+  approvedBy: '',
+  description: '',
+  silhouette: '',
+  collar: '',
+  fastening: '',
+  pockets: '',
+  sleeveCuff: '',
+  extraDetails: '',
+  topstitching: '',
+  auxMaterials: '',
+  notes: '',
+  sizeIds: [],
+  sizeQuantities: [],
+  productIds: [],
+  media: [],
+  callouts: [],
+  colorways: [],
+  bomItems: [],
+  pomPoints: [],
+  construction: { ...emptyConstruction },
+  operations: [],
+  labels: [],
+  packaging: { ...emptyPackaging },
+  costing: { ...emptyCosting },
+  issues: [],
+  signoffs: [],
+  revisions: [],
+};
+
+function stageOrDefault(stage?: string): string {
+  return stage && stage !== 'TECH_CARD_STAGE_UNKNOWN' ? stage : DEFAULT_STAGE;
+}
+function approvalStateOrDefault(state?: string): string {
+  return state && state !== 'TECH_CARD_APPROVAL_STATE_UNKNOWN' ? state : DEFAULT_APPROVAL_STATE;
+}
+function measurementUnitOrDefault(unit?: string): string {
+  return unit && unit !== 'TECH_CARD_MEASUREMENT_UNIT_UNKNOWN' ? unit : DEFAULT_MEASUREMENT_UNIT;
+}
+
+export function mapTechCardToForm(techCard: common_TechCard): TechCardFormData {
+  const insert = techCard.techCard;
+  return {
+    styleNumber: insert?.styleNumber || '',
+    name: insert?.name || '',
+    brand: insert?.brand || '',
+    season: insert?.season || '',
+    collection: insert?.collection || '',
+    version: insert?.version || '',
+    designer: insert?.designer || '',
+    constructorName: insert?.constructor || '',
+    technologist: insert?.technologist || '',
+    status: insert?.status || '',
+    categoryId: insert?.categoryId || 0,
+    baseModelId: insert?.baseModelId || 0,
+    baseSampleSizeId: insert?.baseSampleSizeId || 0,
+    targetCost: decimalToInput(insert?.targetCost),
+    targetRetailPrice: decimalToInput(insert?.targetRetailPrice),
+    currency: insert?.currency || '',
+    targetGender: insert?.targetGender || UNSET_GENDER,
+    stage: stageOrDefault(insert?.stage),
+    approvalState: approvalStateOrDefault(insert?.approvalState),
+    measurementUnit: measurementUnitOrDefault(insert?.measurementUnit),
+    approvedBy: insert?.approvedBy || '',
+    description: insert?.description || '',
+    silhouette: insert?.silhouette || '',
+    collar: insert?.collar || '',
+    fastening: insert?.fastening || '',
+    pockets: insert?.pockets || '',
+    sleeveCuff: insert?.sleeveCuff || '',
+    extraDetails: insert?.extraDetails || '',
+    topstitching: insert?.topstitching || '',
+    auxMaterials: insert?.auxMaterials || '',
+    notes: insert?.notes || '',
+    sizeIds: insert?.sizeIds ?? [],
+    sizeQuantities: (insert?.sizeQuantities ?? []).map((q) => ({
+      sizeId: q.sizeId || 0,
+      orderQty: q.orderQty || 0,
+    })),
+    productIds: insert?.productIds ?? [],
+    media: (insert?.media ?? []).map((m) => ({
+      mediaId: m.mediaId || 0,
+      kind: m.kind && m.kind !== 'TECH_CARD_MEDIA_KIND_UNKNOWN' ? m.kind : DEFAULT_MEDIA_KIND,
+      caption: m.caption || '',
+    })),
+    callouts: (insert?.callouts ?? []).map((c) => ({
+      number: c.number || 0,
+      part: c.part || '',
+      description: c.description || '',
+      dimensions: c.dimensions || '',
+      mediaId: c.mediaId || 0,
+      posX: decimalToInput(c.posX),
+      posY: decimalToInput(c.posY),
+    })),
+    colorways: (insert?.colorways ?? []).map((c) => ({
+      code: c.code || '',
+      name: c.name || '',
+      labDipStatus:
+        c.labDipStatus && c.labDipStatus !== 'TECH_CARD_LAB_DIP_STATUS_UNKNOWN'
+          ? c.labDipStatus
+          : DEFAULT_LAB_DIP,
+      productId: c.productId || 0,
+      comment: c.comment || '',
+      pantone: c.pantone || '',
+      pantoneSystem: c.pantoneSystem || '',
+      hex: c.hex || '',
+      swatchMediaId: c.swatchMediaId || 0,
+      labDipRound: c.labDipRound || 0,
+      labDipSubmittedAt: timestampToDateInput(c.labDipSubmittedAt),
+      labDipDecidedAt: timestampToDateInput(c.labDipDecidedAt),
+      labDipDecidedBy: c.labDipDecidedBy || '',
+      labDipRejectReason: c.labDipRejectReason || '',
+    })),
+    bomItems: (insert?.bomItems ?? []).map((b) => ({
+      section:
+        b.section && b.section !== 'TECH_CARD_BOM_SECTION_UNKNOWN'
+          ? b.section
+          : DEFAULT_BOM_SECTION,
+      name: b.name || '',
+      placement: b.placement || '',
+      supplier: b.supplier || '',
+      supplierRef: b.supplierRef || '',
+      color: b.color || '',
+      composition: b.composition || '',
+      spec: b.spec || '',
+      consumption: decimalToInput(b.consumption),
+      unit: b.unit || '',
+      quantity: decimalToInput(b.quantity),
+      unitPrice: decimalToInput(b.unitPrice),
+      currency: b.currency || '',
+      comment: b.comment || '',
+      colorwayColors: (b.colorwayColors ?? []).map((cc) => ({
+        colorwayIndex: cc.colorwayIndex || 0,
+        color: cc.color || '',
+        pantone: cc.pantone || '',
+      })),
+      fabricWidth: decimalToInput(b.fabricWidth),
+      fabricWeightGsm: decimalToInput(b.fabricWeightGsm),
+      fabricDirection:
+        b.fabricDirection && b.fabricDirection !== 'TECH_CARD_FABRIC_DIRECTION_UNKNOWN'
+          ? b.fabricDirection
+          : 'TECH_CARD_FABRIC_DIRECTION_UNKNOWN',
+      wastagePercent: decimalToInput(b.wastagePercent),
+    })),
+    pomPoints: (insert?.pomPoints ?? []).map((p) => ({
+      section: p.section || '',
+      code: p.code || '',
+      name: p.name || '',
+      howToMeasure: p.howToMeasure || '',
+      baseValue: decimalToInput(p.baseValue),
+      tolerancePlus: decimalToInput(p.tolerancePlus),
+      toleranceMinus: decimalToInput(p.toleranceMinus),
+      grades: (p.grades ?? []).map((g) => ({
+        sizeId: g.sizeId || 0,
+        value: decimalToInput(g.value),
+      })),
+      actuals: (p.actuals ?? []).map((a) => ({
+        fittingId: a.fittingId || 0,
+        label: a.label || '',
+        value: decimalToInput(a.value),
+        sizeId: a.sizeId || 0,
+      })),
+    })),
+    construction: insert?.construction
+      ? {
+          mainStitchType: insert.construction.mainStitchType || '',
+          stitchDensity: insert.construction.stitchDensity || '',
+          overlockThreads: insert.construction.overlockThreads || '',
+          seamAllowances: insert.construction.seamAllowances || '',
+          hemFinish: insert.construction.hemFinish || '',
+          pressing: insert.construction.pressing || '',
+          machineClass: insert.construction.machineClass || '',
+          notes: insert.construction.notes || '',
+          labourRate: decimalToInput(insert.construction.labourRate),
+          labourRateCurrency: insert.construction.labourRateCurrency || '',
+        }
+      : { ...emptyConstruction },
+    operations: (insert?.operations ?? []).map((o) => ({
+      node: o.node || '',
+      description: o.description || '',
+      seamType: o.seamType || '',
+      stitchesPerCm: decimalToInput(o.stitchesPerCm),
+      topstitchWidth: o.topstitchWidth || '',
+      thread: o.thread || '',
+      note: o.note || '',
+      operationNumber: o.operationNumber || 0,
+      machine: o.machine || '',
+      seamAllowance: o.seamAllowance || '',
+      needle: o.needle || '',
+      timeNorm: decimalToInput(o.timeNorm),
+    })),
+    labels: (insert?.labels ?? []).map((l) => ({
+      labelType:
+        l.labelType && l.labelType !== 'TECH_CARD_LABEL_TYPE_UNKNOWN'
+          ? l.labelType
+          : DEFAULT_LABEL_TYPE,
+      content: l.content || '',
+      placement: l.placement || '',
+      attachment: l.attachment || '',
+      size: l.size || '',
+      note: l.note || '',
+    })),
+    packaging: insert?.packaging
+      ? {
+          foldingMethod: insert.packaging.foldingMethod || '',
+          polybag: insert.packaging.polybag || '',
+          bagSticker: insert.packaging.bagSticker || '',
+          inserts: insert.packaging.inserts || '',
+          unitsPerBox: insert.packaging.unitsPerBox || 0,
+          boxMarking: insert.packaging.boxMarking || '',
+          boxDimensions: insert.packaging.boxDimensions || '',
+          weightNet: decimalToInput(insert.packaging.weightNet),
+          weightGross: decimalToInput(insert.packaging.weightGross),
+          notes: insert.packaging.notes || '',
+        }
+      : { ...emptyPackaging },
+    costing: insert?.costing
+      ? {
+          cmtCost: decimalToInput(insert.costing.cmtCost),
+          hardwareCost: decimalToInput(insert.costing.hardwareCost),
+          packagingCost: decimalToInput(insert.costing.packagingCost),
+          logisticsCost: decimalToInput(insert.costing.logisticsCost),
+          overheadCost: decimalToInput(insert.costing.overheadCost),
+          defectPercent: decimalToInput(insert.costing.defectPercent),
+          markupMultiplier: decimalToInput(insert.costing.markupMultiplier),
+          wholesalePrice: decimalToInput(insert.costing.wholesalePrice),
+          retailPrice: decimalToInput(insert.costing.retailPrice),
+          currency: insert.costing.currency || '',
+          notes: insert.costing.notes || '',
+        }
+      : { ...emptyCosting },
+    issues: (insert?.issues ?? []).map((i) => ({
+      operationNumber: i.operationNumber || 0,
+      calloutNumber: i.calloutNumber || 0,
+      raisedBy: i.raisedBy || '',
+      severity:
+        i.severity && i.severity !== 'TECH_CARD_ISSUE_SEVERITY_UNKNOWN'
+          ? i.severity
+          : DEFAULT_ISSUE_SEVERITY,
+      status:
+        i.status && i.status !== 'TECH_CARD_ISSUE_STATUS_UNKNOWN' ? i.status : DEFAULT_ISSUE_STATUS,
+      description: i.description || '',
+      resolutionNote: i.resolutionNote || '',
+    })),
+    signoffs: (insert?.signoffs ?? []).map((s) => ({
+      section:
+        s.section && s.section !== 'TECH_CARD_SIGNOFF_SECTION_UNKNOWN'
+          ? s.section
+          : DEFAULT_SIGNOFF_SECTION,
+      state:
+        s.state && s.state !== 'TECH_CARD_SIGNOFF_STATE_UNKNOWN' ? s.state : DEFAULT_SIGNOFF_STATE,
+      signedBy: s.signedBy || '',
+      signedAt: timestampToDateInput(s.signedAt),
+      note: s.note || '',
+    })),
+    revisions: (insert?.revisions ?? []).map((r) => ({
+      version: r.version || '',
+      revisionDate: timestampToDateInput(r.revisionDate),
+      author: r.author || '',
+      section: r.section || '',
+      changeNote: r.changeNote || '',
+    })),
+  };
+}
+
+// 1:1 sections — sent as undefined (unset) when the whole block is empty.
+function mapConstructionOut(
+  c?: TechCardFormData['construction'],
+): common_TechCardConstruction | undefined {
+  const out: common_TechCardConstruction = {
+    mainStitchType: c?.mainStitchType?.trim() || '',
+    stitchDensity: c?.stitchDensity?.trim() || '',
+    overlockThreads: c?.overlockThreads?.trim() || '',
+    seamAllowances: c?.seamAllowances?.trim() || '',
+    hemFinish: c?.hemFinish?.trim() || '',
+    pressing: c?.pressing?.trim() || '',
+    machineClass: c?.machineClass?.trim() || '',
+    notes: c?.notes?.trim() || '',
+    labourRate: inputToDecimal(c?.labourRate),
+    labourRateCurrency: c?.labourRateCurrency?.trim() || '',
+  };
+  const content =
+    hasContent([
+      out.mainStitchType,
+      out.stitchDensity,
+      out.overlockThreads,
+      out.seamAllowances,
+      out.hemFinish,
+      out.pressing,
+      out.machineClass,
+      out.notes,
+      out.labourRateCurrency,
+    ]) || !!out.labourRate?.value;
+  return content ? out : undefined;
+}
+
+function mapPackagingOut(p?: TechCardFormData['packaging']): common_TechCardPackaging | undefined {
+  if (
+    !hasContent([
+      p?.foldingMethod,
+      p?.polybag,
+      p?.bagSticker,
+      p?.inserts,
+      p?.unitsPerBox,
+      p?.boxMarking,
+      p?.boxDimensions,
+      p?.weightNet,
+      p?.weightGross,
+      p?.notes,
+    ])
+  ) {
+    return undefined;
+  }
+  return {
+    foldingMethod: p?.foldingMethod?.trim() || '',
+    polybag: p?.polybag?.trim() || '',
+    bagSticker: p?.bagSticker?.trim() || '',
+    inserts: p?.inserts?.trim() || '',
+    unitsPerBox: p?.unitsPerBox || 0,
+    boxMarking: p?.boxMarking?.trim() || '',
+    boxDimensions: p?.boxDimensions?.trim() || '',
+    weightNet: inputToDecimal(p?.weightNet),
+    weightGross: inputToDecimal(p?.weightGross),
+    notes: p?.notes?.trim() || '',
+  };
+}
+
+// costing rollup fields (materials_total/materials_cost/total_cost) are output-only —
+// never sent on write.
+function mapCostingOut(c?: TechCardFormData['costing']): common_TechCardCosting | undefined {
+  if (
+    !hasContent([
+      c?.cmtCost,
+      c?.hardwareCost,
+      c?.packagingCost,
+      c?.logisticsCost,
+      c?.overheadCost,
+      c?.defectPercent,
+      c?.markupMultiplier,
+      c?.wholesalePrice,
+      c?.retailPrice,
+      c?.currency,
+      c?.notes,
+    ])
+  ) {
+    return undefined;
+  }
+  return {
+    cmtCost: inputToDecimal(c?.cmtCost),
+    hardwareCost: inputToDecimal(c?.hardwareCost),
+    packagingCost: inputToDecimal(c?.packagingCost),
+    logisticsCost: inputToDecimal(c?.logisticsCost),
+    overheadCost: inputToDecimal(c?.overheadCost),
+    defectPercent: inputToDecimal(c?.defectPercent),
+    markupMultiplier: inputToDecimal(c?.markupMultiplier),
+    wholesalePrice: inputToDecimal(c?.wholesalePrice),
+    retailPrice: inputToDecimal(c?.retailPrice),
+    currency: c?.currency?.trim() || '',
+    notes: c?.notes?.trim() || '',
+    materialsTotal: undefined,
+    materialsCost: undefined,
+    totalCost: undefined,
+    hasUnconvertedCurrencies: undefined,
+    totalSam: undefined,
+    labourCost: undefined,
+  };
+}
+
+// Merge the edited fields over the original insert. With Phase 3 in, every section is
+// now form-managed; `original` is still spread so any future-added proto field survives.
+export function mapFormToTechCardInsert(
+  data: TechCardFormData,
+  original?: common_TechCardInsert,
+): common_TechCardInsert {
+  return {
+    ...original,
+    styleNumber: data.styleNumber.trim(),
+    name: data.name.trim(),
+    brand: data.brand?.trim() || '',
+    season: data.season?.trim() || '',
+    collection: data.collection?.trim() || '',
+    version: data.version?.trim() || '',
+    designer: data.designer?.trim() || '',
+    constructor: data.constructorName?.trim() || '',
+    technologist: data.technologist?.trim() || '',
+    status: data.status?.trim() || '',
+    categoryId: data.categoryId || 0,
+    baseModelId: data.baseModelId || 0,
+    baseSampleSizeId: data.baseSampleSizeId || 0,
+    targetCost: inputToDecimal(data.targetCost),
+    targetRetailPrice: inputToDecimal(data.targetRetailPrice),
+    currency: data.currency?.trim() || '',
+    targetGender: (data.targetGender || UNSET_GENDER) as common_GenderEnum,
+    stage: (data.stage || 'TECH_CARD_STAGE_UNKNOWN') as common_TechCardStage,
+    approvalState: (data.approvalState ||
+      'TECH_CARD_APPROVAL_STATE_UNKNOWN') as common_TechCardApprovalState,
+    measurementUnit: (data.measurementUnit ||
+      'TECH_CARD_MEASUREMENT_UNIT_UNKNOWN') as common_TechCardMeasurementUnit,
+    approvedBy: data.approvedBy?.trim() || '',
+    description: data.description?.trim() || '',
+    silhouette: data.silhouette?.trim() || '',
+    collar: data.collar?.trim() || '',
+    fastening: data.fastening?.trim() || '',
+    pockets: data.pockets?.trim() || '',
+    sleeveCuff: data.sleeveCuff?.trim() || '',
+    extraDetails: data.extraDetails?.trim() || '',
+    topstitching: data.topstitching?.trim() || '',
+    auxMaterials: data.auxMaterials?.trim() || '',
+    notes: data.notes?.trim() || '',
+    // children edited here — override the echoed `original` values
+    sizeIds: data.sizeIds ?? [],
+    sizeQuantities: (data.sizeQuantities ?? []).map((q) => ({
+      sizeId: q.sizeId || 0,
+      orderQty: q.orderQty || 0,
+    })),
+    productIds: data.productIds ?? [],
+    media: (data.media ?? []).map((m) => ({
+      mediaId: m.mediaId,
+      kind: (m.kind || 'TECH_CARD_MEDIA_KIND_UNKNOWN') as common_TechCardMediaKind,
+      caption: m.caption?.trim() || '',
+    })),
+    callouts: (data.callouts ?? []).map((c) => ({
+      number: c.number || 0,
+      part: c.part?.trim() || '',
+      description: c.description?.trim() || '',
+      dimensions: c.dimensions?.trim() || '',
+      mediaId: c.mediaId || 0,
+      posX: inputToDecimal(c.posX),
+      posY: inputToDecimal(c.posY),
+    })),
+    colorways: (data.colorways ?? []).map((c) => ({
+      code: c.code?.trim() || '',
+      name: c.name?.trim() || '',
+      labDipStatus: (c.labDipStatus ||
+        'TECH_CARD_LAB_DIP_STATUS_UNKNOWN') as common_TechCardLabDipStatus,
+      productId: c.productId || 0,
+      comment: c.comment?.trim() || '',
+      pantone: c.pantone?.trim() || '',
+      pantoneSystem: c.pantoneSystem?.trim() || '',
+      hex: c.hex?.trim() || '',
+      swatchMediaId: c.swatchMediaId || 0,
+      labDipRound: c.labDipRound || 0,
+      labDipSubmittedAt: c.labDipSubmittedAt
+        ? dateInputToTimestamp(c.labDipSubmittedAt)
+        : undefined,
+      labDipDecidedAt: c.labDipDecidedAt ? dateInputToTimestamp(c.labDipDecidedAt) : undefined,
+      labDipDecidedBy: c.labDipDecidedBy?.trim() || '',
+      labDipRejectReason: c.labDipRejectReason?.trim() || '',
+    })),
+    bomItems: (data.bomItems ?? []).map((b) => ({
+      section: (b.section || 'TECH_CARD_BOM_SECTION_UNKNOWN') as common_TechCardBomSection,
+      name: b.name?.trim() || '',
+      placement: b.placement?.trim() || '',
+      supplier: b.supplier?.trim() || '',
+      supplierRef: b.supplierRef?.trim() || '',
+      color: b.color?.trim() || '',
+      composition: b.composition?.trim() || '',
+      spec: b.spec?.trim() || '',
+      consumption: inputToDecimal(b.consumption),
+      unit: b.unit?.trim() || '',
+      quantity: inputToDecimal(b.quantity),
+      unitPrice: inputToDecimal(b.unitPrice),
+      currency: b.currency?.trim() || '',
+      comment: b.comment?.trim() || '',
+      colorwayColors: (b.colorwayColors ?? []).map((cc) => ({
+        colorwayIndex: cc.colorwayIndex || 0,
+        color: cc.color?.trim() || '',
+        pantone: cc.pantone?.trim() || '',
+      })),
+      fabricWidth: inputToDecimal(b.fabricWidth),
+      fabricWeightGsm: inputToDecimal(b.fabricWeightGsm),
+      fabricDirection: (b.fabricDirection ||
+        'TECH_CARD_FABRIC_DIRECTION_UNKNOWN') as common_TechCardFabricDirection,
+      wastagePercent: inputToDecimal(b.wastagePercent),
+      // lineTotal is output-only (server-computed) — omitted on write
+    })),
+    pomPoints: (data.pomPoints ?? []).map((p) => ({
+      section: p.section?.trim() || '',
+      code: p.code?.trim() || '',
+      name: p.name?.trim() || '',
+      howToMeasure: p.howToMeasure?.trim() || '',
+      baseValue: inputToDecimal(p.baseValue),
+      tolerancePlus: inputToDecimal(p.tolerancePlus),
+      toleranceMinus: inputToDecimal(p.toleranceMinus),
+      grades: (p.grades ?? []).map((g) => ({
+        sizeId: g.sizeId || 0,
+        value: inputToDecimal(g.value),
+      })),
+      actuals: (p.actuals ?? []).map((a) => ({
+        fittingId: a.fittingId || 0,
+        label: a.label?.trim() || '',
+        value: inputToDecimal(a.value),
+        sizeId: a.sizeId || 0,
+        // deviation/verdict are output-only — omitted on write
+      })),
+    })),
+    construction: mapConstructionOut(data.construction),
+    operations: (data.operations ?? []).map((o) => ({
+      node: o.node?.trim() || '',
+      description: o.description?.trim() || '',
+      seamType: o.seamType?.trim() || '',
+      stitchesPerCm: inputToDecimal(o.stitchesPerCm),
+      topstitchWidth: o.topstitchWidth?.trim() || '',
+      thread: o.thread?.trim() || '',
+      note: o.note?.trim() || '',
+      operationNumber: o.operationNumber || 0,
+      machine: o.machine?.trim() || '',
+      seamAllowance: o.seamAllowance?.trim() || '',
+      needle: o.needle?.trim() || '',
+      timeNorm: inputToDecimal(o.timeNorm),
+    })),
+    labels: (data.labels ?? []).map((l) => ({
+      labelType: (l.labelType || 'TECH_CARD_LABEL_TYPE_UNKNOWN') as common_TechCardLabelType,
+      content: l.content?.trim() || '',
+      placement: l.placement?.trim() || '',
+      attachment: l.attachment?.trim() || '',
+      size: l.size?.trim() || '',
+      note: l.note?.trim() || '',
+    })),
+    packaging: mapPackagingOut(data.packaging),
+    costing: mapCostingOut(data.costing),
+    issues: (data.issues ?? []).map((i) => ({
+      operationNumber: i.operationNumber || 0,
+      calloutNumber: i.calloutNumber || 0,
+      raisedBy: i.raisedBy?.trim() || '',
+      severity: (i.severity || 'TECH_CARD_ISSUE_SEVERITY_UNKNOWN') as common_TechCardIssueSeverity,
+      status: (i.status || 'TECH_CARD_ISSUE_STATUS_UNKNOWN') as common_TechCardIssueStatus,
+      description: i.description?.trim() || '',
+      resolutionNote: i.resolutionNote?.trim() || '',
+    })),
+    signoffs: (data.signoffs ?? []).map((s) => ({
+      section: (s.section || 'TECH_CARD_SIGNOFF_SECTION_UNKNOWN') as common_TechCardSignoffSection,
+      state: (s.state || 'TECH_CARD_SIGNOFF_STATE_UNKNOWN') as common_TechCardSignoffState,
+      signedBy: s.signedBy?.trim() || '',
+      signedAt: s.signedAt ? dateInputToTimestamp(s.signedAt) : undefined,
+      note: s.note?.trim() || '',
+    })),
+    revisions: (data.revisions ?? []).map((r) => ({
+      version: r.version?.trim() || '',
+      revisionDate: dateInputToTimestamp(r.revisionDate),
+      author: r.author?.trim() || '',
+      section: r.section?.trim() || '',
+      changeNote: r.changeNote?.trim() || '',
+    })),
+    // Cast: TechCardInsert keys are required-but-nullable; we set the header + the
+    // children above and echo the still-unbuilt sections (bom_items, colorways,
+    // pom_points, construction, operations, labels, packaging, costing) from
+    // `original`. Untouched keys are omitted on create (absent == empty on the wire),
+    // which the structural type can't express without the cast.
+  } as common_TechCardInsert;
+}

--- a/src/components/managers/tech-card/components/signoffs-field.tsx
+++ b/src/components/managers/tech-card/components/signoffs-field.tsx
@@ -1,0 +1,76 @@
+import { techCardSignoffSectionOptions, techCardSignoffStateOptions } from 'constants/filter';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import { Button } from 'ui/components/button';
+import Text from 'ui/components/text';
+import InputField from 'ui/form/fields/input-field';
+import SelectField from 'ui/form/fields/select-field';
+import { TechCardFormData } from './schema';
+
+const emptySignoff = {
+  section: 'TECH_CARD_SIGNOFF_SECTION_DESIGN',
+  state: 'TECH_CARD_SIGNOFF_STATE_PENDING',
+  signedBy: '',
+  signedAt: '',
+  note: '',
+};
+
+// Per-section sign-off — one responsible role approves a sheet, so the header
+// approval_state isn't the only gate. One row per section (unique per card).
+export function SignoffsField() {
+  const { control } = useFormContext<TechCardFormData>();
+  const { fields, append, remove } = useFieldArray({ control, name: 'signoffs' });
+
+  return (
+    <div className='space-y-3'>
+      {fields.length === 0 ? (
+        <Text variant='inactive' size='small'>
+          no sign-offs
+        </Text>
+      ) : (
+        <div className='space-y-2'>
+          {fields.map((f, index) => (
+            <div
+              key={f.id}
+              className='grid grid-cols-1 items-end gap-2 border border-textInactiveColor p-2 lg:grid-cols-5'
+            >
+              <SelectField
+                name={`signoffs.${index}.section`}
+                label='section'
+                items={techCardSignoffSectionOptions}
+              />
+              <SelectField
+                name={`signoffs.${index}.state`}
+                label='state'
+                items={techCardSignoffStateOptions}
+              />
+              <InputField name={`signoffs.${index}.signedBy`} label='signed by' />
+              <InputField name={`signoffs.${index}.signedAt`} type='date' label='signed at' />
+              <div className='flex items-end gap-2'>
+                <div className='flex-1'>
+                  <InputField name={`signoffs.${index}.note`} label='note' />
+                </div>
+                <Button
+                  type='button'
+                  variant='secondary'
+                  aria-label='remove sign-off'
+                  onClick={() => remove(index)}
+                >
+                  ✕
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Button
+        type='button'
+        variant='main'
+        className='uppercase'
+        onClick={() => append({ ...emptySignoff })}
+      >
+        sign a section
+      </Button>
+    </div>
+  );
+}

--- a/src/components/managers/tech-card/components/size-ids-field.tsx
+++ b/src/components/managers/tech-card/components/size-ids-field.tsx
@@ -1,0 +1,69 @@
+import { SizePickerModal } from 'components/managers/model/components/size-picker-modal';
+import { formatSizeName } from 'components/managers/product/utility/sizes';
+import { useDictionary } from 'lib/providers/dictionary-provider';
+import { useMemo } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { Button } from 'ui/components/button';
+import Text from 'ui/components/text';
+import { TechCardFormData } from './schema';
+
+// Size range / grade for the tech card (FK size ids). Sizes are picked via the
+// shared category modal, filtered by the card's target gender. POM grades in later
+// phases must reference ids from this set.
+export function SizeIdsField() {
+  const { control, setValue } = useFormContext<TechCardFormData>();
+  const { dictionary } = useDictionary();
+
+  const sizeIds = (useWatch({ control, name: 'sizeIds' }) ?? []) as number[];
+  const gender = useWatch({ control, name: 'targetGender' }) as string | undefined;
+
+  const sizeById = useMemo(() => {
+    const m = new Map<number, string>();
+    for (const s of dictionary?.sizes ?? []) if (s.id != null) m.set(s.id, s.name ?? `#${s.id}`);
+    return m;
+  }, [dictionary?.sizes]);
+
+  const toggle = (id: number) => {
+    const next = sizeIds.includes(id) ? sizeIds.filter((x) => x !== id) : [...sizeIds, id];
+    setValue('sizeIds', next, { shouldDirty: true });
+  };
+
+  return (
+    <div className='space-y-3'>
+      <SizePickerModal
+        selectedIds={sizeIds}
+        onToggle={toggle}
+        gender={gender}
+        triggerLabel='select sizes'
+        title='size range'
+      />
+
+      {sizeIds.length === 0 ? (
+        <Text variant='inactive' size='small'>
+          no sizes selected
+        </Text>
+      ) : (
+        <div className='flex flex-wrap gap-2'>
+          {sizeIds.map((id) => (
+            <div
+              key={id}
+              className='flex items-center gap-2 border border-textInactiveColor px-2 py-1'
+            >
+              <Text variant='uppercase' size='small'>
+                {formatSizeName(sizeById.get(id) ?? `#${id}`)}
+              </Text>
+              <Button
+                type='button'
+                aria-label='remove size'
+                className='leading-none'
+                onClick={() => toggle(id)}
+              >
+                ✕
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/managers/tech-card/components/size-quantities-field.tsx
+++ b/src/components/managers/tech-card/components/size-quantities-field.tsx
@@ -1,0 +1,81 @@
+import { formatSizeName } from 'components/managers/product/utility/sizes';
+import { useDictionary } from 'lib/providers/dictionary-provider';
+import { useMemo } from 'react';
+import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
+import { Button } from 'ui/components/button';
+import Text from 'ui/components/text';
+import InputField from 'ui/form/fields/input-field';
+import SelectField from 'ui/form/fields/select-field';
+import { TechCardFormData } from './schema';
+
+// Production size run — order quantity per size (cutter / manager). sizeId is restricted
+// to the card's size range (cross-validated server-side: size_quantities[].size_id ∈ size_ids).
+export function SizeQuantitiesField() {
+  const { control } = useFormContext<TechCardFormData>();
+  const { fields, append, remove } = useFieldArray({ control, name: 'sizeQuantities' });
+  const { dictionary } = useDictionary();
+  const sizeIds = (useWatch({ control, name: 'sizeIds' }) ?? []) as number[];
+
+  const sizeById = useMemo(() => {
+    const m = new Map<number, string>();
+    for (const s of dictionary?.sizes ?? []) if (s.id != null) m.set(s.id, s.name ?? `#${s.id}`);
+    return m;
+  }, [dictionary?.sizes]);
+
+  const sizeOptions = sizeIds.map((id) => ({
+    value: id,
+    label: formatSizeName(sizeById.get(id) ?? `#${id}`),
+  }));
+
+  if (sizeIds.length === 0) {
+    return (
+      <Text variant='inactive' size='small'>
+        pick sizes above to set the order quantity per size
+      </Text>
+    );
+  }
+
+  return (
+    <div className='space-y-2'>
+      {fields.length === 0 ? (
+        <Text variant='inactive' size='small'>
+          no size run set
+        </Text>
+      ) : (
+        fields.map((f, index) => (
+          <div key={f.id} className='grid grid-cols-1 items-end gap-2 lg:grid-cols-3'>
+            <SelectField
+              name={`sizeQuantities.${index}.sizeId`}
+              label='size'
+              items={sizeOptions}
+              valueAsNumber
+            />
+            <InputField
+              name={`sizeQuantities.${index}.orderQty`}
+              type='number'
+              valueAsNumber
+              label='order qty'
+            />
+            <Button
+              type='button'
+              variant='secondary'
+              aria-label='remove size qty'
+              className='w-fit'
+              onClick={() => remove(index)}
+            >
+              ✕
+            </Button>
+          </div>
+        ))
+      )}
+
+      <Button
+        type='button'
+        className='uppercase'
+        onClick={() => append({ sizeId: sizeOptions[0]?.value ?? 0, orderQty: 0 })}
+      >
+        add size qty
+      </Button>
+    </div>
+  );
+}

--- a/src/components/managers/tech-card/components/sketch-tab.tsx
+++ b/src/components/managers/tech-card/components/sketch-tab.tsx
@@ -1,0 +1,293 @@
+import { common_MediaFull, common_TechCard } from 'api/proto-http/admin';
+import { techCardMediaKindOptions } from 'constants/filter';
+import { cn } from 'lib/utility';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
+import { Button } from 'ui/components/button';
+import Text from 'ui/components/text';
+import InputField from 'ui/form/fields/input-field';
+import SelectField from 'ui/form/fields/select-field';
+import TextareaField from 'ui/form/fields/textarea-field';
+import { MediaField } from './media-field';
+import { TechCardFormData } from './schema';
+
+const kindLabels: Record<string, string> = Object.fromEntries(
+  techCardMediaKindOptions.map((o) => [o.value, o.label]),
+);
+
+function Section({
+  title,
+  className,
+  children,
+}: {
+  title: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className={cn('space-y-4 border border-textColor p-4', className)}>
+      <Text variant='uppercase' size='large'>
+        {title}
+      </Text>
+      {children}
+    </section>
+  );
+}
+
+const clamp01 = (n: number) => Math.min(1, Math.max(0, n));
+
+type FormCallout = {
+  number?: number;
+  part?: string;
+  mediaId?: number;
+  posX?: string;
+  posY?: string;
+};
+
+// Sketch annotation: click the active view to add a numbered callout there; drag a
+// marker to move it (stores normalised pos_x/pos_y 0..1). One field array owns both the
+// canvas markers and the text rows so positions stay in sync.
+function CalloutsEditor({ mediaById }: { mediaById: Map<number, common_MediaFull> }) {
+  const { control, setValue } = useFormContext<TechCardFormData>();
+  const { fields, append, remove } = useFieldArray({ control, name: 'callouts' });
+  const callouts = (useWatch({ control, name: 'callouts' }) ?? []) as FormCallout[];
+  const media = (useWatch({ control, name: 'media' }) ?? []) as Array<{
+    mediaId: number;
+    kind?: string;
+  }>;
+
+  const views = media.filter((m) => {
+    const f = mediaById.get(m.mediaId);
+    return !!(f?.media?.fullSize?.mediaUrl || f?.media?.thumbnail?.mediaUrl);
+  });
+  const [viewId, setViewId] = useState<number | null>(null);
+  const activeViewId = viewId ?? views[0]?.mediaId ?? null;
+  const full = activeViewId != null ? mediaById.get(activeViewId) : undefined;
+  const url = full?.media?.fullSize?.mediaUrl || full?.media?.thumbnail?.mediaUrl || '';
+
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const dragIdxRef = useRef<number | null>(null);
+  const dragPosRef = useRef<{ x: number; y: number } | null>(null);
+  const [dragPos, setDragPos] = useState<{ idx: number; x: number; y: number } | null>(null);
+
+  function coords(clientX: number, clientY: number) {
+    const rect = wrapRef.current?.getBoundingClientRect();
+    if (!rect || rect.width === 0) return { x: 0, y: 0 };
+    return {
+      x: clamp01((clientX - rect.left) / rect.width),
+      y: clamp01((clientY - rect.top) / rect.height),
+    };
+  }
+
+  useEffect(() => {
+    function move(e: PointerEvent) {
+      if (dragIdxRef.current == null) return;
+      const p = coords(e.clientX, e.clientY);
+      dragPosRef.current = p;
+      setDragPos({ idx: dragIdxRef.current, ...p });
+    }
+    function up() {
+      const idx = dragIdxRef.current;
+      const p = dragPosRef.current;
+      if (idx != null && p) {
+        setValue(`callouts.${idx}.posX`, p.x.toFixed(3), { shouldDirty: true });
+        setValue(`callouts.${idx}.posY`, p.y.toFixed(3), { shouldDirty: true });
+      }
+      dragIdxRef.current = null;
+      dragPosRef.current = null;
+      setDragPos(null);
+    }
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+    return () => {
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+  }, [setValue]);
+
+  function addAt(e: React.MouseEvent) {
+    if (dragIdxRef.current != null || activeViewId == null) return;
+    const { x, y } = coords(e.clientX, e.clientY);
+    append({
+      number: fields.length + 1,
+      part: '',
+      description: '',
+      dimensions: '',
+      mediaId: activeViewId,
+      posX: x.toFixed(3),
+      posY: y.toFixed(3),
+    });
+  }
+
+  const pinOptions = [
+    { value: 0, label: '— unanchored —' },
+    ...media.map((m, i) => ({
+      value: m.mediaId,
+      label: `#${i + 1} ${kindLabels[m.kind ?? ''] ?? 'sketch'}`,
+    })),
+  ];
+
+  return (
+    <div className='space-y-4'>
+      {views.length === 0 ? (
+        <Text variant='inactive' size='small'>
+          add a sketch with an image to place callouts on it
+        </Text>
+      ) : (
+        <div className='space-y-2'>
+          <div className='flex flex-wrap gap-2'>
+            {views.map((v) => (
+              <button
+                key={v.mediaId}
+                type='button'
+                onClick={() => setViewId(v.mediaId)}
+                className={cn(
+                  'border px-2 py-1 text-sm uppercase transition-colors',
+                  v.mediaId === activeViewId
+                    ? 'border-textColor bg-textColor text-bgColor'
+                    : 'border-textInactiveColor text-textColor hover:border-textColor',
+                )}
+              >
+                {kindLabels[v.kind ?? ''] ?? 'view'}
+              </button>
+            ))}
+          </div>
+
+          <div ref={wrapRef} className='relative w-fit touch-none'>
+            <img
+              src={url}
+              alt='sketch'
+              onClick={addAt}
+              className='block max-h-[460px] w-auto cursor-crosshair select-none border border-textColor'
+              draggable={false}
+            />
+            {callouts.map((c, idx) => {
+              if (c.mediaId !== activeViewId) return null;
+              const dragging = dragPos?.idx === idx;
+              const x = dragging ? dragPos.x : parseFloat(c.posX ?? '');
+              const y = dragging ? dragPos.y : parseFloat(c.posY ?? '');
+              if (Number.isNaN(x) || Number.isNaN(y)) return null;
+              return (
+                <button
+                  key={idx}
+                  type='button'
+                  onPointerDown={(e) => {
+                    e.stopPropagation();
+                    dragIdxRef.current = idx;
+                    const p = coords(e.clientX, e.clientY);
+                    dragPosRef.current = p;
+                    setDragPos({ idx, ...p });
+                  }}
+                  onClick={(e) => e.stopPropagation()}
+                  className='absolute flex size-6 -translate-x-1/2 -translate-y-1/2 cursor-move items-center justify-center rounded-full border-2 border-bgColor bg-textColor text-xs text-bgColor'
+                  style={{ left: `${x * 100}%`, top: `${y * 100}%` }}
+                  aria-label={`callout ${c.number || idx + 1}`}
+                >
+                  {c.number || idx + 1}
+                </button>
+              );
+            })}
+          </div>
+          <Text variant='inactive' size='small'>
+            click the sketch to add a callout · drag a marker to move it
+          </Text>
+        </div>
+      )}
+
+      <div className='space-y-3 border-t border-textInactiveColor pt-3'>
+        {fields.length === 0 ? (
+          <Text variant='inactive' size='small'>
+            no callouts
+          </Text>
+        ) : (
+          fields.map((f, index) => (
+            <div key={f.id} className='space-y-2 border border-textInactiveColor p-3'>
+              <div className='flex items-center justify-between'>
+                <Text variant='uppercase' size='small'>
+                  callout {index + 1}
+                </Text>
+                <Button
+                  type='button'
+                  variant='secondary'
+                  aria-label='remove callout'
+                  onClick={() => remove(index)}
+                >
+                  ✕
+                </Button>
+              </div>
+              <div className='grid grid-cols-1 gap-2 lg:grid-cols-4'>
+                <InputField
+                  name={`callouts.${index}.number`}
+                  type='number'
+                  valueAsNumber
+                  label='number'
+                />
+                <InputField name={`callouts.${index}.part`} label='part' />
+                <InputField name={`callouts.${index}.dimensions`} label='dimensions' />
+                <SelectField
+                  name={`callouts.${index}.mediaId`}
+                  label='pinned to'
+                  items={pinOptions}
+                  valueAsNumber
+                />
+              </div>
+              <TextareaField
+                name={`callouts.${index}.description`}
+                label='description'
+                rows={2}
+                maxLength={2000}
+              />
+            </div>
+          ))
+        )}
+        <Button
+          type='button'
+          variant='main'
+          className='uppercase'
+          onClick={() =>
+            append({
+              number: fields.length + 1,
+              part: '',
+              description: '',
+              dimensions: '',
+              mediaId: 0,
+              posX: '',
+              posY: '',
+            })
+          }
+        >
+          add callout
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// Sketch sheet — owns the resolved-media map shared by the sketch grid and the callout
+// canvas (so a freshly-picked sketch can be annotated without a save/reload).
+export function SketchTab({ techCard }: { techCard?: common_TechCard }) {
+  const [picked, setPicked] = useState<common_MediaFull[]>([]);
+
+  const mediaById = useMemo(() => {
+    const m = new Map<number, common_MediaFull>();
+    for (const rm of techCard?.resolvedMedia ?? []) {
+      if (rm.media?.id != null) m.set(rm.media.id, rm.media);
+    }
+    for (const p of picked) if (p.id != null) m.set(p.id, p);
+    return m;
+  }, [techCard?.resolvedMedia, picked]);
+
+  return (
+    <div className='flex flex-col gap-6 lg:flex-row lg:items-start'>
+      <Section title='technical sketch' className='w-full lg:w-1/2'>
+        <MediaField
+          mediaById={mediaById}
+          onPickedMedia={(items) => setPicked((prev) => [...prev, ...items])}
+        />
+      </Section>
+      <Section title='callouts' className='w-full lg:w-1/2'>
+        <CalloutsEditor mediaById={mediaById} />
+      </Section>
+    </div>
+  );
+}

--- a/src/components/managers/tech-card/components/tech-card-fittings.tsx
+++ b/src/components/managers/tech-card/components/tech-card-fittings.tsx
@@ -1,0 +1,52 @@
+import {
+  formatFittingDate,
+  statusLabel,
+  verdictLabel,
+} from 'components/managers/fittings/components/utils';
+import { useTechCardFittings } from 'components/managers/tech-cards/components/useTechCardQuery';
+import { Link } from 'react-router-dom';
+import Text from 'ui/components/text';
+
+// Read-only list of fittings anchored to this tech card. Edit-mode only (needs a saved
+// id). POM actuals can link a specific fitting from this set.
+export function TechCardFittings({ techCardId }: { techCardId: number }) {
+  const { data: fittings, isLoading } = useTechCardFittings(techCardId);
+
+  if (isLoading) {
+    return (
+      <Text variant='inactive' size='small'>
+        loading fittings…
+      </Text>
+    );
+  }
+  if (!fittings?.length) {
+    return (
+      <Text variant='inactive' size='small'>
+        no fittings for this tech card yet
+      </Text>
+    );
+  }
+
+  return (
+    <div className='space-y-2'>
+      {fittings.map((f) => {
+        const insert = f.fitting;
+        return (
+          <Link
+            key={f.id}
+            to={`/fittings/${f.id}`}
+            className='flex items-center justify-between gap-3 border border-textInactiveColor p-2 transition-colors hover:bg-highlightColor/5'
+          >
+            <Text size='small'>
+              #{f.id} · {formatFittingDate(insert?.fittingDate)}
+            </Text>
+            <Text variant='inactive' size='small'>
+              {statusLabel(insert?.status)} · {verdictLabel(insert?.verdict)} ·{' '}
+              {f.media?.length ?? 0} photo(s)
+            </Text>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/managers/tech-card/page.tsx
+++ b/src/components/managers/tech-card/page.tsx
@@ -1,0 +1,38 @@
+import { useTechCard } from 'components/managers/tech-cards/components/useTechCardQuery';
+import { ROUTES } from 'constants/routes';
+import { Link, useParams } from 'react-router-dom';
+import { Button } from 'ui/components/button';
+import Text from 'ui/components/text';
+import { TechCardForm } from './components';
+
+export function TechCard() {
+  const { id } = useParams<{ id: string }>();
+  const isEditMode = !!id;
+  const numId = id ? parseInt(id, 10) : undefined;
+  const { data, isLoading, isError } = useTechCard(numId);
+
+  if (isEditMode && isLoading) {
+    return (
+      <div className='flex justify-center py-20'>
+        <Text variant='inactive' className='animate-pulse'>
+          loading tech card…
+        </Text>
+      </div>
+    );
+  }
+
+  if (isEditMode && (isError || !data)) {
+    return (
+      <div className='flex flex-col items-center gap-4 py-20'>
+        <Text variant='inactive' className='uppercase'>
+          tech card not found
+        </Text>
+        <Button asChild variant='main' size='lg' className='uppercase'>
+          <Link to={ROUTES.techCards}>← back to tech cards</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return <TechCardForm isEditMode={isEditMode} id={id} techCard={data} />;
+}

--- a/src/components/managers/tech-cards/components/tech-card-list.tsx
+++ b/src/components/managers/tech-cards/components/tech-card-list.tsx
@@ -1,0 +1,203 @@
+import { common_TechCardStage } from 'api/proto-http/admin';
+import { techCardStageOptions } from 'constants/filter';
+import { useSnackBarStore } from 'lib/stores/store';
+import { useEffect, useState } from 'react';
+import { useInView } from 'react-intersection-observer';
+import { useNavigate } from 'react-router-dom';
+import { Button } from 'ui/components/button';
+import { ConfirmationModal } from 'ui/components/confirmation-modal';
+import Input from 'ui/components/input';
+import Select from 'ui/components/select';
+import Text from 'ui/components/text';
+import { approvalStateLabel, formatTechCardDate, stageLabel } from './utils';
+import { useDeleteTechCard, useInfiniteTechCards } from './useTechCardQuery';
+
+const LIMIT = 30;
+const ALL_STAGES = 'TECH_CARD_STAGE_UNKNOWN';
+
+const stageFilterItems = [{ value: ALL_STAGES, label: 'all stages' }, ...techCardStageOptions];
+
+const GENDER_LABEL: Record<string, string> = {
+  GENDER_ENUM_MALE: 'men',
+  GENDER_ENUM_FEMALE: 'women',
+  GENDER_ENUM_UNISEX: 'unisex',
+};
+function genderLabel(g?: string): string {
+  return (g && GENDER_LABEL[g]) || '—';
+}
+
+const COLUMNS = [
+  'style #',
+  'name',
+  'brand',
+  'season',
+  'stage',
+  'approval',
+  'gender',
+  'updated',
+  '',
+];
+
+export function TechCardList() {
+  const navigate = useNavigate();
+  const { showMessage } = useSnackBarStore();
+  const deleteTechCard = useDeleteTechCard();
+
+  const [name, setName] = useState('');
+  const [stage, setStage] = useState<common_TechCardStage>(ALL_STAGES);
+  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteTechCards(
+    { name: name.trim() || undefined, stage: stage === ALL_STAGES ? undefined : stage },
+    LIMIT,
+  );
+  const { ref, inView } = useInView({ rootMargin: '200px' });
+  const [pendingDelete, setPendingDelete] = useState<{ id: number } | null>(null);
+
+  useEffect(() => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const techCards = data?.pages.flatMap((page) => page.techCards) ?? [];
+  const total = data?.pages[0]?.total ?? techCards.length;
+
+  function confirmDelete() {
+    if (!pendingDelete) return;
+    deleteTechCard.mutate(pendingDelete.id, {
+      onSuccess: () => showMessage('tech card deleted', 'success'),
+      onError: (error) =>
+        showMessage(error instanceof Error ? error.message : 'Failed to delete tech card', 'error'),
+    });
+    setPendingDelete(null);
+  }
+
+  return (
+    <div className='flex flex-col gap-4'>
+      <div className='flex flex-wrap items-end justify-between gap-3'>
+        <div className='flex flex-wrap items-end gap-3'>
+          <div className='w-56'>
+            <Input
+              name='name'
+              value={name}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
+              placeholder='search name / style number'
+            />
+          </div>
+          <div className='w-44'>
+            <Select
+              name='stage'
+              value={stage}
+              items={stageFilterItems}
+              onValueChange={(val: string) => setStage((val as common_TechCardStage) ?? ALL_STAGES)}
+            />
+          </div>
+        </div>
+        <Text variant='inactive' size='small'>
+          {techCards.length} of {total}
+        </Text>
+      </div>
+
+      {isLoading ? (
+        <div className='flex justify-center py-20'>
+          <Text variant='inactive' className='animate-pulse'>
+            loading tech cards…
+          </Text>
+        </div>
+      ) : techCards.length === 0 ? (
+        <div className='flex justify-center py-20'>
+          <Text variant='inactive' className='uppercase'>
+            no tech cards
+          </Text>
+        </div>
+      ) : (
+        <div className='overflow-x-auto border border-textColor'>
+          <table className='w-full min-w-max border-collapse text-textBaseSize'>
+            <thead>
+              <tr className='border-b border-textColor bg-textInactiveColor/20'>
+                {COLUMNS.map((h, i) => (
+                  <th key={i} className='px-2 py-2 text-left'>
+                    <Text variant='uppercase' size='small'>
+                      {h}
+                    </Text>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {techCards.map((tc) => {
+                const id = tc.id ?? 0;
+                return (
+                  <tr
+                    key={id}
+                    role='button'
+                    tabIndex={0}
+                    onClick={() => navigate(`/tech-cards/${id}`)}
+                    onKeyDown={(e) => e.key === 'Enter' && navigate(`/tech-cards/${id}`)}
+                    className='cursor-pointer border-b border-textInactiveColor transition-colors last:border-b-0 hover:bg-highlightColor/5'
+                  >
+                    <td className='px-2 py-2'>
+                      <Text variant='uppercase'>{tc.styleNumber || '—'}</Text>
+                    </td>
+                    <td className='px-2 py-2'>
+                      <Text>{tc.name || '—'}</Text>
+                    </td>
+                    <td className='px-2 py-2'>
+                      <Text variant='inactive'>{tc.brand || '—'}</Text>
+                    </td>
+                    <td className='px-2 py-2'>
+                      <Text variant='inactive'>{tc.season || '—'}</Text>
+                    </td>
+                    <td className='px-2 py-2'>
+                      <Text variant='inactive'>{stageLabel(tc.stage)}</Text>
+                    </td>
+                    <td className='px-2 py-2'>
+                      <Text variant='inactive'>{approvalStateLabel(tc.approvalState)}</Text>
+                    </td>
+                    <td className='px-2 py-2'>
+                      <Text variant='inactive'>{genderLabel(tc.targetGender)}</Text>
+                    </td>
+                    <td className='whitespace-nowrap px-2 py-2'>
+                      <Text variant='inactive' size='small'>
+                        {formatTechCardDate(tc.updatedAt)}
+                      </Text>
+                    </td>
+                    <td className='px-2 py-2'>
+                      <Button
+                        type='button'
+                        aria-label='delete tech card'
+                        onClick={(e: React.MouseEvent) => {
+                          e.stopPropagation();
+                          setPendingDelete({ id });
+                        }}
+                        className='border border-textColor bg-bgColor px-1.5 leading-none'
+                      >
+                        ✕
+                      </Button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {hasNextPage && (
+        <div ref={ref} className='flex justify-center py-4'>
+          {isFetchingNextPage && <Text variant='inactive'>loading more…</Text>}
+        </div>
+      )}
+
+      <ConfirmationModal
+        open={!!pendingDelete}
+        onOpenChange={(open) => !open && setPendingDelete(null)}
+        onConfirm={confirmDelete}
+        title='delete tech card'
+        confirmLabel='delete'
+        cancelLabel='cancel'
+      >
+        <Text>delete this tech card? all its sections cascade and this cannot be undone.</Text>
+      </ConfirmationModal>
+    </div>
+  );
+}

--- a/src/components/managers/tech-cards/components/useTechCardQuery.ts
+++ b/src/components/managers/tech-cards/components/useTechCardQuery.ts
@@ -1,0 +1,128 @@
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { adminService } from 'api/api';
+import {
+  common_GenderEnum,
+  common_TechCardInsert,
+  common_TechCardStage,
+} from 'api/proto-http/admin';
+
+export type TechCardFilter = {
+  stage?: common_TechCardStage;
+  gender?: common_GenderEnum;
+  brand?: string;
+  season?: string;
+  name?: string;
+  productId?: number;
+};
+
+export const techCardKeys = {
+  all: ['techCards'] as const,
+  lists: () => [...techCardKeys.all, 'list'] as const,
+  list: (filter: TechCardFilter) => [...techCardKeys.lists(), filter] as const,
+  details: () => [...techCardKeys.all, 'detail'] as const,
+  detail: (id: number) => [...techCardKeys.details(), id] as const,
+};
+
+// Infinite list, optionally filtered. ListTechCards returns `total` (matching count
+// ignoring pagination), so we page by offset until reached.
+export function useInfiniteTechCards(filter: TechCardFilter = {}, limit: number = 30) {
+  return useInfiniteQuery({
+    queryKey: [...techCardKeys.list(filter), 'infinite', limit],
+    queryFn: async ({ pageParam }: { pageParam: number }) => {
+      const response = await adminService.ListTechCards({
+        limit,
+        offset: pageParam,
+        orderFactor: 'ORDER_FACTOR_DESC',
+        stage: filter.stage ?? 'TECH_CARD_STAGE_UNKNOWN',
+        gender: filter.gender ?? 'GENDER_ENUM_UNKNOWN',
+        brand: filter.brand ?? '',
+        season: filter.season ?? '',
+        name: filter.name ?? '',
+        productId: filter.productId ?? 0,
+      });
+      const techCards = response.techCards || [];
+      const total = response.total ?? 0;
+      return {
+        techCards,
+        total,
+        nextOffset: pageParam + limit < total ? pageParam + limit : undefined,
+      };
+    },
+    getNextPageParam: (lastPage) => lastPage.nextOffset,
+    initialPageParam: 0,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useTechCard(id: number | undefined) {
+  return useQuery({
+    queryKey: techCardKeys.detail(id!),
+    queryFn: async () => {
+      const response = await adminService.GetTechCard({ id: id! });
+      return response.techCard;
+    },
+    enabled: !!id,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+// Fittings anchored to this tech card (ListFittings filtered by tech_card_id). Used for
+// the read-only "fittings" block and the POM actuals fitting picker.
+export function useTechCardFittings(techCardId?: number) {
+  return useQuery({
+    queryKey: [...techCardKeys.detail(techCardId ?? 0), 'fittings'],
+    queryFn: async () => {
+      const response = await adminService.ListFittings({
+        limit: 100,
+        offset: 0,
+        orderFactor: 'ORDER_FACTOR_DESC',
+        productId: 0,
+        modelId: 0,
+        techCardId: techCardId ?? 0,
+      });
+      return response.fittings || [];
+    },
+    enabled: !!techCardId,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useCreateTechCard() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (techCard: common_TechCardInsert) => adminService.CreateTechCard({ techCard }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: techCardKeys.lists() });
+    },
+  });
+}
+
+export function useUpdateTechCard() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      techCard,
+      expectedLockVersion,
+    }: {
+      id: number;
+      techCard: common_TechCardInsert;
+      expectedLockVersion: number;
+    }) => adminService.UpdateTechCard({ id, techCard, expectedLockVersion }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: techCardKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: techCardKeys.detail(variables.id) });
+    },
+  });
+}
+
+export function useDeleteTechCard() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => adminService.DeleteTechCard({ id }),
+    onSuccess: (_data, id) => {
+      queryClient.removeQueries({ queryKey: techCardKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: techCardKeys.lists() });
+    },
+  });
+}

--- a/src/components/managers/tech-cards/components/utils.ts
+++ b/src/components/managers/tech-cards/components/utils.ts
@@ -1,0 +1,46 @@
+import { techCardApprovalStateOptions, techCardStageOptions } from 'constants/filter';
+
+export const ZERO_TIMESTAMP = '0001-01-01T00:00:00Z';
+
+const stageLabels: Record<string, string> = Object.fromEntries(
+  techCardStageOptions.map((o) => [o.value, o.label]),
+);
+const approvalStateLabels: Record<string, string> = Object.fromEntries(
+  techCardApprovalStateOptions.map((o) => [o.value, o.label]),
+);
+
+export function stageLabel(stage?: string): string {
+  if (!stage || stage === 'TECH_CARD_STAGE_UNKNOWN') return '—';
+  return stageLabels[stage] ?? '—';
+}
+
+export function approvalStateLabel(state?: string): string {
+  if (!state || state === 'TECH_CARD_APPROVAL_STATE_UNKNOWN') return '—';
+  return approvalStateLabels[state] ?? '—';
+}
+
+// Maps a failed TechCard request to a role-readable message. The API layer attaches
+// the HTTP status (grpc-gateway: Aborted→409, FailedPrecondition→412, InvalidArgument
+// →400) and the backend message. See tmp/features.md §3.
+export function techCardErrorMessage(error: unknown, fallback: string): string {
+  const status = (error as { status?: number })?.status;
+  const raw = error instanceof Error ? error.message : '';
+  switch (status) {
+    case 409:
+      return 'This tech card was saved by someone else. Reload to get the latest version, then re-apply your changes.';
+    case 412:
+      return 'This tech card is released and frozen. Re-open it to Draft before editing.';
+    case 400:
+      return raw || 'Validation failed — check the highlighted fields.';
+    default:
+      return raw || fallback;
+  }
+}
+
+// Renders a stored timestamp as YYYY-MM-DD, or '—' for the zero/unset value.
+export function formatTechCardDate(timestamp?: string): string {
+  if (!timestamp || timestamp === ZERO_TIMESTAMP) return '—';
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toISOString().slice(0, 10);
+}

--- a/src/components/managers/tech-cards/index.tsx
+++ b/src/components/managers/tech-cards/index.tsx
@@ -1,0 +1,22 @@
+import { ROUTES } from 'constants/routes';
+import { Link } from 'react-router-dom';
+import { Button } from 'ui/components/button';
+import Text from 'ui/components/text';
+import { TechCardList } from './components/tech-card-list';
+
+export function TechCards() {
+  return (
+    <div className='flex flex-col gap-6 pb-16'>
+      <div className='-mx-2.5 flex flex-wrap items-center justify-between gap-3 border-b border-textColor bg-bgColor px-2.5 py-3'>
+        <Text variant='uppercase' size='large'>
+          tech cards
+        </Text>
+        <Button size='lg' variant='main' className='uppercase' asChild>
+          <Link to={ROUTES.addTechCard}>create new</Link>
+        </Button>
+      </div>
+
+      <TechCardList />
+    </div>
+  );
+}

--- a/src/constants/filter.ts
+++ b/src/constants/filter.ts
@@ -6,6 +6,18 @@ import {
   common_OrderStatusEnum,
   common_SeasonEnum,
   common_SortFactor,
+  common_TechCardApprovalState,
+  common_TechCardBomSection,
+  common_TechCardFabricDirection,
+  common_TechCardIssueSeverity,
+  common_TechCardIssueStatus,
+  common_TechCardLabDipStatus,
+  common_TechCardLabelType,
+  common_TechCardSignoffSection,
+  common_TechCardSignoffState,
+  common_TechCardMeasurementUnit,
+  common_TechCardMediaKind,
+  common_TechCardStage,
 } from 'api/proto-http/admin';
 
 interface Colors {
@@ -76,6 +88,149 @@ export const fittingVerdictOptions: Array<{ value: common_FittingVerdict; label:
   { value: 'FITTING_VERDICT_APPROVED', label: 'approved' },
   { value: 'FITTING_VERDICT_NEEDS_REWORK', label: 'needs rework' },
   { value: 'FITTING_VERDICT_REJECTED', label: 'rejected' },
+];
+
+// Tech-card development stage (excludes the UNKNOWN sentinel; server defaults UNKNOWN→PROTO).
+export const techCardStageOptions: Array<{ value: common_TechCardStage; label: string }> = [
+  { value: 'TECH_CARD_STAGE_PROTO', label: 'proto' },
+  { value: 'TECH_CARD_STAGE_FIT', label: 'fit sample' },
+  { value: 'TECH_CARD_STAGE_SMS', label: 'salesman sample' },
+  { value: 'TECH_CARD_STAGE_PP', label: 'pre-production' },
+  { value: 'TECH_CARD_STAGE_PROD', label: 'production' },
+];
+
+// Tech-card release gate, orthogonal to stage (server defaults UNKNOWN→DRAFT).
+export const techCardApprovalStateOptions: Array<{
+  value: common_TechCardApprovalState;
+  label: string;
+}> = [
+  { value: 'TECH_CARD_APPROVAL_STATE_DRAFT', label: 'draft' },
+  { value: 'TECH_CARD_APPROVAL_STATE_IN_REVIEW', label: 'in review' },
+  { value: 'TECH_CARD_APPROVAL_STATE_APPROVED', label: 'approved' },
+  { value: 'TECH_CARD_APPROVAL_STATE_RELEASED', label: 'released' },
+  { value: 'TECH_CARD_APPROVAL_STATE_OBSOLETE', label: 'obsolete' },
+];
+
+// Tech-card geometry unit for callouts and the POM chart (server defaults UNKNOWN→CM).
+export const techCardMeasurementUnitOptions: Array<{
+  value: common_TechCardMeasurementUnit;
+  label: string;
+}> = [
+  { value: 'TECH_CARD_MEASUREMENT_UNIT_CM', label: 'cm' },
+  { value: 'TECH_CARD_MEASUREMENT_UNIT_MM', label: 'mm' },
+];
+
+// Gender select including an explicit unset sentinel (tech-card target gender is optional).
+export const techCardGenderOptions: Array<{ value: common_GenderEnum; label: string }> = [
+  { value: 'GENDER_ENUM_UNKNOWN', label: '— unset —' },
+  ...genderOptions,
+];
+
+// Tech-card sketch-media kind (excludes the UNKNOWN sentinel; new media defaults to FRONT).
+export const techCardMediaKindOptions: Array<{ value: common_TechCardMediaKind; label: string }> = [
+  { value: 'TECH_CARD_MEDIA_KIND_FRONT', label: 'front' },
+  { value: 'TECH_CARD_MEDIA_KIND_BACK', label: 'back' },
+  { value: 'TECH_CARD_MEDIA_KIND_DETAIL', label: 'detail' },
+  { value: 'TECH_CARD_MEDIA_KIND_LINING', label: 'lining' },
+  { value: 'TECH_CARD_MEDIA_KIND_PREVIEW', label: 'preview' },
+  { value: 'TECH_CARD_MEDIA_KIND_MOODBOARD', label: 'moodboard' },
+  { value: 'TECH_CARD_MEDIA_KIND_REFERENCE', label: 'reference' },
+  { value: 'TECH_CARD_MEDIA_KIND_SWATCH', label: 'swatch' },
+];
+
+// BOM material family (Sheet «Спецификация»); required on each BOM line. New lines
+// default to FABRIC. Excludes the UNKNOWN sentinel.
+export const techCardBomSectionOptions: Array<{ value: common_TechCardBomSection; label: string }> =
+  [
+    { value: 'TECH_CARD_BOM_SECTION_FABRIC', label: 'fabric' },
+    { value: 'TECH_CARD_BOM_SECTION_LINING', label: 'lining' },
+    { value: 'TECH_CARD_BOM_SECTION_INTERLINING', label: 'interlining' },
+    { value: 'TECH_CARD_BOM_SECTION_INSULATION', label: 'insulation' },
+    { value: 'TECH_CARD_BOM_SECTION_HARDWARE', label: 'hardware' },
+    { value: 'TECH_CARD_BOM_SECTION_THREAD', label: 'thread' },
+    { value: 'TECH_CARD_BOM_SECTION_LABEL', label: 'label' },
+    { value: 'TECH_CARD_BOM_SECTION_PACKAGING', label: 'packaging' },
+  ];
+
+// BOM fabric cutting layout (Sheet «Спецификация», fabric lines). Includes an explicit
+// unset so a non-fabric line can stay blank.
+export const techCardFabricDirectionOptions: Array<{
+  value: common_TechCardFabricDirection;
+  label: string;
+}> = [
+  { value: 'TECH_CARD_FABRIC_DIRECTION_UNKNOWN', label: '— unset —' },
+  { value: 'TECH_CARD_FABRIC_DIRECTION_ANY', label: 'any (no nap)' },
+  { value: 'TECH_CARD_FABRIC_DIRECTION_ONE_WAY', label: 'one-way' },
+  { value: 'TECH_CARD_FABRIC_DIRECTION_TWO_WAY', label: 'two-way' },
+];
+
+// Colourway lab-dip approval lifecycle (excludes UNKNOWN; server defaults UNKNOWN→PENDING).
+export const techCardLabDipStatusOptions: Array<{
+  value: common_TechCardLabDipStatus;
+  label: string;
+}> = [
+  { value: 'TECH_CARD_LAB_DIP_STATUS_PENDING', label: 'pending' },
+  { value: 'TECH_CARD_LAB_DIP_STATUS_SUBMITTED', label: 'submitted' },
+  { value: 'TECH_CARD_LAB_DIP_STATUS_APPROVED', label: 'approved' },
+  { value: 'TECH_CARD_LAB_DIP_STATUS_REJECTED', label: 'rejected' },
+];
+
+// Maker-flagged issue severity (excludes UNKNOWN; server defaults UNKNOWN→MEDIUM).
+export const techCardIssueSeverityOptions: Array<{
+  value: common_TechCardIssueSeverity;
+  label: string;
+}> = [
+  { value: 'TECH_CARD_ISSUE_SEVERITY_LOW', label: 'low' },
+  { value: 'TECH_CARD_ISSUE_SEVERITY_MEDIUM', label: 'medium' },
+  { value: 'TECH_CARD_ISSUE_SEVERITY_HIGH', label: 'high' },
+];
+
+// Issue resolution state (excludes UNKNOWN; server defaults UNKNOWN→OPEN).
+export const techCardIssueStatusOptions: Array<{
+  value: common_TechCardIssueStatus;
+  label: string;
+}> = [
+  { value: 'TECH_CARD_ISSUE_STATUS_OPEN', label: 'open' },
+  { value: 'TECH_CARD_ISSUE_STATUS_RESOLVED', label: 'resolved' },
+  { value: 'TECH_CARD_ISSUE_STATUS_WONTFIX', label: "won't fix" },
+];
+
+// Per-section sign-off sheet (one row per section, unique per card).
+export const techCardSignoffSectionOptions: Array<{
+  value: common_TechCardSignoffSection;
+  label: string;
+}> = [
+  { value: 'TECH_CARD_SIGNOFF_SECTION_DESIGN', label: 'design' },
+  { value: 'TECH_CARD_SIGNOFF_SECTION_CONSTRUCTION', label: 'construction' },
+  { value: 'TECH_CARD_SIGNOFF_SECTION_POM', label: 'POM' },
+  { value: 'TECH_CARD_SIGNOFF_SECTION_MATERIALS', label: 'materials' },
+  { value: 'TECH_CARD_SIGNOFF_SECTION_COLOUR', label: 'colour' },
+  { value: 'TECH_CARD_SIGNOFF_SECTION_LABELS', label: 'labels' },
+  { value: 'TECH_CARD_SIGNOFF_SECTION_PACKAGING', label: 'packaging' },
+  { value: 'TECH_CARD_SIGNOFF_SECTION_COSTING', label: 'costing' },
+];
+
+// Sign-off decision (excludes UNKNOWN; server defaults UNKNOWN→PENDING).
+export const techCardSignoffStateOptions: Array<{
+  value: common_TechCardSignoffState;
+  label: string;
+}> = [
+  { value: 'TECH_CARD_SIGNOFF_STATE_PENDING', label: 'pending' },
+  { value: 'TECH_CARD_SIGNOFF_STATE_APPROVED', label: 'approved' },
+  { value: 'TECH_CARD_SIGNOFF_STATE_REJECTED', label: 'rejected' },
+];
+
+// Label / tag type (Sheet «Этикетки и упаковка»); required on each label. New labels
+// default to MAIN. Excludes the UNKNOWN sentinel.
+export const techCardLabelTypeOptions: Array<{ value: common_TechCardLabelType; label: string }> = [
+  { value: 'TECH_CARD_LABEL_TYPE_MAIN', label: 'main (brand)' },
+  { value: 'TECH_CARD_LABEL_TYPE_SIZE', label: 'size' },
+  { value: 'TECH_CARD_LABEL_TYPE_CARE', label: 'care' },
+  { value: 'TECH_CARD_LABEL_TYPE_ORIGIN', label: 'origin' },
+  { value: 'TECH_CARD_LABEL_TYPE_FLAG', label: 'flag' },
+  { value: 'TECH_CARD_LABEL_TYPE_HANGTAG', label: 'hangtag' },
+  { value: 'TECH_CARD_LABEL_TYPE_BARCODE', label: 'barcode / RFID' },
+  { value: 'TECH_CARD_LABEL_TYPE_SPECIAL', label: 'special' },
 ];
 
 export const colors: Colors[] = [

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -38,6 +38,9 @@ export enum ROUTES {
   fittings = '/fittings',
   addFitting = '/add-fitting',
   singleFitting = '/fittings/:id',
+  techCards = '/tech-cards',
+  addTechCard = '/add-tech-card',
+  singleTechCard = '/tech-cards/:id',
 }
 
 export const SIDE_BAR_ITEMS = [
@@ -94,6 +97,10 @@ export const SIDE_BAR_ITEMS = [
     route: ROUTES.fittings,
   },
   {
+    label: 'TECH CARDS',
+    route: ROUTES.techCards,
+  },
+  {
     label: 'TIER CONFIG',
     route: ROUTES.tierConfig,
   },
@@ -143,6 +150,10 @@ export const LEFT_SIDE_ITEMS: Manager[] = [
   {
     label: 'fittings',
     route: ROUTES.fittings,
+  },
+  {
+    label: 'tech cards',
+    route: ROUTES.techCards,
   },
   // {
   //   label: 'promo',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -52,7 +52,9 @@ const MemberDetails = lazy(() =>
   })),
 );
 const TierConfig = lazy(() =>
-  import('components/managers/membership/tier-config/page').then((m) => ({ default: m.TierConfig })),
+  import('components/managers/membership/tier-config/page').then((m) => ({
+    default: m.TierConfig,
+  })),
 );
 const HackerManager = lazy(() =>
   import('components/managers/membership/hacker/page').then((m) => ({ default: m.HackerManager })),
@@ -71,6 +73,12 @@ const Fittings = lazy(() =>
 );
 const Fitting = lazy(() =>
   import('components/managers/fitting/page').then((m) => ({ default: m.Fitting })),
+);
+const TechCards = lazy(() =>
+  import('components/managers/tech-cards').then((m) => ({ default: m.TechCards })),
+);
+const TechCard = lazy(() =>
+  import('components/managers/tech-card/page').then((m) => ({ default: m.TechCard })),
 );
 
 // Configure QueryClient with best practices
@@ -134,42 +142,45 @@ root.render(
           <BrowserRouter>
             <Suspense fallback={<LoadingFallback />}>
               <Routes>
-                  <Route path={ROUTES.login} element={<LoginBlock />} />
-                  <Route path='/' element={<ProtectedLayout />}>
-                    <Route path={ROUTES.main} element={<Analitic />} />
-                    <Route path={ROUTES.media} element={<MediaManager disabled={true} />} />
-                    <Route path={ROUTES.singleProduct} element={<Product />} />
-                    <Route path={ROUTES.product} element={<ProductsCatalog />} />
-                    <Route path={ROUTES.addProduct} element={<Product />} />
-                    <Route path={`${ROUTES.copyProduct}/:id`} element={<Product />} />
-                    <Route path={ROUTES.hero} element={<Hero />} />
-                    <Route path={ROUTES.promo} element={<Promo />} />
-                    <Route path={ROUTES.settings} element={<Settings />} />
-                    <Route path={ROUTES.shipping} element={<Shipping />} />
-                    <Route path={ROUTES.orderDetails} element={<OrderDetails />} />
-                    <Route path={ROUTES.customOrders} element={<CustomOrders />} />
-                    <Route path={ROUTES.orders} element={<OrdersCatalog />} />
-                    <Route path={ROUTES.singleArchive} element={<Archive />} />
-                    <Route path={ROUTES.archives} element={<Archives />} />
-                    <Route path={ROUTES.addArchive} element={<Archive />} />
-                    <Route path={ROUTES.customerSupport} element={<CustomerPage />} />
-                    <Route path={ROUTES.members} element={<Members />} />
-                    <Route path={ROUTES.memberDetails} element={<MemberDetails />} />
-                    <Route path={ROUTES.tierConfig} element={<TierConfig />} />
-                    <Route path={ROUTES.hacker} element={<HackerManager />} />
-                    <Route path={ROUTES.tierAudit} element={<TierAudit />} />
-                    <Route path={ROUTES.models} element={<Models />} />
-                    <Route path={ROUTES.addModel} element={<Model />} />
-                    <Route path={ROUTES.singleModel} element={<Model />} />
-                    <Route path={ROUTES.fittings} element={<Fittings />} />
-                    <Route path={ROUTES.addFitting} element={<Fitting />} />
-                    <Route path={ROUTES.singleFitting} element={<Fitting />} />
-                  </Route>
-                </Routes>
-              </Suspense>
-            </BrowserRouter>
-            <ReactQueryDevtools initialIsOpen={false} />
-          </QueryClientProvider>
+                <Route path={ROUTES.login} element={<LoginBlock />} />
+                <Route path='/' element={<ProtectedLayout />}>
+                  <Route path={ROUTES.main} element={<Analitic />} />
+                  <Route path={ROUTES.media} element={<MediaManager disabled={true} />} />
+                  <Route path={ROUTES.singleProduct} element={<Product />} />
+                  <Route path={ROUTES.product} element={<ProductsCatalog />} />
+                  <Route path={ROUTES.addProduct} element={<Product />} />
+                  <Route path={`${ROUTES.copyProduct}/:id`} element={<Product />} />
+                  <Route path={ROUTES.hero} element={<Hero />} />
+                  <Route path={ROUTES.promo} element={<Promo />} />
+                  <Route path={ROUTES.settings} element={<Settings />} />
+                  <Route path={ROUTES.shipping} element={<Shipping />} />
+                  <Route path={ROUTES.orderDetails} element={<OrderDetails />} />
+                  <Route path={ROUTES.customOrders} element={<CustomOrders />} />
+                  <Route path={ROUTES.orders} element={<OrdersCatalog />} />
+                  <Route path={ROUTES.singleArchive} element={<Archive />} />
+                  <Route path={ROUTES.archives} element={<Archives />} />
+                  <Route path={ROUTES.addArchive} element={<Archive />} />
+                  <Route path={ROUTES.customerSupport} element={<CustomerPage />} />
+                  <Route path={ROUTES.members} element={<Members />} />
+                  <Route path={ROUTES.memberDetails} element={<MemberDetails />} />
+                  <Route path={ROUTES.tierConfig} element={<TierConfig />} />
+                  <Route path={ROUTES.hacker} element={<HackerManager />} />
+                  <Route path={ROUTES.tierAudit} element={<TierAudit />} />
+                  <Route path={ROUTES.models} element={<Models />} />
+                  <Route path={ROUTES.addModel} element={<Model />} />
+                  <Route path={ROUTES.singleModel} element={<Model />} />
+                  <Route path={ROUTES.fittings} element={<Fittings />} />
+                  <Route path={ROUTES.addFitting} element={<Fitting />} />
+                  <Route path={ROUTES.singleFitting} element={<Fitting />} />
+                  <Route path={ROUTES.techCards} element={<TechCards />} />
+                  <Route path={ROUTES.addTechCard} element={<TechCard />} />
+                  <Route path={ROUTES.singleTechCard} element={<TechCard />} />
+                </Route>
+              </Routes>
+            </Suspense>
+          </BrowserRouter>
+          <ReactQueryDevtools initialIsOpen={false} />
+        </QueryClientProvider>
       </ContextProvider>
     </ErrorBoundary>
   </StrictMode>,

--- a/src/utils/decimal.ts
+++ b/src/utils/decimal.ts
@@ -1,0 +1,27 @@
+import { googletype_Decimal } from 'api/proto-http/admin';
+
+// google.type.Decimal is a string-valued number/money on the wire: { value: "42.50" }.
+// Forms edit decimals as plain strings; convert only at the schema boundary.
+
+export function decimalToInput(d?: googletype_Decimal): string {
+  return d?.value ?? '';
+}
+
+// Empty/blank → undefined so the field is omitted (treated as unset by the backend).
+// We do not validate the numeric format here — the backend normalizes and rejects.
+export function inputToDecimal(value?: string): googletype_Decimal | undefined {
+  const v = value?.trim();
+  if (!v) return undefined;
+  return { value: v };
+}
+
+// Best-effort client-side preview of a decimal product (e.g. qty × price). Returns ''
+// when either operand is missing or non-numeric — the authoritative value is computed
+// server-side (output-only fields like bom line_total).
+export function multiplyDecimalInputs(a?: string, b?: string): string {
+  const x = Number(a);
+  const y = Number(b);
+  if (!a?.trim() || !b?.trim() || Number.isNaN(x) || Number.isNaN(y)) return '';
+  const result = x * y;
+  return Number.isFinite(result) ? String(Number(result.toFixed(4))) : '';
+}


### PR DESCRIPTION
Tabbed editor for the full tech-pack spec on the v2 grbpwr-proto contract: header (+FK/targets), sketch with click-to-place callouts, BOM (+ fabric data, colourway matrix), colourways with lab-dip lifecycle, POM (graded + QC actuals/verdict), construction/operations (SAM), labels & packaging, costing (+ computed rollup), issues, sign-off, size run, revisions. Sticky lifecycle/lock bar with optimistic locking, release freeze + gate, and 409/412/400 handling. List view as a table. Bumps the proto submodule to tech-card-2 and regenerates the TS client.