### PR TITLE
Hero: tint/stroke, tag picker, tag-preview, double/lookbook/split/newsletter refactors (+ proto bump)

### DIFF
--- a/src/api/proto-http/admin/index.ts
+++ b/src/api/proto-http/admin/index.ts
@@ -92,6 +92,7 @@ export type common_Dictionary = {
   isProd: boolean | undefined;
   // Hero section background color for the storefront (CSS). Empty if unset.
   backgroundHeroColor: string | undefined;
+  productTags: string[] | undefined;
 };
 
 // Category represents a hierarchical category structure
@@ -1774,11 +1775,15 @@ export type common_HeroSingleInsert = {
 };
 
 // HeroMedia is a portrait/landscape media pair addressed by id (write side).
-// disable_overlay lives here so the scrim can be toggled per media slot.
+// The per-slot presentation modifiers live here: disable_overlay toggles the
+// scrim, disable_tint toggles the frontend's background colour tint, and stroke
+// toggles a border/outline around the media.
 export type common_HeroMedia = {
   portraitId: number | undefined;
   landscapeId: number | undefined;
   disableOverlay: boolean | undefined;
+  disableTint: boolean | undefined;
+  stroke: boolean | undefined;
 };
 
 // HeroCopyTranslation is the single, shared translation for every hero block.

