### PR TITLE
Release: hero explore/CTA link picker (beta → master)

### DIFF
--- a/src/components/managers/hero/components/block-editor.tsx
+++ b/src/components/managers/hero/components/block-editor.tsx
@@ -9,6 +9,7 @@ import { MediaPreviewWithSelector } from '../../media/components/media-preview-w
 import { CommonEntity } from './common-entity';
 import { FeaturedProductBase } from './featured-prduct-base';
 import { HeroProductPicker } from './hero-product-picker';
+import { LinkField } from './link-field';
 import { MediaPairField } from './media-pair-field';
 import { ReleaseDateField } from './release-date-field';
 import { SlideListField } from './slide-list-field';
@@ -291,11 +292,7 @@ export function BlockEditor({ index, entity, featuredProducts }: BlockEditorProp
               <ToggleField name={`entities.${index}.video.muted`} label='muted' />
             </div>
             <div className='space-y-4'>
-              <InputField
-                name={`entities.${index}.video.ctaLink`}
-                label='CTA link (optional)'
-                placeholder='https://…'
-              />
+              <LinkField name={`entities.${index}.video.ctaLink`} label='CTA link (optional)' />
               <UnifiedTranslationFields
                 fieldPrefix={`entities.${index}.video.translations`}
                 fields={[
@@ -315,11 +312,7 @@ export function BlockEditor({ index, entity, featuredProducts }: BlockEditorProp
               marquee
             </Text>
             <div className='space-y-4'>
-              <InputField
-                name={`entities.${index}.marquee.link`}
-                label='link (optional)'
-                placeholder='https://…'
-              />
+              <LinkField name={`entities.${index}.marquee.link`} label='link (optional)' />
               <InputField
                 name={`entities.${index}.marquee.speed`}
                 label='speed (optional)'
@@ -349,10 +342,9 @@ export function BlockEditor({ index, entity, featuredProducts }: BlockEditorProp
               optional
             />
             <div className='space-y-4'>
-              <InputField
+              <LinkField
                 name={`entities.${index}.statement.exploreLink`}
                 label='explore link (optional)'
-                placeholder='https://…'
               />
               <UnifiedTranslationFields
                 fieldPrefix={`entities.${index}.statement.translations`}
@@ -444,11 +436,7 @@ export function BlockEditor({ index, entity, featuredProducts }: BlockEditorProp
               />
             </div>
             <div className='space-y-4'>
-              <InputField
-                name={`entities.${index}.embed.ctaLink`}
-                label='CTA link (optional)'
-                placeholder='https://…'
-              />
+              <LinkField name={`entities.${index}.embed.ctaLink`} label='CTA link (optional)' />
               <UnifiedTranslationFields
                 fieldPrefix={`entities.${index}.embed.translations`}
                 fields={[
@@ -489,10 +477,9 @@ export function BlockEditor({ index, entity, featuredProducts }: BlockEditorProp
                 label='collection tag (optional)'
                 placeholder='e.g. ss26-drop'
               />
-              <InputField
+              <LinkField
                 name={`entities.${index}.drop.exploreLink`}
                 label='explore link (optional, shown after release)'
-                placeholder='https://…'
               />
               <UnifiedTranslationFields
                 fieldPrefix={`entities.${index}.drop.translations`}
@@ -544,10 +531,9 @@ export function BlockEditor({ index, entity, featuredProducts }: BlockEditorProp
                 valueAsNumber
                 placeholder='e.g. 8'
               />
-              <InputField
+              <LinkField
                 name={`entities.${index}.lastChance.exploreLink`}
                 label='explore link (optional)'
-                placeholder='https://…'
               />
               <UnifiedTranslationFields
                 fieldPrefix={`entities.${index}.lastChance.translations`}
@@ -592,10 +578,9 @@ export function BlockEditor({ index, entity, featuredProducts }: BlockEditorProp
                 valueAsNumber
                 placeholder='e.g. 8'
               />
-              <InputField
+              <LinkField
                 name={`entities.${index}.newArrivals.exploreLink`}
                 label='explore link (optional)'
-                placeholder='https://…'
               />
               <UnifiedTranslationFields
                 fieldPrefix={`entities.${index}.newArrivals.translations`}
@@ -695,10 +680,9 @@ export function BlockEditor({ index, entity, featuredProducts }: BlockEditorProp
               ]}
             />
             <div className='space-y-4'>
-              <InputField
+              <LinkField
                 name={`entities.${index}.lookbook.exploreLink`}
                 label='explore link (optional)'
-                placeholder='https://…'
               />
               <UnifiedTranslationFields
                 fieldPrefix={`entities.${index}.lookbook.translations`}
@@ -729,10 +713,9 @@ export function BlockEditor({ index, entity, featuredProducts }: BlockEditorProp
               portraitUrl={entity.split?.media?.mediaPortraitUrl || ''}
             />
             <div className='space-y-4'>
-              <InputField
+              <LinkField
                 name={`entities.${index}.split.media.exploreLink`}
                 label='explore link (optional)'
-                placeholder='https://…'
               />
               <UnifiedTranslationFields
                 fieldPrefix={`entities.${index}.split.media.translations`}
@@ -790,10 +773,9 @@ export function BlockEditor({ index, entity, featuredProducts }: BlockEditorProp
               optional
             />
             <div className='space-y-4'>
-              <InputField
+              <LinkField
                 name={`entities.${index}.productSpotlight.exploreLink`}
                 label='explore link (optional)'
-                placeholder='https://…'
               />
               <UnifiedTranslationFields
                 fieldPrefix={`entities.${index}.productSpotlight.translations`}

--- a/src/components/managers/hero/components/common-entity.tsx
+++ b/src/components/managers/hero/components/common-entity.tsx
@@ -1,6 +1,6 @@
 import { useFormContext } from 'react-hook-form';
 import Text from 'ui/components/text';
-import InputField from 'ui/form/fields/input-field';
+import { LinkField } from './link-field';
 import { UnifiedTranslationFields } from 'ui/form/fields/unified-translation-fields';
 import { MediaPreviewWithSelector } from '../../media/components/media-preview-with-selector';
 import { Props } from '../utility/interface';
@@ -140,11 +140,7 @@ export function CommonEntity({
 
       {/* Text + translations — full width below the media */}
       <div className='space-y-4'>
-        <InputField
-          name={`${prefix}.exploreLink` as any}
-          label='explore link (optional)'
-          placeholder='https://…'
-        />
+        <LinkField name={`${prefix}.exploreLink`} label='explore link (optional)' />
 
         <UnifiedTranslationFields
           fieldPrefix={`${prefix}.translations`}

--- a/src/components/managers/hero/components/featured-prduct-base.tsx
+++ b/src/components/managers/hero/components/featured-prduct-base.tsx
@@ -2,6 +2,7 @@ import { ProductPickerModal } from 'components/managers/hero/components/productP
 import { useFormContext } from 'react-hook-form';
 import Text from 'ui/components/text';
 import InputField from 'ui/form/fields/input-field';
+import { LinkField } from './link-field';
 import { UnifiedTranslationFields } from 'ui/form/fields/unified-translation-fields';
 import { HeroProductEntityInterface } from '../utility/interface';
 import { HeroProductTable } from './heroProductsTable';
@@ -60,11 +61,7 @@ export function FeaturedProductBase({
         fields={FEATURED_PRODUCTS_TRANSLATION_FIELDS}
         editMode={true}
       />
-      <InputField
-        name={`entities.${index}.${prefix}.exploreLink`}
-        label='explore link (optional)'
-        placeholder='https://…'
-      />
+      <LinkField name={`entities.${index}.${prefix}.exploreLink`} label='explore link (optional)' />
 
       {isLoadingProducts && prefix?.includes('featuredProductsTag') ? (
         <div className='py-8 text-center'>

--- a/src/components/managers/hero/components/link-field.tsx
+++ b/src/components/managers/hero/components/link-field.tsx
@@ -18,6 +18,7 @@ import Input from 'ui/components/input';
 import Media from 'ui/components/media';
 import Select from 'ui/components/select';
 import Text from 'ui/components/text';
+import { useArchives } from '../../archives/components/useArchiveQuery';
 import { ProductPickerModal } from './productPickerModal';
 
 // Radix Select forbids an empty-string item value, so use a sentinel for "any".
@@ -177,7 +178,44 @@ export function LinkField({ name, label, optional }: LinkFieldProps) {
       )}
 
       {link.type === 'catalog' && <CatalogBody link={link} onChange={update} fieldName={name} />}
+
+      {link.type === 'archive' && <ArchiveBody link={link} onChange={update} fieldName={name} />}
     </div>
+  );
+}
+
+/** Archive picker → serialized into the archive URL by the parent. */
+function ArchiveBody({
+  link,
+  onChange,
+  fieldName,
+}: {
+  link: { slug: string };
+  onChange: (l: StorefrontLink) => void;
+  fieldName: string;
+}) {
+  const { data: archives = [], isLoading } = useArchives();
+  const items = (archives || [])
+    .filter((a) => a.slug)
+    .map((a) => ({
+      value: a.slug as string,
+      label: a.translations?.find((t) => t.heading)?.heading || a.tag || (a.slug as string),
+    }));
+  // Keep the stored slug visible even if it isn't in the fetched page.
+  const hasCurrent = items.some((i) => i.value === link.slug);
+  const allItems =
+    link.slug && !hasCurrent ? [{ value: link.slug, label: link.slug }, ...items] : items;
+
+  return (
+    <Labeled label='archive'>
+      <Select
+        name={`${fieldName}-archive`}
+        placeholder={isLoading ? 'loading…' : 'select an archive'}
+        value={link.slug || ''}
+        items={allItems}
+        onValueChange={(v: string) => onChange({ type: 'archive', slug: v })}
+      />
+    </Labeled>
   );
 }
 

--- a/src/components/managers/hero/components/link-field.tsx
+++ b/src/components/managers/hero/components/link-field.tsx
@@ -1,3 +1,4 @@
+import { common_Product } from 'api/proto-http/admin';
 import { cn } from 'lib/utility';
 import {
   buildStorefrontLink,
@@ -8,7 +9,9 @@ import {
 import { ChangeEvent, useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import Input from 'ui/components/input';
+import Media from 'ui/components/media';
 import Text from 'ui/components/text';
+import { ProductPickerModal } from './productPickerModal';
 
 interface LinkFieldProps {
   /** RHF form path holding the URL string (unchanged contract). */
@@ -37,6 +40,9 @@ export function LinkField({ name, label, optional }: LinkFieldProps) {
   const { watch, setValue } = useFormContext();
   const raw: string = watch(name) || '';
   const [link, setLink] = useState<StorefrontLink>(() => parseStorefrontLink(raw));
+  const [productModalOpen, setProductModalOpen] = useState(false);
+  // Resolved product for display only (thumbnail); the link stores just the slug.
+  const [pickedProduct, setPickedProduct] = useState<common_Product | null>(null);
 
   // Re-sync when the form value changes from outside (form reset / duplicate),
   // but not on our own writes (then raw already equals build(link)).
@@ -69,6 +75,13 @@ export function LinkField({ name, label, optional }: LinkFieldProps) {
         return update(link.type === 'catalog' ? link : { type: 'catalog' });
     }
   };
+
+  // Only trust the resolved product for display when it matches the stored slug
+  // (guards against a stale pick when this field is reused for another block).
+  const showProduct =
+    link.type === 'product' && pickedProduct && pickedProduct.slug === link.slug
+      ? pickedProduct
+      : null;
 
   return (
     <div className='space-y-2'>
@@ -115,6 +128,42 @@ export function LinkField({ name, label, optional }: LinkFieldProps) {
         <Text variant='label' size='small'>
           this block has no link.
         </Text>
+      )}
+
+      {link.type === 'product' && (
+        <div className='space-y-2'>
+          {link.slug ? (
+            <div className='flex items-center gap-2'>
+              {showProduct?.productDisplay?.thumbnail?.media?.thumbnail?.mediaUrl && (
+                <div className='w-12 shrink-0'>
+                  <Media
+                    src={showProduct.productDisplay.thumbnail.media.thumbnail.mediaUrl}
+                    alt='product'
+                    aspectRatio='1/1'
+                    fit='cover'
+                  />
+                </div>
+              )}
+              <Text size='small'>product: {link.slug}</Text>
+            </div>
+          ) : (
+            <Text variant='label' size='small'>
+              no product selected yet.
+            </Text>
+          )}
+          <ProductPickerModal
+            open={productModalOpen}
+            selectedProductIds={showProduct?.id ? [showProduct.id] : []}
+            onOpenRequest={() => setProductModalOpen(true)}
+            onClose={() => setProductModalOpen(false)}
+            onSave={(prods) => {
+              const p = prods[prods.length - 1];
+              update({ type: 'product', slug: p?.slug || '' });
+              setPickedProduct(p || null);
+              setProductModalOpen(false);
+            }}
+          />
+        </div>
       )}
     </div>
   );

--- a/src/components/managers/hero/components/link-field.tsx
+++ b/src/components/managers/hero/components/link-field.tsx
@@ -164,6 +164,7 @@ export function LinkField({ name, label, optional }: LinkFieldProps) {
           )}
           <ProductPickerModal
             open={productModalOpen}
+            single
             selectedProductIds={showProduct?.id ? [showProduct.id] : []}
             onOpenRequest={() => setProductModalOpen(true)}
             onClose={() => setProductModalOpen(false)}
@@ -179,43 +180,70 @@ export function LinkField({ name, label, optional }: LinkFieldProps) {
 
       {link.type === 'catalog' && <CatalogBody link={link} onChange={update} fieldName={name} />}
 
-      {link.type === 'archive' && <ArchiveBody link={link} onChange={update} fieldName={name} />}
+      {link.type === 'archive' && <ArchiveBody link={link} onChange={update} />}
     </div>
   );
 }
 
-/** Archive picker → serialized into the archive URL by the parent. */
+/** Visual archive picker (thumbnail grid) → serialized into the archive URL. */
 function ArchiveBody({
   link,
   onChange,
-  fieldName,
 }: {
   link: { slug: string };
   onChange: (l: StorefrontLink) => void;
-  fieldName: string;
 }) {
   const { data: archives = [], isLoading } = useArchives();
-  const items = (archives || [])
-    .filter((a) => a.slug)
-    .map((a) => ({
-      value: a.slug as string,
-      label: a.translations?.find((t) => t.heading)?.heading || a.tag || (a.slug as string),
-    }));
-  // Keep the stored slug visible even if it isn't in the fetched page.
-  const hasCurrent = items.some((i) => i.value === link.slug);
-  const allItems =
-    link.slug && !hasCurrent ? [{ value: link.slug, label: link.slug }, ...items] : items;
+  const list = (archives || []).filter((a) => a.slug);
 
   return (
-    <Labeled label='archive'>
-      <Select
-        name={`${fieldName}-archive`}
-        placeholder={isLoading ? 'loading…' : 'select an archive'}
-        value={link.slug || ''}
-        items={allItems}
-        onValueChange={(v: string) => onChange({ type: 'archive', slug: v })}
-      />
-    </Labeled>
+    <div className='space-y-2'>
+      <Text component='label' size='small' variant='label'>
+        archive
+      </Text>
+      {isLoading ? (
+        <Text variant='label' size='small'>
+          loading…
+        </Text>
+      ) : list.length === 0 ? (
+        <Text variant='label' size='small'>
+          no archives found.
+        </Text>
+      ) : (
+        <div className='grid max-h-72 grid-cols-2 gap-2 overflow-y-auto sm:grid-cols-3'>
+          {list.map((a) => {
+            const slug = a.slug as string;
+            const heading = a.translations?.find((t) => t.heading)?.heading || a.tag || slug;
+            const selected = link.slug === slug;
+            return (
+              <button
+                key={slug}
+                type='button'
+                onClick={() => onChange({ type: 'archive', slug })}
+                aria-pressed={selected}
+                className={cn(
+                  'flex flex-col gap-1 border-2 p-1 text-left cursor-pointer',
+                  'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-textColor',
+                  selected ? 'border-textColor' : 'border-textInactiveColor hover:border-textColor',
+                )}
+              >
+                <div className='aspect-[4/5] w-full overflow-hidden'>
+                  <Media
+                    src={a.thumbnail?.media?.thumbnail?.mediaUrl || ''}
+                    alt={heading}
+                    aspectRatio='4/5'
+                    fit='cover'
+                  />
+                </div>
+                <Text size='small' className='truncate'>
+                  {heading}
+                </Text>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/src/components/managers/hero/components/link-field.tsx
+++ b/src/components/managers/hero/components/link-field.tsx
@@ -1,17 +1,27 @@
 import { common_Product } from 'api/proto-http/admin';
-import { cn } from 'lib/utility';
+import { useDictionary } from 'lib/providers/dictionary-provider';
 import {
   buildStorefrontLink,
+  CatalogLink,
+  GENDER_OPTIONS,
+  ORDER_OPTIONS,
   parseStorefrontLink,
+  SEASON_OPTIONS,
+  SORT_OPTIONS,
   StorefrontLink,
   StorefrontLinkType,
 } from 'lib/storefront-links';
-import { ChangeEvent, useEffect, useState } from 'react';
+import { cn } from 'lib/utility';
+import { ChangeEvent, ReactNode, useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import Input from 'ui/components/input';
 import Media from 'ui/components/media';
+import Select from 'ui/components/select';
 import Text from 'ui/components/text';
 import { ProductPickerModal } from './productPickerModal';
+
+// Radix Select forbids an empty-string item value, so use a sentinel for "any".
+const ANY = '__any';
 
 interface LinkFieldProps {
   /** RHF form path holding the URL string (unchanged contract). */
@@ -165,6 +175,158 @@ export function LinkField({ name, label, optional }: LinkFieldProps) {
           />
         </div>
       )}
+
+      {link.type === 'catalog' && <CatalogBody link={link} onChange={update} fieldName={name} />}
+    </div>
+  );
+}
+
+function Labeled({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className='space-y-1'>
+      <Text component='label' size='small' variant='label'>
+        {label}
+      </Text>
+      {children}
+    </div>
+  );
+}
+
+/** Catalog filters + sort → serialized into the catalog URL by the parent. */
+function CatalogBody({
+  link,
+  onChange,
+  fieldName,
+}: {
+  link: CatalogLink;
+  onChange: (l: StorefrontLink) => void;
+  fieldName: string;
+}) {
+  const { dictionary } = useDictionary();
+  const set = (patch: Partial<CatalogLink>) => onChange({ ...link, ...patch });
+
+  const withAny = (items: { value: string; label: string }[], anyLabel = 'any') => [
+    { value: ANY, label: anyLabel },
+    ...items,
+  ];
+
+  const categoryItems = (dictionary?.categories || [])
+    .filter((c) => c.id != null && c.name)
+    .map((c) => ({ value: String(c.id), label: c.name as string }));
+  const collectionItems = (dictionary?.collections || [])
+    .filter((c) => c.name)
+    .map((c) => ({ value: c.name as string, label: c.name as string }));
+
+  return (
+    <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
+      <Labeled label='gender'>
+        <Select
+          name={`${fieldName}-gender`}
+          placeholder='any'
+          value={link.gender || ANY}
+          items={withAny(GENDER_OPTIONS.map((o) => ({ value: o.value, label: o.label })))}
+          onValueChange={(v: string) =>
+            set({ gender: v === ANY ? undefined : (v as CatalogLink['gender']) })
+          }
+        />
+      </Labeled>
+
+      <Labeled label='category'>
+        <Select
+          name={`${fieldName}-category`}
+          placeholder='any'
+          value={link.categoryId != null ? String(link.categoryId) : ANY}
+          items={withAny(categoryItems)}
+          onValueChange={(v: string) => set({ categoryId: v === ANY ? undefined : Number(v) })}
+        />
+      </Labeled>
+
+      <Labeled label='collection'>
+        <Select
+          name={`${fieldName}-collection`}
+          placeholder='any'
+          value={link.collection || ANY}
+          items={withAny(collectionItems)}
+          onValueChange={(v: string) => set({ collection: v === ANY ? undefined : v })}
+        />
+      </Labeled>
+
+      <Labeled label='tag'>
+        <Input
+          value={link.tag || ''}
+          placeholder='e.g. ss26'
+          className='border px-2 py-1.5'
+          onChange={(e: ChangeEvent<HTMLInputElement>) => set({ tag: e.target.value || undefined })}
+        />
+      </Labeled>
+
+      <Labeled label='season'>
+        <Select
+          name={`${fieldName}-season`}
+          placeholder='any'
+          value={link.season || ANY}
+          items={withAny(SEASON_OPTIONS.map((o) => ({ value: o.value, label: o.label })))}
+          onValueChange={(v: string) =>
+            set({ season: v === ANY ? undefined : (v as CatalogLink['season']) })
+          }
+        />
+      </Labeled>
+
+      <Labeled label='sort by'>
+        <Select
+          name={`${fieldName}-sort`}
+          placeholder='default'
+          value={link.sort || ANY}
+          items={withAny(
+            SORT_OPTIONS.map((o) => ({ value: o.value, label: o.label })),
+            'default',
+          )}
+          onValueChange={(v: string) =>
+            set({
+              sort: v === ANY ? undefined : (v as CatalogLink['sort']),
+              order: v === ANY ? undefined : link.order,
+            })
+          }
+        />
+      </Labeled>
+
+      {link.sort && (
+        <Labeled label='order'>
+          <Select
+            name={`${fieldName}-order`}
+            placeholder='descending'
+            value={link.order || ANY}
+            items={withAny(
+              ORDER_OPTIONS.map((o) => ({ value: o.value, label: o.label })),
+              'default (desc)',
+            )}
+            onValueChange={(v: string) =>
+              set({ order: v === ANY ? undefined : (v as CatalogLink['order']) })
+            }
+          />
+        </Labeled>
+      )}
+
+      <button
+        type='button'
+        onClick={() => set({ onSale: !link.onSale })}
+        aria-pressed={!!link.onSale}
+        className={cn(
+          'flex items-center gap-2 self-end border px-2 py-1.5 cursor-pointer',
+          'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-textColor',
+          link.onSale ? 'border-textColor' : 'border-textInactiveColor',
+        )}
+      >
+        <span
+          className={cn(
+            'inline-block h-3 w-3 border',
+            link.onSale ? 'border-textColor bg-textColor' : 'border-textInactiveColor',
+          )}
+        />
+        <Text size='small' variant='uppercase'>
+          on sale only
+        </Text>
+      </button>
     </div>
   );
 }

--- a/src/components/managers/hero/components/link-field.tsx
+++ b/src/components/managers/hero/components/link-field.tsx
@@ -1,0 +1,121 @@
+import { cn } from 'lib/utility';
+import {
+  buildStorefrontLink,
+  parseStorefrontLink,
+  StorefrontLink,
+  StorefrontLinkType,
+} from 'lib/storefront-links';
+import { ChangeEvent, useEffect, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import Input from 'ui/components/input';
+import Text from 'ui/components/text';
+
+interface LinkFieldProps {
+  /** RHF form path holding the URL string (unchanged contract). */
+  name: string;
+  label: string;
+  optional?: boolean;
+}
+
+const TYPE_TABS: { value: StorefrontLinkType; label: string }[] = [
+  { value: 'none', label: 'none' },
+  { value: 'product', label: 'product' },
+  { value: 'catalog', label: 'catalog' },
+  { value: 'archive', label: 'archive' },
+  { value: 'external', label: 'custom url' },
+];
+
+/**
+ * Structured picker for a hero "explore / CTA" link. Replaces the raw URL input:
+ * the user picks a target (product / catalog+filters / archive / custom / none)
+ * and the component serializes it to the URL string the storefront expects (via
+ * lib/storefront-links), writing that string back to the same form field — so
+ * the contract is unchanged. On edit, the stored URL is parsed back into the
+ * picker; anything unrecognized falls back to "custom url" and stays editable.
+ */
+export function LinkField({ name, label, optional }: LinkFieldProps) {
+  const { watch, setValue } = useFormContext();
+  const raw: string = watch(name) || '';
+  const [link, setLink] = useState<StorefrontLink>(() => parseStorefrontLink(raw));
+
+  // Re-sync when the form value changes from outside (form reset / duplicate),
+  // but not on our own writes (then raw already equals build(link)).
+  useEffect(() => {
+    if (raw !== buildStorefrontLink(link)) setLink(parseStorefrontLink(raw));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [raw]);
+
+  const update = (next: StorefrontLink) => {
+    setLink(next);
+    setValue(name, buildStorefrontLink(next), {
+      shouldDirty: true,
+      shouldTouch: true,
+      shouldValidate: true,
+    });
+  };
+
+  const changeType = (type: StorefrontLinkType) => {
+    if (type === link.type) return;
+    switch (type) {
+      case 'none':
+        return update({ type: 'none' });
+      case 'external':
+        return update({ type: 'external', url: link.type === 'external' ? link.url : '' });
+      case 'product':
+        return update({ type: 'product', slug: link.type === 'product' ? link.slug : '' });
+      case 'archive':
+        return update({ type: 'archive', slug: link.type === 'archive' ? link.slug : '' });
+      case 'catalog':
+        return update(link.type === 'catalog' ? link : { type: 'catalog' });
+    }
+  };
+
+  return (
+    <div className='space-y-2'>
+      <Text component='label' size='small' variant='label'>
+        {label}
+        {optional ? ' (optional)' : ''}
+      </Text>
+
+      <div className='flex flex-wrap gap-1'>
+        {TYPE_TABS.map((t) => {
+          const active = link.type === t.value;
+          return (
+            <button
+              key={t.value}
+              type='button'
+              onClick={() => changeType(t.value)}
+              aria-pressed={active}
+              className={cn(
+                'border px-2 py-1 text-small uppercase leading-none cursor-pointer',
+                'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-textColor',
+                active
+                  ? 'border-textColor bg-textColor text-bgColor'
+                  : 'border-textInactiveColor text-textColor hover:border-textColor',
+              )}
+            >
+              {t.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {link.type === 'external' && (
+        <Input
+          value={link.url}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            update({ type: 'external', url: e.target.value })
+          }
+          placeholder='https://…'
+          className='border px-2 py-1.5'
+        />
+      )}
+
+      {link.type === 'none' && (
+        <Text variant='label' size='small'>
+          this block has no link.
+        </Text>
+      )}
+    </div>
+  );
+}

--- a/src/components/managers/hero/components/productPickerModal.tsx
+++ b/src/components/managers/hero/components/productPickerModal.tsx
@@ -24,6 +24,8 @@ interface ProductsPickerData {
   onClose: () => void;
   onSave: (newSelectedProducts: common_Product[]) => void;
   onOpenRequest?: () => void;
+  /** Single-select mode: radio picker, choosing one replaces any prior pick. */
+  single?: boolean;
 }
 
 export const ProductPickerModal: FC<ProductsPickerData> = ({
@@ -32,6 +34,7 @@ export const ProductPickerModal: FC<ProductsPickerData> = ({
   onClose,
   onSave,
   onOpenRequest,
+  single = false,
 }) => {
   const calculateOffset = (page: number, limit: number) => (page - 1) * limit;
 
@@ -92,6 +95,11 @@ export const ProductPickerModal: FC<ProductsPickerData> = ({
   };
 
   const handleSelectionChange = (product: common_Product) => {
+    if (single) {
+      // One target only — replace any prior pick.
+      setSelectedProducts([product]);
+      return;
+    }
     const isSelected = selectedProducts.some((p) => p.id === product.id);
     if (isSelected) {
       setSelectedProducts((prev) => prev.filter((p) => p.id !== product.id));
@@ -112,7 +120,8 @@ export const ProductPickerModal: FC<ProductsPickerData> = ({
           const isSelected = selectedProducts.some((p) => p.id === product.id);
           return (
             <input
-              type='checkbox'
+              type={single ? 'radio' : 'checkbox'}
+              name={single ? 'product-pick' : undefined}
               checked={isSelected}
               onChange={() => handleSelectionChange(product)}
               className='cursor-pointer'
@@ -194,7 +203,7 @@ export const ProductPickerModal: FC<ProductsPickerData> = ({
         },
       },
     ],
-    [selectedProducts, categories],
+    [selectedProducts, categories, single],
   );
 
   return (

--- a/src/components/managers/hero/components/slide-list-field.tsx
+++ b/src/components/managers/hero/components/slide-list-field.tsx
@@ -2,7 +2,7 @@ import { LANGUAGES } from 'constants/constants';
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import { Button } from 'ui/components/button';
 import Text from 'ui/components/text';
-import InputField from 'ui/form/fields/input-field';
+import { LinkField } from './link-field';
 import { UnifiedTranslationFields } from 'ui/form/fields/unified-translation-fields';
 import { MediaPairField } from './media-pair-field';
 
@@ -109,11 +109,7 @@ export function SlideListField({
               portraitRatio={portraitRatio}
             />
 
-            <InputField
-              name={`${name}.${i}.exploreLink`}
-              label='explore link (optional)'
-              placeholder='https://…'
-            />
+            <LinkField name={`${name}.${i}.exploreLink`} label='explore link (optional)' />
 
             <UnifiedTranslationFields
               fieldPrefix={`${name}.${i}.translations`}

--- a/src/lib/storefront-links.ts
+++ b/src/lib/storefront-links.ts
@@ -1,0 +1,216 @@
+import {
+  common_GenderEnum,
+  common_OrderFactor,
+  common_SeasonEnum,
+  common_SortFactor,
+} from 'api/proto-http/frontend';
+
+/**
+ * SINGLE SOURCE OF TRUTH for turning a hero "explore / CTA" link into the URL
+ * string the storefront expects, and back. The admin app never builds storefront
+ * page URLs anywhere else, so THIS FILE is the one place to confirm/adjust the
+ * exact paths + query-param names.
+ *
+ * Any URL that doesn't match a known internal pattern (or points off-origin) is
+ * kept as an `external` raw string, so legacy links and off-site links never
+ * break and stay editable.
+ *
+ * TODO(confirm with storefront): the `PATHS`, `Q`, and *_URL maps below are best
+ * guesses. Also decide whether internal links need a `/{country}/{locale}`
+ * prefix — they are currently emitted as prefix-less relative paths (portable
+ * across beta/prod and locale), on the assumption the storefront resolves them
+ * within the active locale. If a prefix or absolute origin is required, add it
+ * in `PATHS`/`buildStorefrontLink` here and nowhere else.
+ */
+
+export type StorefrontLinkType = 'none' | 'external' | 'product' | 'archive' | 'catalog';
+
+export type CatalogLink = {
+  type: 'catalog';
+  gender?: common_GenderEnum;
+  categoryId?: number;
+  collection?: string;
+  tag?: string;
+  onSale?: boolean;
+  season?: common_SeasonEnum;
+  sort?: common_SortFactor;
+  order?: common_OrderFactor;
+};
+
+export type StorefrontLink =
+  | { type: 'none' }
+  | { type: 'external'; url: string }
+  | { type: 'product'; slug: string }
+  | { type: 'archive'; slug: string }
+  | CatalogLink;
+
+// ---- editable templates ---------------------------------------------------
+
+// Internal page paths (relative, no locale prefix — see file header).
+const PATHS = {
+  product: (slug: string) => `/product/${encodeURIComponent(slug)}`,
+  archive: (slug: string) => `/archive/${encodeURIComponent(slug)}`,
+  catalog: '/catalog',
+};
+
+// Catalog page query-param names.
+const Q = {
+  gender: 'gender',
+  categoryId: 'categoryId',
+  collection: 'collection',
+  tag: 'tag',
+  onSale: 'sale',
+  season: 'season',
+  sort: 'sort',
+  order: 'order',
+} as const;
+
+// How enum values appear in the URL (short human forms).
+const GENDER_URL: Record<string, string> = {
+  GENDER_ENUM_MALE: 'men',
+  GENDER_ENUM_FEMALE: 'women',
+  GENDER_ENUM_UNISEX: 'unisex',
+};
+const SORT_URL: Record<string, string> = {
+  SORT_FACTOR_CREATED_AT: 'new',
+  SORT_FACTOR_UPDATED_AT: 'updated',
+  SORT_FACTOR_NAME: 'name',
+  SORT_FACTOR_PRICE: 'price',
+};
+const ORDER_URL: Record<string, string> = {
+  ORDER_FACTOR_ASC: 'asc',
+  ORDER_FACTOR_DESC: 'desc',
+};
+const SEASON_URL: Record<string, string> = {
+  SEASON_ENUM_SS: 'ss',
+  SEASON_ENUM_FW: 'fw',
+  SEASON_ENUM_PF: 'pf',
+  SEASON_ENUM_RC: 'rc',
+};
+
+// ---- internals ------------------------------------------------------------
+
+const invert = (m: Record<string, string>): Record<string, string> =>
+  Object.fromEntries(Object.entries(m).map(([k, v]) => [v, k]));
+const GENDER_ENUM = invert(GENDER_URL);
+const SORT_ENUM = invert(SORT_URL);
+const ORDER_ENUM = invert(ORDER_URL);
+const SEASON_ENUM = invert(SEASON_URL);
+
+const STOREFRONT_ORIGIN = (() => {
+  try {
+    return new URL(import.meta.env.VITE_STOREFRONT_URL || 'https://grbpwr.com').origin;
+  } catch {
+    return 'https://grbpwr.com';
+  }
+})();
+
+// ---- build ----------------------------------------------------------------
+
+/** Serialize a StorefrontLink to the URL string stored in the form / contract. */
+export function buildStorefrontLink(link: StorefrontLink): string {
+  switch (link.type) {
+    case 'none':
+      return '';
+    case 'external':
+      return link.url || '';
+    case 'product':
+      return link.slug ? PATHS.product(link.slug) : '';
+    case 'archive':
+      return link.slug ? PATHS.archive(link.slug) : '';
+    case 'catalog': {
+      const p = new URLSearchParams();
+      if (link.gender && GENDER_URL[link.gender]) p.set(Q.gender, GENDER_URL[link.gender]);
+      if (link.categoryId != null) p.set(Q.categoryId, String(link.categoryId));
+      if (link.collection) p.set(Q.collection, link.collection);
+      if (link.tag) p.set(Q.tag, link.tag);
+      if (link.onSale) p.set(Q.onSale, 'true');
+      if (link.season && SEASON_URL[link.season]) p.set(Q.season, SEASON_URL[link.season]);
+      if (link.sort && SORT_URL[link.sort]) p.set(Q.sort, SORT_URL[link.sort]);
+      if (link.order && ORDER_URL[link.order]) p.set(Q.order, ORDER_URL[link.order]);
+      const qs = p.toString();
+      return qs ? `${PATHS.catalog}?${qs}` : PATHS.catalog;
+    }
+  }
+  return '';
+}
+
+// ---- parse ----------------------------------------------------------------
+
+/**
+ * Parse a stored URL string back into a StorefrontLink. Relative paths resolve
+ * against the storefront origin; absolute URLs to a different origin, and any
+ * path that doesn't match a known pattern, become `external` (kept verbatim).
+ */
+export function parseStorefrontLink(url: string | null | undefined): StorefrontLink {
+  if (!url || !url.trim()) return { type: 'none' };
+
+  let u: URL;
+  try {
+    u = new URL(url, STOREFRONT_ORIGIN);
+  } catch {
+    return { type: 'external', url };
+  }
+
+  // Absolute link to some other site → external.
+  if (/^https?:\/\//i.test(url) && u.origin !== STOREFRONT_ORIGIN) {
+    return { type: 'external', url };
+  }
+
+  const path = u.pathname.replace(/\/+$/, '') || '/';
+
+  const product = path.match(/^\/product\/(.+)$/);
+  if (product) return { type: 'product', slug: decodeURIComponent(product[1]) };
+
+  const archive = path.match(/^\/archive\/(.+)$/);
+  if (archive) return { type: 'archive', slug: decodeURIComponent(archive[1]) };
+
+  if (path === '/catalog') {
+    const q = u.searchParams;
+    const out: CatalogLink = { type: 'catalog' };
+    const gender = q.get(Q.gender);
+    if (gender && GENDER_ENUM[gender]) out.gender = GENDER_ENUM[gender] as common_GenderEnum;
+    const categoryId = q.get(Q.categoryId);
+    if (categoryId && !Number.isNaN(Number(categoryId))) out.categoryId = Number(categoryId);
+    const collection = q.get(Q.collection);
+    if (collection) out.collection = collection;
+    const tag = q.get(Q.tag);
+    if (tag) out.tag = tag;
+    if (q.get(Q.onSale) === 'true') out.onSale = true;
+    const season = q.get(Q.season);
+    if (season && SEASON_ENUM[season]) out.season = SEASON_ENUM[season] as common_SeasonEnum;
+    const sort = q.get(Q.sort);
+    if (sort && SORT_ENUM[sort]) out.sort = SORT_ENUM[sort] as common_SortFactor;
+    const order = q.get(Q.order);
+    if (order && ORDER_ENUM[order]) out.order = ORDER_ENUM[order] as common_OrderFactor;
+    return out;
+  }
+
+  return { type: 'external', url };
+}
+
+// ---- option lists (for the picker UI) -------------------------------------
+
+export const GENDER_OPTIONS: { label: string; value: common_GenderEnum }[] = [
+  { label: 'men', value: 'GENDER_ENUM_MALE' },
+  { label: 'women', value: 'GENDER_ENUM_FEMALE' },
+  { label: 'unisex', value: 'GENDER_ENUM_UNISEX' },
+];
+
+export const SORT_OPTIONS: { label: string; value: common_SortFactor }[] = [
+  { label: 'newest', value: 'SORT_FACTOR_CREATED_AT' },
+  { label: 'price', value: 'SORT_FACTOR_PRICE' },
+  { label: 'name', value: 'SORT_FACTOR_NAME' },
+];
+
+export const ORDER_OPTIONS: { label: string; value: common_OrderFactor }[] = [
+  { label: 'ascending', value: 'ORDER_FACTOR_ASC' },
+  { label: 'descending', value: 'ORDER_FACTOR_DESC' },
+];
+
+export const SEASON_OPTIONS: { label: string; value: common_SeasonEnum }[] = [
+  { label: 'SS', value: 'SEASON_ENUM_SS' },
+  { label: 'FW', value: 'SEASON_ENUM_FW' },
+  { label: 'PF', value: 'SEASON_ENUM_PF' },
+  { label: 'RC', value: 'SEASON_ENUM_RC' },
+];


### PR DESCRIPTION
Release of PR #311 (hero structured link picker) from beta to master.

Replaces the 13 hand-typed hero explore/CTA URL inputs with a structured LinkField (product / catalog+filters / archive / custom). URL build/parse centralized in src/lib/storefront-links.ts; internal links relative + prefix-less. Existing links round-trip; unrecognized stay as raw custom url.

beta carried only this work, so the release is contained to the hero link fields.

Verification: tsc baseline (26 / 0 hero+lib), yarn build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8ATXa7zmUrwv3Hs5pMdnn