--- a/src/api/proto-http/common/index.ts
+++ b/src/api/proto-http/common/index.ts
@@ -726,6 +726,7 @@ export type Dictionary = {
   isProd: boolean | undefined;
   // Hero section background color for the storefront (CSS). Empty if unset.
   backgroundHeroColor: string | undefined;
+  productTags: string[] | undefined;
 };
 
 export type Collection = {
@@ -839,11 +840,15 @@ export type HeroAudience =
   | "HERO_AUDIENCE_MEMBERS"
   | "HERO_AUDIENCE_TIER";
 // HeroMedia is a portrait/landscape media pair addressed by id (write side).
-// disable_overlay lives here so the scrim can be toggled per media slot.
+// The per-slot presentation modifiers live here: disable_overlay toggles the
+// scrim, disable_tint toggles the frontend's background colour tint, and stroke
+// toggles a border/outline around the media.
 export type HeroMedia = {
   portraitId: number | undefined;
   landscapeId: number | undefined;
   disableOverlay: boolean | undefined;
+  disableTint: boolean | undefined;
+  stroke: boolean | undefined;
 };
 
 // HeroMediaFull is the resolved form of HeroMedia (read side).
@@ -851,6 +856,8 @@ export type HeroMediaFull = {
   portrait: MediaFull | undefined;
   landscape: MediaFull | undefined;
   disableOverlay: boolean | undefined;
+  disableTint: boolean | undefined;
+  stroke: boolean | undefined;
 };
 
 export type HeroFullWithTranslations = {

--- a/src/api/proto-http/frontend/index.ts
+++ b/src/api/proto-http/frontend/index.ts
@@ -85,6 +85,8 @@ export type common_HeroMediaFull = {
   portrait: common_MediaFull | undefined;
   landscape: common_MediaFull | undefined;
   disableOverlay: boolean | undefined;
+  disableTint: boolean | undefined;
+  stroke: boolean | undefined;
 };
 
 export type common_MediaFull = {
@@ -443,6 +445,7 @@ export type common_Dictionary = {
   isProd: boolean | undefined;
   // Hero section background color for the storefront (CSS). Empty if unset.
   backgroundHeroColor: string | undefined;
+  productTags: string[] | undefined;
 };
 
 // Category represents a hierarchical category structure

--- a/src/components/managers/hero/components/block-editor.tsx
+++ b/src/components/managers/hero/components/block-editor.tsx
@@ -7,6 +7,7 @@ import ToggleField from 'ui/form/fields/toggle-field';
 import { UnifiedTranslationFields } from 'ui/form/fields/unified-translation-fields';
 import { MediaPreviewWithSelector } from '../../media/components/media-preview-with-selector';
 import { CommonEntity } from './common-entity';
+import { DoubleEditor } from './double-editor';
 import { FeaturedProductBase } from './featured-prduct-base';
 import { HeroProductPicker } from './hero-product-picker';
 import { LinkField } from './link-field';
@@ -157,39 +158,7 @@ export function BlockEditor({ index, entity, featuredProducts }: BlockEditorProp
         );
 
       case 'HERO_TYPE_DOUBLE':
-        return (
-          <div className='flex flex-col gap-4'>
-            <div className='p-3 lg:p-4'>
-              <Text className='font-bold leading-none' variant='uppercase' size='large'>
-                double add
-              </Text>
-            </div>
-            <CommonEntity
-              title='left add'
-              prefix={`entities.${index}.double.left`}
-              landscapeLink={entity.double?.left?.mediaLandscapeUrl || ''}
-              portraitLink={entity.double?.left?.mediaPortraitUrl || ''}
-              aspectRatio={['1:1']}
-              isDoubleAd
-              onSaveMedia={(media: common_MediaFull[], orientation: 'Portrait' | 'Landscape') =>
-                handleSaveMedia(media, 'doubleLeft', orientation)
-              }
-              onClearMedia={(orientation) => handleClearMedia('doubleLeft', orientation)}
-            />
-            <CommonEntity
-              title='right add'
-              prefix={`entities.${index}.double.right`}
-              landscapeLink={entity.double?.right?.mediaLandscapeUrl || ''}
-              portraitLink={entity.double?.right?.mediaPortraitUrl || ''}
-              aspectRatio={['1:1']}
-              isDoubleAd
-              onSaveMedia={(media: common_MediaFull[], orientation: 'Portrait' | 'Landscape') =>
-                handleSaveMedia(media, 'doubleRight', orientation)
-              }
-              onClearMedia={(orientation) => handleClearMedia('doubleRight', orientation)}
-            />
-          </div>
-        );
+        return <DoubleEditor index={index} />;
 
       case 'HERO_TYPE_FEATURED_PRODUCTS':
         return (

--- a/src/components/managers/hero/components/block-editor.tsx
+++ b/src/components/managers/hero/components/block-editor.tsx
@@ -673,6 +673,8 @@ export function BlockEditor({ index, entity, featuredProducts }: BlockEditorProp
               portraitUrl={entity.split?.media?.mediaPortraitUrl || ''}
               landscapeRatio={['1:2']}
               portraitRatio={['1:2']}
+              landscapeLabel='desktop'
+              portraitLabel='mobile'
             />
             <div className='space-y-4'>
               <LinkField

--- a/src/components/managers/hero/components/block-editor.tsx
+++ b/src/components/managers/hero/components/block-editor.tsx
@@ -364,19 +364,6 @@ export function BlockEditor({ index, entity, featuredProducts }: BlockEditorProp
                     rows: 2,
                     required: false,
                   },
-                  {
-                    name: 'placeholder',
-                    label: 'email placeholder (optional)',
-                    type: 'input',
-                    required: false,
-                  },
-                  { name: 'ctaText', label: 'button text', type: 'input' },
-                  {
-                    name: 'successText',
-                    label: 'success message (optional)',
-                    type: 'input',
-                    required: false,
-                  },
                 ]}
                 editMode
               />

--- a/src/components/managers/hero/components/block-editor.tsx
+++ b/src/components/managers/hero/components/block-editor.tsx
@@ -8,6 +8,7 @@ import { UnifiedTranslationFields } from 'ui/form/fields/unified-translation-fie
 import { MediaPreviewWithSelector } from '../../media/components/media-preview-with-selector';
 import { CommonEntity } from './common-entity';
 import { DoubleEditor } from './double-editor';
+import { TagPicker } from './tag-picker';
 import { FeaturedProductBase } from './featured-prduct-base';
 import { HeroProductPicker } from './hero-product-picker';
 import { LinkField } from './link-field';
@@ -441,8 +442,11 @@ export function BlockEditor({ index, entity, featuredProducts }: BlockEditorProp
                 value={entity.drop?.releaseAt}
                 label='release date & time'
               />
-              <InputField
-                name={`entities.${index}.drop.tag`}
+              <TagPicker
+                value={entity.drop?.tag || ''}
+                onChange={(v) =>
+                  setValue(`entities.${index}.drop.tag` as any, v, { shouldDirty: true })
+                }
                 label='collection tag (optional)'
                 placeholder='e.g. ss26-drop'
               />

--- a/src/components/managers/hero/components/block-editor.tsx
+++ b/src/components/managers/hero/components/block-editor.tsx
@@ -684,6 +684,8 @@ export function BlockEditor({ index, entity, featuredProducts }: BlockEditorProp
               prefix={`entities.${index}.split.media`}
               landscapeUrl={entity.split?.media?.mediaLandscapeUrl || ''}
               portraitUrl={entity.split?.media?.mediaPortraitUrl || ''}
+              landscapeRatio={['2:1']}
+              portraitRatio={['1:1']}
             />
             <div className='space-y-4'>
               <LinkField

--- a/src/components/managers/hero/components/block-editor.tsx
+++ b/src/components/managers/hero/components/block-editor.tsx
@@ -671,8 +671,8 @@ export function BlockEditor({ index, entity, featuredProducts }: BlockEditorProp
               prefix={`entities.${index}.split.media`}
               landscapeUrl={entity.split?.media?.mediaLandscapeUrl || ''}
               portraitUrl={entity.split?.media?.mediaPortraitUrl || ''}
-              landscapeRatio={['2:1']}
-              portraitRatio={['1:1']}
+              landscapeRatio={['1:2']}
+              portraitRatio={['1:2']}
             />
             <div className='space-y-4'>
               <LinkField

--- a/src/components/managers/hero/components/common-entity.tsx
+++ b/src/components/managers/hero/components/common-entity.tsx
@@ -1,6 +1,7 @@
 import { useFormContext } from 'react-hook-form';
 import Text from 'ui/components/text';
 import { LinkField } from './link-field';
+import { MediaModifierToggles } from './media-modifier-toggles';
 import { UnifiedTranslationFields } from 'ui/form/fields/unified-translation-fields';
 import { MediaPreviewWithSelector } from '../../media/components/media-preview-with-selector';
 import { Props } from '../utility/interface';
@@ -137,6 +138,8 @@ export function CommonEntity({
           />
         </div>
       )}
+
+      <MediaModifierToggles prefix={prefix} />
 
       {/* Text + translations — full width below the media */}
       <div className='space-y-4'>

--- a/src/components/managers/hero/components/common-entity.tsx
+++ b/src/components/managers/hero/components/common-entity.tsx
@@ -31,7 +31,13 @@ const TRANSLATION_CONFIGS = {
   ],
   double: [
     { name: 'headline', label: 'headline', type: 'input' as const, required: false, maxLength: 39 },
-    { name: 'exploreText', label: 'explore text', type: 'input' as const, maxLength: 39 },
+    {
+      name: 'exploreText',
+      label: 'explore text',
+      type: 'input' as const,
+      required: false,
+      maxLength: 39,
+    },
   ],
 };
 

--- a/src/components/managers/hero/components/double-editor.tsx
+++ b/src/components/managers/hero/components/double-editor.tsx
@@ -1,0 +1,102 @@
+import { common_MediaFull } from 'api/proto-http/admin';
+import { useFormContext, useWatch } from 'react-hook-form';
+import Text from 'ui/components/text';
+import { UnifiedTranslationFields } from 'ui/form/fields/unified-translation-fields';
+import { MediaPreviewWithSelector } from '../../media/components/media-preview-with-selector';
+import { LinkField } from './link-field';
+import { MediaModifierToggles } from './media-modifier-toggles';
+
+const DOUBLE_TRANSLATION_FIELDS = [
+  { name: 'headline', label: 'headline', type: 'input' as const, required: false, maxLength: 39 },
+  {
+    name: 'exploreText',
+    label: 'explore text',
+    type: 'input' as const,
+    required: false,
+    maxLength: 39,
+  },
+];
+
+// One half of a double ad. A double ad is a single square image per side; store
+// it in both the landscape and portrait slots so the existing HeroMedia mapping
+// works unchanged.
+function DoubleHalf({ side, prefix }: { side: 'left' | 'right'; prefix: string }) {
+  const { control, setValue } = useFormContext();
+  const mediaUrl = (useWatch({ control, name: `${prefix}.mediaLandscapeUrl` }) as string) || '';
+
+  const save = (media: common_MediaFull[]) => {
+    if (!media.length) return;
+    const id = media[0].id;
+    const thumb = media[0].media?.thumbnail?.mediaUrl || '';
+    (['Landscape', 'Portrait'] as const).forEach((o) => {
+      setValue(`${prefix}.media${o}Id`, id, { shouldDirty: true, shouldTouch: true });
+      setValue(`${prefix}.media${o}Url`, thumb, { shouldDirty: true, shouldTouch: true });
+    });
+  };
+
+  const clear = () => {
+    (['Landscape', 'Portrait'] as const).forEach((o) => {
+      setValue(`${prefix}.media${o}Id`, undefined, { shouldDirty: true, shouldTouch: true });
+      setValue(`${prefix}.media${o}Url`, '', { shouldDirty: true, shouldTouch: true });
+    });
+  };
+
+  return (
+    <div className='space-y-4 border border-textInactiveColor p-3'>
+      <Text variant='uppercase' size='small' className='font-bold'>
+        {side}
+      </Text>
+
+      <div className='space-y-1'>
+        <Text variant='label' size='small'>
+          square image (1:1)
+        </Text>
+        <MediaPreviewWithSelector
+          mediaUrl={mediaUrl}
+          aspectRatio={['1:1']}
+          allowMultiple={false}
+          showVideos={true}
+          alt={`${side} media`}
+          label='select'
+          purpose={side}
+          heightClass='h-44'
+          onSaveMedia={save}
+          onClear={clear}
+        />
+      </div>
+
+      <MediaModifierToggles prefix={prefix} />
+      <LinkField name={`${prefix}.exploreLink`} label='explore link (optional)' />
+      <UnifiedTranslationFields
+        fieldPrefix={`${prefix}.translations`}
+        fields={DOUBLE_TRANSLATION_FIELDS}
+        editMode
+      />
+    </div>
+  );
+}
+
+/**
+ * Editor for a DOUBLE block: two square ads shown side by side on the storefront.
+ * Purpose-built (replaces the CommonEntity `isDoubleAd` reuse) so the pairing and
+ * the single-square-image-per-side model are obvious.
+ */
+export function DoubleEditor({ index }: { index: number }) {
+  return (
+    <div className='space-y-5 p-3 lg:p-4'>
+      <div className='space-y-1'>
+        <Text className='font-bold leading-none' variant='uppercase' size='large'>
+          double
+        </Text>
+        <Text variant='label' size='small'>
+          two square blocks shown side by side on the storefront — fill in both.
+        </Text>
+      </div>
+
+      <div className='grid gap-4 lg:grid-cols-2'>
+        <DoubleHalf side='left' prefix={`entities.${index}.double.left`} />
+        <DoubleHalf side='right' prefix={`entities.${index}.double.right`} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/managers/hero/components/featured-prduct-base.tsx
+++ b/src/components/managers/hero/components/featured-prduct-base.tsx
@@ -1,9 +1,8 @@
 import { ProductPickerModal } from 'components/managers/hero/components/productPickerModal';
-import { useDictionary } from 'lib/providers/dictionary-provider';
 import { useFormContext } from 'react-hook-form';
 import Text from 'ui/components/text';
-import SelectField from 'ui/form/fields/select-field';
 import { LinkField } from './link-field';
+import { TagPicker } from './tag-picker';
 import { UnifiedTranslationFields } from 'ui/form/fields/unified-translation-fields';
 import { HeroProductEntityInterface } from '../utility/interface';
 import { HeroProductTable } from './heroProductsTable';
@@ -32,18 +31,12 @@ export function FeaturedProductBase({
   const {
     formState: { errors },
     watch,
+    setValue,
   } = useFormContext<HeroSchema>();
 
   const tag = prefix?.includes('featuredProductsTag')
     ? watch(`entities.${index}.${prefix}.tag` as any)
     : undefined;
-
-  const { dictionary } = useDictionary();
-  const productTags = dictionary?.productTags || [];
-  // Keep the stored tag selectable even if it's no longer in the dictionary.
-  const tagItems = (tag && !productTags.includes(tag) ? [tag, ...productTags] : productTags).map(
-    (t) => ({ value: t, label: t }),
-  );
 
   const { data: productsByTag = [], isLoading: isLoadingProducts } = useProductsByTag(
     tag,
@@ -61,11 +54,12 @@ export function FeaturedProductBase({
         {title}
       </Text>
       {prefix?.includes('featuredProductsTag') && (
-        <SelectField
-          name={`entities.${index}.${prefix}.tag`}
+        <TagPicker
+          value={tag || ''}
+          onChange={(v) =>
+            setValue(`entities.${index}.${prefix}.tag` as any, v, { shouldDirty: true })
+          }
           label='tag'
-          placeholder='select a product tag'
-          items={tagItems}
         />
       )}
 

--- a/src/components/managers/hero/components/featured-prduct-base.tsx
+++ b/src/components/managers/hero/components/featured-prduct-base.tsx
@@ -1,7 +1,8 @@
 import { ProductPickerModal } from 'components/managers/hero/components/productPickerModal';
+import { useDictionary } from 'lib/providers/dictionary-provider';
 import { useFormContext } from 'react-hook-form';
 import Text from 'ui/components/text';
-import InputField from 'ui/form/fields/input-field';
+import SelectField from 'ui/form/fields/select-field';
 import { LinkField } from './link-field';
 import { UnifiedTranslationFields } from 'ui/form/fields/unified-translation-fields';
 import { HeroProductEntityInterface } from '../utility/interface';
@@ -37,6 +38,13 @@ export function FeaturedProductBase({
     ? watch(`entities.${index}.${prefix}.tag` as any)
     : undefined;
 
+  const { dictionary } = useDictionary();
+  const productTags = dictionary?.productTags || [];
+  // Keep the stored tag selectable even if it's no longer in the dictionary.
+  const tagItems = (tag && !productTags.includes(tag) ? [tag, ...productTags] : productTags).map(
+    (t) => ({ value: t, label: t }),
+  );
+
   const { data: productsByTag = [], isLoading: isLoadingProducts } = useProductsByTag(
     tag,
     prefix?.includes('featuredProductsTag'),
@@ -53,7 +61,12 @@ export function FeaturedProductBase({
         {title}
       </Text>
       {prefix?.includes('featuredProductsTag') && (
-        <InputField name={`entities.${index}.${prefix}.tag`} label='tag' />
+        <SelectField
+          name={`entities.${index}.${prefix}.tag`}
+          label='tag'
+          placeholder='select a product tag'
+          items={tagItems}
+        />
       )}
 
       <UnifiedTranslationFields

--- a/src/components/managers/hero/components/hero-preview-panel.tsx
+++ b/src/components/managers/hero/components/hero-preview-panel.tsx
@@ -1,8 +1,9 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Control, useWatch } from 'react-hook-form';
-import { useMemo } from 'react';
 import { HeroPreview } from './hero-preview';
 import { mapFormToHeroFull } from './map-form-to-hero-full';
 import { HeroSchema } from './schema';
+import { useProductsByTag } from './useProductsByTag';
 
 interface HeroPreviewPanelProps {
   control: Control<HeroSchema>;
@@ -14,11 +15,34 @@ interface HeroPreviewPanelProps {
   onBlockClick: (index: number) => void;
 }
 
+// Hidden per-tag-block loader: resolves the products for a FEATURED_PRODUCTS_TAG
+// block's tag (the same query the storefront resolves under the hood) and reports
+// them by uid, so the preview can render the block with real product media
+// instead of empty.
+function TagProductsLoader({
+  uid,
+  tag,
+  onProducts,
+}: {
+  uid: string;
+  tag: string;
+  onProducts: (uid: string, products: any[]) => void;
+}) {
+  const { data } = useProductsByTag(tag, true);
+  useEffect(() => {
+    onProducts(uid, data || []);
+  }, [data, uid, onProducts]);
+  return null;
+}
+
 /**
  * Owns the per-keystroke useWatch so only this subtree re-renders on form edits
  * (the canvas stays put; the iframe stays mounted and the push is debounced).
  * Builds the hydrated draft from live form values, dropping soft-deleted blocks
  * so the preview and its block-click indices match what will actually be saved.
+ *
+ * FEATURED_PRODUCTS_TAG blocks have no picked products; their products are fetched
+ * by tag here and merged into the uid-keyed product map the mapper reads.
  */
 export function HeroPreviewPanel({
   control,
@@ -28,15 +52,43 @@ export function HeroPreviewPanel({
   onBlockClick,
 }: HeroPreviewPanelProps) {
   const values = useWatch({ control });
+  const [tagProducts, setTagProducts] = useState<Record<string, any[]>>({});
+
+  const handleTagProducts = useCallback((uid: string, prods: any[]) => {
+    // React Query returns a stable array ref until the data changes, so this
+    // no-ops after the first set and can't loop.
+    setTagProducts((prev) => (prev[uid] === prods ? prev : { ...prev, [uid]: prods }));
+  }, []);
+
+  const tagBlocks = (((values?.entities as any[]) || []) as any[]).filter(
+    (e) =>
+      e?.type === 'HERO_TYPE_FEATURED_PRODUCTS_TAG' &&
+      e?.featuredProductsTag?.tag &&
+      !deletedIndicesRef.current.has(e?._uid),
+  );
+
+  const mergedProducts = useMemo(() => ({ ...products, ...tagProducts }), [products, tagProducts]);
 
   const draft = useMemo(() => {
     const entities = (((values?.entities as any[]) || []) as any[]).filter(
       (e) => !deletedIndicesRef.current.has(e?._uid),
     );
-    return mapFormToHeroFull({ ...(values as HeroSchema), entities }, products);
+    return mapFormToHeroFull({ ...(values as HeroSchema), entities }, mergedProducts);
     // deletedIndicesRef is stable; deletedVersion forces a recompute on soft-delete change
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [values, deletedVersion, products]);
+  }, [values, deletedVersion, mergedProducts]);
 
-  return <HeroPreview hero={draft} onBlockClick={onBlockClick} />;
+  return (
+    <>
+      {tagBlocks.map((e) => (
+        <TagProductsLoader
+          key={e._uid}
+          uid={e._uid}
+          tag={e.featuredProductsTag.tag}
+          onProducts={handleTagProducts}
+        />
+      ))}
+      <HeroPreview hero={draft} onBlockClick={onBlockClick} />
+    </>
+  );
 }

--- a/src/components/managers/hero/components/link-field.tsx
+++ b/src/components/managers/hero/components/link-field.tsx
@@ -20,6 +20,7 @@ import Select from 'ui/components/select';
 import Text from 'ui/components/text';
 import { useArchives } from '../../archives/components/useArchiveQuery';
 import { ProductPickerModal } from './productPickerModal';
+import { TagPicker } from './tag-picker';
 
 // Radix Select forbids an empty-string item value, so use a sentinel for "any".
 const ANY = '__any';
@@ -317,14 +318,11 @@ function CatalogBody({
         />
       </Labeled>
 
-      <Labeled label='tag'>
-        <Input
-          value={link.tag || ''}
-          placeholder='e.g. ss26'
-          className='border px-2 py-1.5'
-          onChange={(e: ChangeEvent<HTMLInputElement>) => set({ tag: e.target.value || undefined })}
-        />
-      </Labeled>
+      <TagPicker
+        value={link.tag || ''}
+        onChange={(v) => set({ tag: v || undefined })}
+        label='tag'
+      />
 
       <Labeled label='season'>
         <Select

--- a/src/components/managers/hero/components/map-form-to-hero-full.ts
+++ b/src/components/managers/hero/components/map-form-to-hero-full.ts
@@ -150,10 +150,14 @@ function mapEntity(
           ...emptyEntity(e.type),
           featuredProductsTag: {
             tag: e.featuredProductsTag?.tag ?? undefined,
-            // products for a tag block are resolved by the backend from the tag;
-            // the form has no resolved list, so the preview renders it empty until
-            // the tag-products cache is wired in (later pass).
-            products: undefined,
+            // Products are resolved by tag (useProductsByTag) and merged into
+            // productsByUid by the preview panel, keyed by this block's uid. The
+            // read model nests them under a HeroFeaturedProducts shape.
+            products: {
+              products: productsByUid[e._uid] || [],
+              exploreLink: e.featuredProductsTag?.exploreLink ?? undefined,
+              translations: (e.featuredProductsTag?.translations || []).map(toCopy),
+            },
             translations: (e.featuredProductsTag?.translations || []).map(toCopy),
           },
         };

--- a/src/components/managers/hero/components/map-form-to-hero-full.ts
+++ b/src/components/managers/hero/components/map-form-to-hero-full.ts
@@ -59,6 +59,8 @@ function toMediaPair(s: any): common_HeroMediaFull {
     portrait: toMediaFull(s?.mediaPortraitId, s?.mediaPortraitUrl),
     landscape: toMediaFull(s?.mediaLandscapeId, s?.mediaLandscapeUrl),
     disableOverlay: s?.disableOverlay ?? false,
+    disableTint: s?.disableTint ?? false,
+    stroke: s?.stroke ?? false,
   };
 }
 

--- a/src/components/managers/hero/components/map-schema-to-hero-data.ts
+++ b/src/components/managers/hero/components/map-schema-to-hero-data.ts
@@ -290,12 +290,23 @@ function readCopy(t: common_HeroCopyTranslation) {
 
 // Read a resolved single/main media pair back into the form's flat id+url fields
 // (thumbnail URL, which is all the form keeps).
+// Read the per-slot presentation modifiers back into the flat form so the
+// toggles show the saved state on edit instead of resetting.
+function readMediaModifiers(m: any) {
+  return {
+    disableOverlay: m?.disableOverlay ?? false,
+    disableTint: m?.disableTint ?? false,
+    stroke: m?.stroke ?? false,
+  };
+}
+
 function readSingle(s?: common_HeroSingleWithTranslations) {
   return {
     mediaLandscapeId: s?.media?.landscape?.id || 0,
     mediaPortraitId: s?.media?.portrait?.id || 0,
     mediaLandscapeUrl: s?.media?.landscape?.media?.thumbnail?.mediaUrl || '',
     mediaPortraitUrl: s?.media?.portrait?.media?.thumbnail?.mediaUrl || '',
+    ...readMediaModifiers(s?.media),
     exploreLink: s?.exploreLink,
     translations: (s?.translations || []).map(readCopy),
   };
@@ -325,6 +336,7 @@ export function mapHeroFullToFormData(
                   mediaPortraitId: e.main?.media?.portrait?.id || 0,
                   mediaLandscapeUrl: e.main?.media?.landscape?.media?.thumbnail?.mediaUrl || '',
                   mediaPortraitUrl: e.main?.media?.portrait?.media?.thumbnail?.mediaUrl || '',
+                  ...readMediaModifiers(e.main?.media),
                   exploreLink: e.main?.exploreLink,
                   translations:
                     e.main?.translations?.map((t) => ({
@@ -423,6 +435,7 @@ export function mapHeroFullToFormData(
                   mediaLandscapeUrl:
                     e.statement?.media?.landscape?.media?.thumbnail?.mediaUrl || '',
                   mediaPortraitUrl: e.statement?.media?.portrait?.media?.thumbnail?.mediaUrl || '',
+                  ...readMediaModifiers(e.statement?.media),
                   exploreLink: e.statement?.exploreLink,
                   translations:
                     e.statement?.translations?.map((t) => ({
@@ -441,6 +454,7 @@ export function mapHeroFullToFormData(
                   mediaLandscapeUrl:
                     e.newsletter?.media?.landscape?.media?.thumbnail?.mediaUrl || '',
                   mediaPortraitUrl: e.newsletter?.media?.portrait?.media?.thumbnail?.mediaUrl || '',
+                  ...readMediaModifiers(e.newsletter?.media),
                   translations:
                     e.newsletter?.translations?.map((t) => ({
                       languageId: t.languageId || 0,
@@ -461,6 +475,7 @@ export function mapHeroFullToFormData(
                   mediaPortraitId: e.embed?.fallback?.portrait?.id || 0,
                   mediaLandscapeUrl: e.embed?.fallback?.landscape?.media?.thumbnail?.mediaUrl || '',
                   mediaPortraitUrl: e.embed?.fallback?.portrait?.media?.thumbnail?.mediaUrl || '',
+                  ...readMediaModifiers(e.embed?.fallback),
                   ctaLink: e.embed?.ctaLink,
                   translations:
                     e.embed?.translations?.map((t) => ({
@@ -478,6 +493,7 @@ export function mapHeroFullToFormData(
                   mediaPortraitId: e.drop?.media?.portrait?.id || 0,
                   mediaLandscapeUrl: e.drop?.media?.landscape?.media?.thumbnail?.mediaUrl || '',
                   mediaPortraitUrl: e.drop?.media?.portrait?.media?.thumbnail?.mediaUrl || '',
+                  ...readMediaModifiers(e.drop?.media),
                   releaseAt: e.drop?.releaseAt || '',
                   tag: e.drop?.tag,
                   exploreLink: e.drop?.exploreLink,
@@ -586,6 +602,7 @@ export function mapHeroFullToFormData(
                     e.productSpotlight?.media?.landscape?.media?.thumbnail?.mediaUrl || '',
                   mediaPortraitUrl:
                     e.productSpotlight?.media?.portrait?.media?.thumbnail?.mediaUrl || '',
+                  ...readMediaModifiers(e.productSpotlight?.media),
                   exploreLink: e.productSpotlight?.exploreLink,
                   translations:
                     e.productSpotlight?.translations?.map((t) => ({

--- a/src/components/managers/hero/components/map-schema-to-hero-data.ts
+++ b/src/components/managers/hero/components/map-schema-to-hero-data.ts
@@ -39,6 +39,8 @@ function toMedia(s: any): common_HeroMedia {
     portraitId: s?.mediaPortraitId || 0,
     landscapeId: s?.mediaLandscapeId || 0,
     disableOverlay: s?.disableOverlay ?? false,
+    disableTint: s?.disableTint ?? false,
+    stroke: s?.stroke ?? false,
   };
 }
 

--- a/src/components/managers/hero/components/media-modifier-toggles.tsx
+++ b/src/components/managers/hero/components/media-modifier-toggles.tsx
@@ -1,0 +1,36 @@
+import { useFormContext, useWatch } from 'react-hook-form';
+import { ToggleSwitch } from 'ui/components/toggle-switch';
+
+interface Props {
+  /** RHF path of the media slot, e.g. `entities.3.statement`, `entities.3.main`. */
+  prefix: string;
+}
+
+/**
+ * Per-slot media presentation toggles bound to the flat form fields the hero
+ * mappers read into HeroMedia: `tint` (on = the storefront's background-colour
+ * tint is shown; writes disableTint = !on) and `stroke` (a border/outline around
+ * the media).
+ */
+export function MediaModifierToggles({ prefix }: Props) {
+  const { control, setValue } = useFormContext();
+  const disableTint = useWatch({ control, name: `${prefix}.disableTint` });
+  const stroke = useWatch({ control, name: `${prefix}.stroke` });
+
+  return (
+    <div className='flex flex-wrap items-center gap-6'>
+      <ToggleSwitch
+        checked={!disableTint}
+        onCheckedChange={(v: boolean) =>
+          setValue(`${prefix}.disableTint`, !v, { shouldDirty: true })
+        }
+        label='tint'
+      />
+      <ToggleSwitch
+        checked={!!stroke}
+        onCheckedChange={(v: boolean) => setValue(`${prefix}.stroke`, v, { shouldDirty: true })}
+        label='stroke'
+      />
+    </div>
+  );
+}

--- a/src/components/managers/hero/components/media-pair-field.tsx
+++ b/src/components/managers/hero/components/media-pair-field.tsx
@@ -11,6 +11,9 @@ interface MediaPairFieldProps {
   portraitUrl: string;
   landscapeRatio?: string[];
   portraitRatio?: string[];
+  /** Slot labels (default "landscape" / "portrait"). */
+  landscapeLabel?: string;
+  portraitLabel?: string;
   /** Append "(optional)" to the slot labels. */
   optional?: boolean;
 }
@@ -27,6 +30,8 @@ export function MediaPairField({
   portraitUrl,
   landscapeRatio = ['2:1'],
   portraitRatio = ['9:16'],
+  landscapeLabel = 'landscape',
+  portraitLabel = 'portrait',
   optional,
 }: MediaPairFieldProps) {
   const { setValue } = useFormContext();
@@ -61,7 +66,8 @@ export function MediaPairField({
       <div className='flex flex-col gap-4 sm:flex-row sm:items-start'>
         <div className='w-full space-y-1 sm:w-auto'>
           <Text variant='label' size='small'>
-            landscape{suffix}
+            {landscapeLabel}
+            {suffix}
           </Text>
           <MediaPreviewWithSelector
             mediaUrl={landscapeUrl}
@@ -78,7 +84,8 @@ export function MediaPairField({
         </div>
         <div className='w-full space-y-1 sm:w-auto'>
           <Text variant='label' size='small'>
-            portrait{suffix}
+            {portraitLabel}
+            {suffix}
           </Text>
           <MediaPreviewWithSelector
             mediaUrl={portraitUrl}

--- a/src/components/managers/hero/components/media-pair-field.tsx
+++ b/src/components/managers/hero/components/media-pair-field.tsx
@@ -2,6 +2,7 @@ import { common_MediaFull } from 'api/proto-http/admin';
 import { useFormContext } from 'react-hook-form';
 import Text from 'ui/components/text';
 import { MediaPreviewWithSelector } from '../../media/components/media-preview-with-selector';
+import { MediaModifierToggles } from './media-modifier-toggles';
 
 interface MediaPairFieldProps {
   /** RHF path prefix for the slot, e.g. `entities.3.statement`. */
@@ -56,41 +57,44 @@ export function MediaPairField({
   const suffix = optional ? ' (optional)' : '';
 
   return (
-    <div className='flex flex-col gap-4 sm:flex-row sm:items-start'>
-      <div className='w-full space-y-1 sm:w-auto'>
-        <Text variant='label' size='small'>
-          landscape{suffix}
-        </Text>
-        <MediaPreviewWithSelector
-          mediaUrl={landscapeUrl}
-          aspectRatio={landscapeRatio}
-          allowMultiple={false}
-          showVideos={true}
-          alt='landscape'
-          label='select'
-          purpose='landscape'
-          heightClass='h-44'
-          onSaveMedia={(media) => save('Landscape', media)}
-          onClear={() => clear('Landscape')}
-        />
+    <div className='space-y-3'>
+      <div className='flex flex-col gap-4 sm:flex-row sm:items-start'>
+        <div className='w-full space-y-1 sm:w-auto'>
+          <Text variant='label' size='small'>
+            landscape{suffix}
+          </Text>
+          <MediaPreviewWithSelector
+            mediaUrl={landscapeUrl}
+            aspectRatio={landscapeRatio}
+            allowMultiple={false}
+            showVideos={true}
+            alt='landscape'
+            label='select'
+            purpose='landscape'
+            heightClass='h-44'
+            onSaveMedia={(media) => save('Landscape', media)}
+            onClear={() => clear('Landscape')}
+          />
+        </div>
+        <div className='w-full space-y-1 sm:w-auto'>
+          <Text variant='label' size='small'>
+            portrait{suffix}
+          </Text>
+          <MediaPreviewWithSelector
+            mediaUrl={portraitUrl}
+            aspectRatio={portraitRatio}
+            allowMultiple={false}
+            showVideos={true}
+            alt='portrait'
+            label='select'
+            purpose='portrait'
+            heightClass='h-44'
+            onSaveMedia={(media) => save('Portrait', media)}
+            onClear={() => clear('Portrait')}
+          />
+        </div>
       </div>
-      <div className='w-full space-y-1 sm:w-auto'>
-        <Text variant='label' size='small'>
-          portrait{suffix}
-        </Text>
-        <MediaPreviewWithSelector
-          mediaUrl={portraitUrl}
-          aspectRatio={portraitRatio}
-          allowMultiple={false}
-          showVideos={true}
-          alt='portrait'
-          label='select'
-          purpose='portrait'
-          heightClass='h-44'
-          onSaveMedia={(media) => save('Portrait', media)}
-          onClear={() => clear('Portrait')}
-        />
-      </div>
+      <MediaModifierToggles prefix={prefix} />
     </div>
   );
 }

--- a/src/components/managers/hero/components/productPickerModal.tsx
+++ b/src/components/managers/hero/components/productPickerModal.tsx
@@ -63,7 +63,8 @@ export const ProductPickerModal: FC<ProductsPickerData> = ({
           sortFactors: ['SORT_FACTOR_CREATED_AT'],
           orderFactor: 'ORDER_FACTOR_DESC',
           filterConditions: undefined,
-          showHidden: true,
+          // Hidden products must not be featurable in the hero.
+          showHidden: false,
         });
         if (Array.isArray(response.products)) {
           setAllProducts((prevProducts) => {

--- a/src/components/managers/hero/components/schema.ts
+++ b/src/components/managers/hero/components/schema.ts
@@ -411,7 +411,7 @@ const heroEntitySchema = z.discriminatedUnion('type', [
           headline: z.string().min(1, 'Headline is required'),
           body: z.string().optional(),
           placeholder: z.string().optional(),
-          ctaText: z.string().min(1, 'Button text is required'),
+          ctaText: z.string().optional(),
           successText: z.string().optional(),
         }),
         requiredLanguageIds,

--- a/src/components/managers/hero/components/schema.ts
+++ b/src/components/managers/hero/components/schema.ts
@@ -67,6 +67,7 @@ const heroSingleItemSchema = (translationShape: z.ZodRawShape) =>
     mediaPortraitId: z.number().optional(),
     mediaLandscapeUrl: z.string().optional(),
     mediaPortraitUrl: z.string().optional(),
+    ...mediaModifierShape,
     exploreLink: z.string().nullable().optional(),
     translations: createStrictTranslationSchema(
       z.object({
@@ -90,6 +91,15 @@ const targetingFields = {
     ])
     .optional(),
   minTierId: z.number().optional(),
+};
+
+// Per-slot media presentation modifiers on HeroMedia (disable_overlay / disable_tint
+// / stroke). Optional booleans, declared here and spread into every media slot so
+// Zod keeps them through parse (unknown keys are stripped otherwise).
+const mediaModifierShape = {
+  disableOverlay: z.boolean().optional(),
+  disableTint: z.boolean().optional(),
+  stroke: z.boolean().optional(),
 };
 
 export const navFeatured = z.object({
@@ -137,6 +147,7 @@ const heroEntitySchema = z.discriminatedUnion('type', [
         }),
       mediaLandscapeUrl: z.string().optional(),
       mediaPortraitUrl: z.string().optional(),
+      ...mediaModifierShape,
       exploreLink: z.string().nullable().optional(),
       translations: createStrictTranslationSchema(
         z.object({
@@ -171,6 +182,7 @@ const heroEntitySchema = z.discriminatedUnion('type', [
         }),
       mediaLandscapeUrl: z.string().optional(),
       mediaPortraitUrl: z.string().optional(),
+      ...mediaModifierShape,
       exploreLink: z.string().nullable().optional(),
       translations: createStrictTranslationSchema(
         z.object({
@@ -205,6 +217,7 @@ const heroEntitySchema = z.discriminatedUnion('type', [
             }),
           mediaLandscapeUrl: z.string().optional(),
           mediaPortraitUrl: z.string().optional(),
+          ...mediaModifierShape,
           exploreLink: z.string().nullable().optional(),
           translations: createStrictTranslationSchema(
             z.object({
@@ -231,6 +244,7 @@ const heroEntitySchema = z.discriminatedUnion('type', [
             }),
           mediaLandscapeUrl: z.string().optional(),
           mediaPortraitUrl: z.string().optional(),
+          ...mediaModifierShape,
           exploreLink: z.string().nullable().optional(),
           translations: createStrictTranslationSchema(
             z.object({
@@ -364,6 +378,7 @@ const heroEntitySchema = z.discriminatedUnion('type', [
       mediaPortraitId: z.number().optional(),
       mediaLandscapeUrl: z.string().optional(),
       mediaPortraitUrl: z.string().optional(),
+      ...mediaModifierShape,
       exploreLink: z.string().nullable().optional(),
       translations: createStrictTranslationSchema(
         z.object({
@@ -389,6 +404,7 @@ const heroEntitySchema = z.discriminatedUnion('type', [
       mediaPortraitId: z.number().optional(),
       mediaLandscapeUrl: z.string().optional(),
       mediaPortraitUrl: z.string().optional(),
+      ...mediaModifierShape,
       translations: createStrictTranslationSchema(
         z.object({
           languageId: z.number().min(1, 'Language is required'),
@@ -414,6 +430,7 @@ const heroEntitySchema = z.discriminatedUnion('type', [
       mediaPortraitId: z.number().optional(),
       mediaLandscapeUrl: z.string().optional(),
       mediaPortraitUrl: z.string().optional(),
+      ...mediaModifierShape,
       ctaLink: z.string().nullable().optional(),
       translations: createStrictTranslationSchema(
         z.object({
@@ -436,6 +453,7 @@ const heroEntitySchema = z.discriminatedUnion('type', [
       mediaPortraitId: z.number().optional(),
       mediaLandscapeUrl: z.string().optional(),
       mediaPortraitUrl: z.string().optional(),
+      ...mediaModifierShape,
       // RFC3339 string; the countdown target.
       releaseAt: z.string().min(1, 'Release date is required'),
       // collection/product tag surfaced after the drop goes live.
@@ -505,6 +523,7 @@ const heroEntitySchema = z.discriminatedUnion('type', [
             mediaPortraitId: z.number().optional(),
             mediaLandscapeUrl: z.string().optional(),
             mediaPortraitUrl: z.string().optional(),
+            ...mediaModifierShape,
             exploreLink: z.string().nullable().optional(),
             translations: createStrictTranslationSchema(
               z.object({
@@ -587,6 +606,7 @@ const heroEntitySchema = z.discriminatedUnion('type', [
       mediaPortraitId: z.number().optional(),
       mediaLandscapeUrl: z.string().optional(),
       mediaPortraitUrl: z.string().optional(),
+      ...mediaModifierShape,
       exploreLink: z.string().nullable().optional(),
       translations: createStrictTranslationSchema(
         z.object({

--- a/src/components/managers/hero/components/schema.ts
+++ b/src/components/managers/hero/components/schema.ts
@@ -225,8 +225,8 @@ const heroEntitySchema = z.discriminatedUnion('type', [
               headline: z.string().max(39, 'Headline must be at most 39 characters').optional(),
               exploreText: z
                 .string()
-                .min(1, 'Explore text is required')
-                .max(39, 'Explore text must be at most 39 characters'),
+                .max(39, 'Explore text must be at most 39 characters')
+                .optional(),
             }),
             requiredLanguageIds,
           ),
@@ -252,8 +252,8 @@ const heroEntitySchema = z.discriminatedUnion('type', [
               headline: z.string().max(39, 'Headline must be at most 39 characters').optional(),
               exploreText: z
                 .string()
-                .min(1, 'Explore text is required')
-                .max(39, 'Explore text must be at most 39 characters'),
+                .max(39, 'Explore text must be at most 39 characters')
+                .optional(),
             }),
             requiredLanguageIds,
           ),

--- a/src/components/managers/hero/components/slide-list-field.tsx
+++ b/src/components/managers/hero/components/slide-list-field.tsx
@@ -1,9 +1,11 @@
 import { LANGUAGES } from 'constants/constants';
+import { cn } from 'lib/utility';
+import { useEffect, useRef, useState } from 'react';
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import { Button } from 'ui/components/button';
 import Text from 'ui/components/text';
-import { LinkField } from './link-field';
 import { UnifiedTranslationFields } from 'ui/form/fields/unified-translation-fields';
+import { LinkField } from './link-field';
 import { MediaPairField } from './media-pair-field';
 
 type FieldConfig = {
@@ -47,9 +49,9 @@ function blankSlide() {
 
 /**
  * A reorderable list of HeroSingle items (media pair + explore link + copy),
- * shared by the slideshow / mosaic / lookbook blocks. Uses a nested field array
- * for add/remove/move and reads live values via useWatch so the media previews
- * update as media is picked.
+ * shared by the slideshow / mosaic / lookbook blocks. Each item is a collapsible
+ * row — a compact summary (thumbnail + primary copy) that expands to the full
+ * editor — so a long list stays scannable instead of a giant stacked scroll.
  */
 export function SlideListField({
   name,
@@ -61,9 +63,34 @@ export function SlideListField({
   const { control } = useFormContext();
   const { fields, append, remove, move } = useFieldArray({ control, name });
   const watched: any[] = useWatch({ control, name }) || [];
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const prevLen = useRef(fields.length);
+
+  // Auto-expand a newly added item (not existing ones on mount).
+  useEffect(() => {
+    if (fields.length > prevLen.current) {
+      const newId = fields[fields.length - 1]?.id;
+      if (newId) setExpanded((prev) => new Set(prev).add(newId));
+    }
+    prevLen.current = fields.length;
+  }, [fields]);
+
+  const toggle = (id: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+
+  const primaryKey = translationFields[0]?.name;
+  const summaryOf = (slide: any): string => {
+    const list = slide?.translations || [];
+    const t = list.find((x: any) => x?.languageId === 1) || list[0];
+    return primaryKey ? (t?.[primaryKey] || '').trim() : '';
+  };
 
   return (
-    <div className='space-y-4'>
+    <div className='space-y-3'>
       {fields.length === 0 && (
         <Text variant='label' size='small'>
           no {itemLabel}s yet — add one below.
@@ -72,50 +99,90 @@ export function SlideListField({
 
       {fields.map((field, i) => {
         const slide = watched[i] || {};
+        const isOpen = expanded.has(field.id);
+        const thumb = slide.mediaLandscapeUrl || slide.mediaPortraitUrl || '';
+        const summary = summaryOf(slide);
+
         return (
-          <div key={field.id} className='space-y-3 border border-textInactiveColor p-3'>
-            <div className='flex items-center justify-between'>
-              <Text variant='uppercase' size='small'>
-                {itemLabel} {i + 1}
-              </Text>
-              <div className='flex items-center gap-3'>
-                <Button
+          <div key={field.id} className='border border-textInactiveColor'>
+            <div className='flex items-center gap-1 p-2'>
+              <button
+                type='button'
+                onClick={() => toggle(field.id)}
+                aria-expanded={isOpen}
+                className='flex min-w-0 flex-1 items-center gap-2 text-left cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-textColor'
+              >
+                {thumb ? (
+                  <img
+                    src={thumb}
+                    alt=''
+                    className='h-9 w-9 shrink-0 border border-textInactiveColor object-cover'
+                  />
+                ) : (
+                  <div className='h-9 w-9 shrink-0 border border-dashed border-textInactiveColor' />
+                )}
+                <span className='flex min-w-0 flex-1 flex-col'>
+                  <Text variant='label' size='small'>
+                    {itemLabel} {i + 1}
+                  </Text>
+                  {summary && (
+                    <Text size='small' className='truncate'>
+                      {summary}
+                    </Text>
+                  )}
+                </span>
+                <span className='shrink-0 text-labelColor'>{isOpen ? '▴' : '▾'}</span>
+              </button>
+
+              <div className='flex shrink-0 items-center'>
+                <button
                   type='button'
-                  variant='underline'
                   disabled={i === 0}
                   onClick={() => move(i, i - 1)}
+                  aria-label={`move ${itemLabel} up`}
+                  className='px-1.5 py-1 leading-none cursor-pointer text-textInactiveColor hover:text-textColor disabled:opacity-40 disabled:cursor-not-allowed focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-textColor'
                 >
-                  up
-                </Button>
-                <Button
+                  ↑
+                </button>
+                <button
                   type='button'
-                  variant='underline'
                   disabled={i === fields.length - 1}
                   onClick={() => move(i, i + 1)}
+                  aria-label={`move ${itemLabel} down`}
+                  className='px-1.5 py-1 leading-none cursor-pointer text-textInactiveColor hover:text-textColor disabled:opacity-40 disabled:cursor-not-allowed focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-textColor'
                 >
-                  down
-                </Button>
-                <Button type='button' variant='underline' onClick={() => remove(i)}>
-                  remove
-                </Button>
+                  ↓
+                </button>
+                <button
+                  type='button'
+                  onClick={() => remove(i)}
+                  aria-label={`remove ${itemLabel}`}
+                  className='px-1.5 py-1 leading-none cursor-pointer text-textInactiveColor hover:text-textColor focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-textColor'
+                >
+                  ×
+                </button>
               </div>
             </div>
 
-            <MediaPairField
-              prefix={`${name}.${i}`}
-              landscapeUrl={slide.mediaLandscapeUrl || ''}
-              portraitUrl={slide.mediaPortraitUrl || ''}
-              landscapeRatio={landscapeRatio}
-              portraitRatio={portraitRatio}
-            />
+            {isOpen && (
+              <div className='space-y-3 border-t border-textInactiveColor p-3'>
+                <MediaPairField
+                  prefix={`${name}.${i}`}
+                  landscapeUrl={slide.mediaLandscapeUrl || ''}
+                  portraitUrl={slide.mediaPortraitUrl || ''}
+                  landscapeRatio={landscapeRatio}
+                  portraitRatio={portraitRatio}
+                />
 
-            <LinkField name={`${name}.${i}.exploreLink`} label='explore link (optional)' />
+                <LinkField name={`${name}.${i}.exploreLink`} label='explore link (optional)' />
 
-            <UnifiedTranslationFields
-              fieldPrefix={`${name}.${i}.translations`}
-              fields={translationFields}
-              editMode
-            />
+                <UnifiedTranslationFields
+                  fieldPrefix={`${name}.${i}.translations`}
+                  fields={translationFields}
+                  editMode
+                />
+              </div>
+            )}
           </div>
         );
       })}

--- a/src/components/managers/hero/components/tag-picker.tsx
+++ b/src/components/managers/hero/components/tag-picker.tsx
@@ -1,0 +1,51 @@
+import { useDictionary } from 'lib/providers/dictionary-provider';
+import { ChangeEvent, useId } from 'react';
+import Input from 'ui/components/input';
+import Text from 'ui/components/text';
+
+interface TagPickerProps {
+  value: string;
+  onChange: (value: string) => void;
+  label?: string;
+  placeholder?: string;
+}
+
+/**
+ * Reusable product-tag picker: a text field with autocomplete suggestions from
+ * the dictionary's `productTags`, so the admin selects an existing tag instead
+ * of typing it blind — while still allowing a custom tag (a drop may reference a
+ * tag before products carry it). Controlled (value + onChange) so it works both
+ * as an RHF-bound field and inside the link builder's local catalog state.
+ */
+export function TagPicker({
+  value,
+  onChange,
+  label = 'tag',
+  placeholder = 'select or type a tag',
+}: TagPickerProps) {
+  const { dictionary } = useDictionary();
+  const productTags = dictionary?.productTags || [];
+  const listId = useId();
+
+  return (
+    <div className='space-y-1'>
+      {label && (
+        <Text component='label' size='small' variant='label'>
+          {label}
+        </Text>
+      )}
+      <Input
+        value={value}
+        list={listId}
+        placeholder={placeholder}
+        className='border px-2 py-1.5'
+        onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
+      />
+      <datalist id={listId}>
+        {productTags.map((t) => (
+          <option key={t} value={t} />
+        ))}
+      </datalist>
+    </div>
+  );
+}

--- a/src/components/managers/hero/components/tag-picker.tsx
+++ b/src/components/managers/hero/components/tag-picker.tsx
@@ -1,7 +1,9 @@
 import { useDictionary } from 'lib/providers/dictionary-provider';
-import { ChangeEvent, useId } from 'react';
+import { cn } from 'lib/utility';
+import { ChangeEvent, KeyboardEvent, useEffect, useRef, useState } from 'react';
 import Input from 'ui/components/input';
 import Text from 'ui/components/text';
+import { HeroSectionModal } from './hero-section-modal';
 
 interface TagPickerProps {
   value: string;
@@ -11,21 +13,39 @@ interface TagPickerProps {
 }
 
 /**
- * Reusable product-tag picker: a text field with autocomplete suggestions from
- * the dictionary's `productTags`, so the admin selects an existing tag instead
- * of typing it blind — while still allowing a custom tag (a drop may reference a
- * tag before products carry it). Controlled (value + onChange) so it works both
- * as an RHF-bound field and inside the link builder's local catalog state.
+ * Reusable product-tag picker. A trigger shows the current tag and opens a modal
+ * with a search box, the full list of the dictionary's `productTags` as clickable
+ * chips, and a "use custom tag" action for a value that isn't in the list (a drop
+ * may reference a tag before products carry it). Controlled (value + onChange) so
+ * it works both as an RHF-bound field and inside the link builder's local state.
  */
 export function TagPicker({
   value,
   onChange,
   label = 'tag',
-  placeholder = 'select or type a tag',
+  placeholder = 'select a tag',
 }: TagPickerProps) {
   const { dictionary } = useDictionary();
   const productTags = dictionary?.productTags || [];
-  const listId = useId();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const t = setTimeout(() => searchRef.current?.focus(), 50);
+    return () => clearTimeout(t);
+  }, [open]);
+
+  const q = query.trim().toLowerCase();
+  const filtered = productTags.filter((t) => t.toLowerCase().includes(q));
+  const isExisting = productTags.some((t) => t.toLowerCase() === q);
+
+  const pick = (tag: string) => {
+    onChange(tag);
+    setOpen(false);
+    setQuery('');
+  };
 
   return (
     <div className='space-y-1'>
@@ -34,18 +54,100 @@ export function TagPicker({
           {label}
         </Text>
       )}
-      <Input
-        value={value}
-        list={listId}
-        placeholder={placeholder}
-        className='border px-2 py-1.5'
-        onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
-      />
-      <datalist id={listId}>
-        {productTags.map((t) => (
-          <option key={t} value={t} />
-        ))}
-      </datalist>
+
+      <div className='flex items-center gap-2'>
+        <button
+          type='button'
+          onClick={() => setOpen(true)}
+          className='flex flex-1 items-center justify-between border border-textColor px-2 py-1.5 text-left cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-textColor'
+        >
+          <Text size='small' variant={value ? 'default' : 'label'} className='truncate'>
+            {value || placeholder}
+          </Text>
+          <span className='text-labelColor'>▾</span>
+        </button>
+        {value && (
+          <button
+            type='button'
+            onClick={() => onChange('')}
+            aria-label='clear tag'
+            className='border border-textInactiveColor px-2 py-1.5 leading-none cursor-pointer text-textInactiveColor hover:text-textColor focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-textColor'
+          >
+            ×
+          </button>
+        )}
+      </div>
+
+      <HeroSectionModal
+        open={open}
+        onOpenChange={(o) => {
+          setOpen(o);
+          if (!o) setQuery('');
+        }}
+        title='select tag'
+      >
+        <div className='space-y-4'>
+          <Input
+            ref={searchRef}
+            value={query}
+            placeholder='search tags, or type a new one…'
+            aria-label='search tags'
+            className='border px-2 py-1.5'
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setQuery(e.target.value)}
+            onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
+              if (e.key === 'Enter' && query.trim()) {
+                e.preventDefault();
+                pick(query.trim());
+              }
+            }}
+          />
+
+          {q && !isExisting && (
+            <button
+              type='button'
+              onClick={() => pick(query.trim())}
+              className='w-full border border-textColor px-2 py-2 text-left cursor-pointer hover:bg-textColor hover:text-bgColor focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-textColor'
+            >
+              <Text size='small'>use “{query.trim()}” as a custom tag</Text>
+            </button>
+          )}
+
+          {filtered.length === 0 && !q ? (
+            <Text variant='label' size='small'>
+              no product tags in the dictionary yet — type one above.
+            </Text>
+          ) : filtered.length === 0 ? (
+            <Text variant='label' size='small'>
+              no tags match “{query.trim()}”.
+            </Text>
+          ) : (
+            <div className='flex flex-wrap gap-2'>
+              {filtered.map((t) => {
+                const selected = value === t;
+                return (
+                  <button
+                    key={t}
+                    type='button'
+                    onClick={() => pick(t)}
+                    aria-pressed={selected}
+                    className={cn(
+                      'border px-2 py-1 cursor-pointer',
+                      'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-textColor',
+                      selected
+                        ? 'border-textColor bg-textColor text-bgColor'
+                        : 'border-textInactiveColor hover:border-textColor',
+                    )}
+                  >
+                    <Text size='small' className={selected ? '!text-bgColor' : ''}>
+                      {t}
+                    </Text>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </HeroSectionModal>
     </div>
   );
 }


### PR DESCRIPTION
A batch of hero-editor changes on top of the link-picker release, plus the proto bump they need.

## Proto
- Regenerate the TS client from grbpwr-proto `7dfb2f5` — adds `dictionary.productTags`, `HeroMedia.disable_tint`/`stroke`, and the reworked archive contract.

## Tint / stroke
- Per-slot media presentation toggles (`tint` inverts `disable_tint`; `stroke`) on every media slot (MediaPairField + CommonEntity), wired through schema (shared `mediaModifierShape`), the write/preview mappers, and read-back so they round-trip.

## Tag picker
- Reusable **TagPicker** (modal: searchable list of `productTags` as chips + custom entry + clear) used at every tag field — featured-products-tag, the catalog `tag` filter, and the drop collection tag.

## Blocks
- **FEATURED PRODUCTS TAG** now renders in the preview: its products are fetched by tag (hidden per-block `useProductsByTag` loader) and mapped into the read model's nested `HeroFeaturedProducts` shape.
- **DOUBLE**: purpose-built editor (LEFT/RIGHT cards side-by-side, clear "square image" labels) replacing the confusing CommonEntity reuse; explore text is now optional.
- **LOOKBOOK / SLIDESHOW / MOSAIC**: each frame is a collapsible row (thumbnail + summary → expand to edit) instead of a giant stacked scroll.
- **SPLIT**: media is 1:2 on desktop and mobile, slots labelled desktop / mobile.
- **NEWSLETTER**: drop the email-placeholder / button-text / success-message fields (storefront uses defaults).
- Product picker no longer offers hidden products.

## Verification
`npx tsc --noEmit` at the pre-existing baseline (26 errors, 0 in hero); `yarn build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8ATXa7zmUrwv3Hs5pMdnn
