### PR TITLE
Release: admin accounts RBAC

### DIFF
--- a/src/api/proto-http/admin/index.ts
+++ b/src/api/proto-http/admin/index.ts
@@ -56,6 +56,15 @@ export type MetricsSection =
   | "METRICS_SECTION_GEOGRAPHY"
   | "METRICS_SECTION_CUSTOMER_SEGMENTATION"
   | "METRICS_SECTION_RFM";
+// RefundReason is the canonical, structured refund/return reason used by the return-analysis
+// breakdown. Keys mirror the historical free-text buckets.
+export type RefundReason =
+  | "REFUND_REASON_UNSPECIFIED"
+  | "REFUND_REASON_WRONG_SIZE"
+  | "REFUND_REASON_NOT_AS_DESCRIBED"
+  | "REFUND_REASON_DEFECTIVE"
+  | "REFUND_REASON_CHANGED_MIND"
+  | "REFUND_REASON_OTHER";
 // TrendGranularity defines time bucket size for trend analysis
 export type TrendGranularity =
   | "TREND_GRANULARITY_DAILY"
@@ -66,6 +75,11 @@ export type TierCode =
   | "TIER_CODE_PLUS"
   | "TIER_CODE_PLUS_PLUS"
   | "TIER_CODE_HACKER";
+// AccessLevel is the level of access an account has to a section. WRITE implies READ.
+export type AccessLevel =
+  | "ACCESS_LEVEL_UNSPECIFIED"
+  | "ACCESS_LEVEL_READ"
+  | "ACCESS_LEVEL_WRITE";
 export type GetDictionaryRequest = {
 };
 
@@ -1444,6 +1458,13 @@ export type InventoryHealthRow = {
   quantity: number | undefined;
   avgDailySales: number | undefined;
   daysOnHand: number | undefined;
+  // Optional per-SKU targets (0 = unset) and the server-side reorder decision derived
+  // from them. needs_reorder is meaningful only when has_target is true.
+  reorderPoint: number | undefined;
+  targetDaysCover: number | undefined;
+  leadTimeDays: number | undefined;
+  needsReorder: boolean | undefined;
+  hasTarget: boolean | undefined;
 };
 
 export type SizeRunEfficiencyRow = {
@@ -1552,6 +1573,10 @@ export type CampaignAttributionRow = {
   conversions: number | undefined;
   revenue: googletype_Decimal | undefined;
   conversionRate: number | undefined;
+  // Marketing spend (base currency, from channel_spend) and ROAS = revenue / spend. spend is
+  // zero when none is recorded for the channel; roas is 0 unless spend > 0.
+  spend: googletype_Decimal | undefined;
+  roas: number | undefined;
 };
 
 // AddToCartRateAnalysis contains both per-product aggregate data for scatter plot
@@ -1683,12 +1708,15 @@ export type RefundOrderRequest = {
   orderUuid: string | undefined;
   // Only used when status is PendingReturn. Empty = full refund. Non-empty = partial refund for specified order_item IDs.
   orderItemIds: number[] | undefined;
-  // Optional reason for the refund (stored in order for audit).
+  // Optional free-text note for the refund (stored in order for audit).
   reason: string | undefined;
   // Whether to include shipping fee in the refund amount.
   // For full refund of not-yet-shipped orders this is automatically true.
   // For partial refunds, the caller decides whether to refund shipping.
   refundShipping: boolean | undefined;
+  // Optional structured reason. When set, it drives the return-analysis breakdown exactly
+  // (the free-text reason is only bucketed heuristically). Additive to reason (field 3).
+  reasonCode: RefundReason | undefined;
 };
 
 export type RefundOrderResponse = {
@@ -2571,6 +2599,41 @@ export type UpdateSupportTicketRequest = {
 export type UpdateSupportTicketResponse = {
 };
 
+// InventoryTargetInsert is an admin-supplied per-SKU reorder target. Each threshold is
+// optional — 0 means "no trigger on that dimension" (stored as NULL).
+export type InventoryTargetInsert = {
+  productId: number | undefined;
+  sizeId: number | undefined;
+  reorderPoint: number | undefined;
+  targetDaysCover: number | undefined;
+  leadTimeDays: number | undefined;
+};
+
+export type UpsertInventoryTargetsRequest = {
+  targets: InventoryTargetInsert[] | undefined;
+};
+
+export type UpsertInventoryTargetsResponse = {
+};
+
+// ChannelSpendInsert is one operator-entered marketing spend row for a channel on a day.
+// Enter spend in base currency for it to feed ROAS (the shop has no live FX).
+export type ChannelSpendInsert = {
+  date: string | undefined;
+  utmSource: string | undefined;
+  utmMedium: string | undefined;
+  utmCampaign: string | undefined;
+  amount: googletype_Decimal | undefined;
+  currency: string | undefined;
+};
+
+export type UpsertChannelSpendRequest = {
+  spend: ChannelSpendInsert[] | undefined;
+};
+
+export type UpsertChannelSpendResponse = {
+};
+
 export type GetOrderReviewsPagedRequest = {
   limit: number | undefined;
   offset: number | undefined;
@@ -3334,6 +3397,97 @@ export type common_TechCardListItem = {
   lockVersion: number | undefined;
 };
 
+// AdminPermission grants an account a level of access to one section.
+export type AdminPermission = {
+  // section is a section key from ListAccountSections (e.g. "orders").
+  section: string | undefined;
+  access: AccessLevel | undefined;
+};
+
+// AdminAccount is an admin account with its permission set. is_super grants full
+// access, in which case permissions is empty.
+export type AdminAccount = {
+  username: string | undefined;
+  isSuper: boolean | undefined;
+  disabled: boolean | undefined;
+  permissions: AdminPermission[] | undefined;
+  createdAt: wellKnownTimestamp | undefined;
+  updatedAt: wellKnownTimestamp | undefined;
+};
+
+// AdminSectionInfo describes a grantable section for the permission picker.
+export type AdminSectionInfo = {
+  key: string | undefined;
+  title: string | undefined;
+  description: string | undefined;
+};
+
+export type GetCurrentAccountRequest = {
+};
+
+export type GetCurrentAccountResponse = {
+  account: AdminAccount | undefined;
+};
+
+export type ListAccountSectionsRequest = {
+};
+
+export type ListAccountSectionsResponse = {
+  sections: AdminSectionInfo[] | undefined;
+};
+
+export type ListAccountsRequest = {
+};
+
+export type ListAccountsResponse = {
+  accounts: AdminAccount[] | undefined;
+};
+
+export type CreateAccountRequest = {
+  username: string | undefined;
+  password: string | undefined;
+  // is_super grants full access; when true, permissions is ignored.
+  isSuper: boolean | undefined;
+  permissions: AdminPermission[] | undefined;
+};
+
+export type CreateAccountResponse = {
+  account: AdminAccount | undefined;
+};
+
+export type UpdateAccountPermissionsRequest = {
+  username: string | undefined;
+  isSuper: boolean | undefined;
+  permissions: AdminPermission[] | undefined;
+};
+
+export type UpdateAccountPermissionsResponse = {
+  account: AdminAccount | undefined;
+};
+
+export type SetAccountDisabledRequest = {
+  username: string | undefined;
+  disabled: boolean | undefined;
+};
+
+export type SetAccountDisabledResponse = {
+};
+
+export type ResetAccountPasswordRequest = {
+  username: string | undefined;
+  newPassword: string | undefined;
+};
+
+export type ResetAccountPasswordResponse = {
+};
+
+export type DeleteAccountRequest = {
+  username: string | undefined;
+};
+
+export type DeleteAccountResponse = {
+};
+
 export interface AdminService {
   // Retrieves a key-value dictionary.
   GetDictionary(request: GetDictionaryRequest): Promise<GetDictionaryResponse>;
@@ -3388,6 +3542,10 @@ export interface AdminService {
   // order_sequence, entry_products, revenue_pareto, spending_curve, category_loyalty,
   // inventory_health, size_run_efficiency.
   GetMetrics(request: GetMetricsRequest): Promise<GetMetricsResponse>;
+  // Sets per-SKU inventory reorder targets used by the inventory-health metrics.
+  UpsertInventoryTargets(request: UpsertInventoryTargetsRequest): Promise<UpsertInventoryTargetsResponse>;
+  // Records operator-entered marketing spend per channel per day, used for ROAS.
+  UpsertChannelSpend(request: UpsertChannelSpendRequest): Promise<UpsertChannelSpendResponse>;
   // Cancels an order
   CancelOrder(request: CancelOrderRequest): Promise<CancelOrderResponse>;
   // Adds a comment to an order
@@ -3487,6 +3645,31 @@ export interface AdminService {
   GetTierAuditLog(request: GetTierAuditLogRequest): Promise<GetTierAuditLogResponse>;
   // One-time legacy backfill (admin-triggered).
   RunTierBackfill(request: RunTierBackfillRequest): Promise<RunTierBackfillResponse>;
+  // GetCurrentAccount returns the calling account's identity and effective
+  // permissions (what its token authorizes). Any authenticated admin may call it;
+  // the admin panel uses it to decide which sections to show.
+  GetCurrentAccount(request: GetCurrentAccountRequest): Promise<GetCurrentAccountResponse>;
+  // ListAccountSections returns the catalog of grantable admin-panel sections
+  // (for the permission picker). Any authenticated admin may call it.
+  ListAccountSections(request: ListAccountSectionsRequest): Promise<ListAccountSectionsResponse>;
+  // ListAccounts lists every admin account with its permissions. Requires the
+  // accounts section (read).
+  ListAccounts(request: ListAccountsRequest): Promise<ListAccountsResponse>;
+  // CreateAccount creates a scoped (or super) admin account. Requires the accounts
+  // section (write).
+  CreateAccount(request: CreateAccountRequest): Promise<CreateAccountResponse>;
+  // UpdateAccountPermissions replaces an account's super flag and permission set.
+  // Requires the accounts section (write).
+  UpdateAccountPermissions(request: UpdateAccountPermissionsRequest): Promise<UpdateAccountPermissionsResponse>;
+  // SetAccountDisabled enables or disables an account (a disabled account cannot
+  // obtain new tokens at login). Requires the accounts section (write).
+  SetAccountDisabled(request: SetAccountDisabledRequest): Promise<SetAccountDisabledResponse>;
+  // ResetAccountPassword sets a new password for an account. Requires the accounts
+  // section (write).
+  ResetAccountPassword(request: ResetAccountPasswordRequest): Promise<ResetAccountPasswordResponse>;
+  // DeleteAccount removes an admin account (and its permissions). Requires the
+  // accounts section (write).
+  DeleteAccount(request: DeleteAccountRequest): Promise<DeleteAccountResponse>;
 }
 
 type RequestType = {
@@ -4085,6 +4268,40 @@ export function createAdminServiceClient(
         service: "AdminService",
         method: "GetMetrics",
       }) as Promise<GetMetricsResponse>;
+    },
+    UpsertInventoryTargets(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/metrics/inventory/targets/upsert`; // eslint-disable-line quotes
+      const body = JSON.stringify(request);
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "POST",
+        body,
+      }, {
+        service: "AdminService",
+        method: "UpsertInventoryTargets",
+      }) as Promise<UpsertInventoryTargetsResponse>;
+    },
+    UpsertChannelSpend(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/metrics/channel-spend/upsert`; // eslint-disable-line quotes
+      const body = JSON.stringify(request);
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "POST",
+        body,
+      }, {
+        service: "AdminService",
+        method: "UpsertChannelSpend",
+      }) as Promise<UpsertChannelSpendResponse>;
     },
     CancelOrder(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
       if (!request.orderUuid) {
@@ -5246,6 +5463,154 @@ export function createAdminServiceClient(
         service: "AdminService",
         method: "RunTierBackfill",
       }) as Promise<RunTierBackfillResponse>;
+    },
+    GetCurrentAccount(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/accounts/me`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "GET",
+        body,
+      }, {
+        service: "AdminService",
+        method: "GetCurrentAccount",
+      }) as Promise<GetCurrentAccountResponse>;
+    },
+    ListAccountSections(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/accounts/sections`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "GET",
+        body,
+      }, {
+        service: "AdminService",
+        method: "ListAccountSections",
+      }) as Promise<ListAccountSectionsResponse>;
+    },
+    ListAccounts(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/accounts`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "GET",
+        body,
+      }, {
+        service: "AdminService",
+        method: "ListAccounts",
+      }) as Promise<ListAccountsResponse>;
+    },
+    CreateAccount(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/accounts`; // eslint-disable-line quotes
+      const body = JSON.stringify(request);
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "POST",
+        body,
+      }, {
+        service: "AdminService",
+        method: "CreateAccount",
+      }) as Promise<CreateAccountResponse>;
+    },
+    UpdateAccountPermissions(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      if (!request.username) {
+        throw new Error("missing required field request.username");
+      }
+      const path = `api/admin/accounts/${request.username}/permissions`; // eslint-disable-line quotes
+      const body = JSON.stringify(request);
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "PUT",
+        body,
+      }, {
+        service: "AdminService",
+        method: "UpdateAccountPermissions",
+      }) as Promise<UpdateAccountPermissionsResponse>;
+    },
+    SetAccountDisabled(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      if (!request.username) {
+        throw new Error("missing required field request.username");
+      }
+      const path = `api/admin/accounts/${request.username}/disabled`; // eslint-disable-line quotes
+      const body = JSON.stringify(request);
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "PUT",
+        body,
+      }, {
+        service: "AdminService",
+        method: "SetAccountDisabled",
+      }) as Promise<SetAccountDisabledResponse>;
+    },
+    ResetAccountPassword(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      if (!request.username) {
+        throw new Error("missing required field request.username");
+      }
+      const path = `api/admin/accounts/${request.username}/password`; // eslint-disable-line quotes
+      const body = JSON.stringify(request);
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "PUT",
+        body,
+      }, {
+        service: "AdminService",
+        method: "ResetAccountPassword",
+      }) as Promise<ResetAccountPasswordResponse>;
+    },
+    DeleteAccount(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      if (!request.username) {
+        throw new Error("missing required field request.username");
+      }
+      const path = `api/admin/accounts/${request.username}`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "DELETE",
+        body,
+      }, {
+        service: "AdminService",
+        method: "DeleteAccount",
+      }) as Promise<DeleteAccountResponse>;
     },
   };
 }

--- a/src/components/managers/accounts/components/account-form-modal.tsx
+++ b/src/components/managers/accounts/components/account-form-modal.tsx
@@ -1,0 +1,169 @@
+import * as DialogPrimitives from '@radix-ui/react-dialog';
+import { AdminAccount, AdminPermission, AdminSectionInfo } from 'api/proto-http/admin';
+import { useEffect, useState } from 'react';
+import { Button } from 'ui/components/button';
+import Input from 'ui/components/input';
+import Text from 'ui/components/text';
+import { ToggleSwitch } from 'ui/components/toggle-switch';
+import { useCreateAccount, useUpdateAccountPermissions } from '../utils/hooks';
+import { PermissionPicker } from './permission-picker';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: 'create' | 'edit';
+  account?: AdminAccount | null;
+  sections: AdminSectionInfo[];
+  sectionsLoading?: boolean;
+}
+
+export function AccountFormModal({
+  open,
+  onOpenChange,
+  mode,
+  account,
+  sections,
+  sectionsLoading,
+}: Props) {
+  const create = useCreateAccount();
+  const update = useUpdateAccountPermissions();
+
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [isSuper, setIsSuper] = useState(false);
+  const [permissions, setPermissions] = useState<AdminPermission[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset the form each time the modal opens or the target account changes.
+  useEffect(() => {
+    if (!open) return;
+    setError(null);
+    setPassword('');
+    if (mode === 'edit' && account) {
+      setUsername(account.username ?? '');
+      setIsSuper(account.isSuper ?? false);
+      setPermissions((account.permissions ?? []).filter((p): p is AdminPermission => !!p.section));
+    } else {
+      setUsername('');
+      setIsSuper(false);
+      setPermissions([]);
+    }
+  }, [open, mode, account]);
+
+  const isEdit = mode === 'edit';
+  const pending = create.isPending || update.isPending;
+
+  const handleSubmit = () => {
+    setError(null);
+    if (!isEdit) {
+      if (!username.trim()) return setError('Username is required');
+      if (!password.trim()) return setError('Password is required');
+    }
+    if (!isSuper && permissions.length === 0) {
+      return setError('Grant at least one section, or make the account super');
+    }
+
+    const done = { onSuccess: () => onOpenChange(false) };
+    if (isEdit) {
+      update.mutate({ username, isSuper, permissions }, done);
+    } else {
+      create.mutate({ username: username.trim(), password, isSuper, permissions }, done);
+    }
+  };
+
+  return (
+    <DialogPrimitives.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitives.Portal>
+        <DialogPrimitives.Overlay className='fixed inset-0 z-20 h-screen bg-overlay' />
+        <DialogPrimitives.Content className='fixed inset-x-2.5 top-1/2 z-50 flex max-h-[90vh] w-auto -translate-y-1/2 flex-col overflow-y-auto border border-textInactiveColor bg-bgColor p-3 text-textColor lg:inset-x-auto lg:left-1/2 lg:w-[560px] lg:-translate-x-1/2'>
+          <div className='mb-3 flex items-center justify-between gap-2 border-b border-textColor pb-2'>
+            <DialogPrimitives.Title className='text-lg uppercase'>
+              {isEdit ? `edit — ${username}` : 'new account'}
+            </DialogPrimitives.Title>
+            <DialogPrimitives.Close asChild>
+              <Button type='button' className='cursor-pointer'>
+                [x]
+              </Button>
+            </DialogPrimitives.Close>
+          </div>
+          <DialogPrimitives.Description className='sr-only'>
+            {isEdit ? 'Edit admin account permissions' : 'Create a new admin account'}
+          </DialogPrimitives.Description>
+
+          <div className='flex flex-col gap-4'>
+            {!isEdit && (
+              <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
+                <div className='flex flex-col gap-1'>
+                  <Text variant='inactive' size='small'>
+                    username
+                  </Text>
+                  <Input
+                    name='newUsername'
+                    value={username}
+                    autoComplete='off'
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                      setUsername(e.target.value)
+                    }
+                  />
+                </div>
+                <div className='flex flex-col gap-1'>
+                  <Text variant='inactive' size='small'>
+                    password
+                  </Text>
+                  <Input
+                    name='newPassword'
+                    type='text'
+                    value={password}
+                    autoComplete='new-password'
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                      setPassword(e.target.value)
+                    }
+                  />
+                </div>
+              </div>
+            )}
+
+            <div className='border border-textColor p-3'>
+              <ToggleSwitch
+                checked={isSuper}
+                label='super admin — full access to every section'
+                onCheckedChange={setIsSuper}
+              />
+            </div>
+
+            {!isSuper && (
+              <PermissionPicker
+                sections={sections}
+                value={permissions}
+                onChange={setPermissions}
+                loading={sectionsLoading}
+              />
+            )}
+
+            {error && (
+              <Text variant='error' size='small'>
+                {error}
+              </Text>
+            )}
+          </div>
+
+          <div className='mt-4 flex justify-end gap-2'>
+            <Button type='button' onClick={() => onOpenChange(false)} variant='secondary' size='lg'>
+              cancel
+            </Button>
+            <Button
+              type='button'
+              onClick={handleSubmit}
+              variant='main'
+              size='lg'
+              loading={pending}
+              disabled={pending}
+            >
+              {isEdit ? 'save' : 'create'}
+            </Button>
+          </div>
+        </DialogPrimitives.Content>
+      </DialogPrimitives.Portal>
+    </DialogPrimitives.Root>
+  );
+}

--- a/src/components/managers/accounts/components/accounts-table.tsx
+++ b/src/components/managers/accounts/components/accounts-table.tsx
@@ -1,0 +1,177 @@
+import { AdminAccount } from 'api/proto-http/admin';
+import { useState } from 'react';
+import { Button } from 'ui/components/button';
+import { ConfirmationModal } from 'ui/components/confirmation-modal';
+import Text from 'ui/components/text';
+import { formatDateShort } from '../../orders-catalog/components/utility';
+import { ACCESS, useDeleteAccount, useSetAccountDisabled } from '../utils/hooks';
+
+const ACCESS_ABBR: Record<string, string> = {
+  [ACCESS.READ]: 'r',
+  [ACCESS.WRITE]: 'w',
+};
+
+function AccessSummary({ account }: { account: AdminAccount }) {
+  if (account.isSuper) {
+    return (
+      <span className='border border-textColor px-1.5 py-0.5'>
+        <Text variant='uppercase' size='small'>
+          super
+        </Text>
+      </span>
+    );
+  }
+  const perms = (account.permissions ?? []).filter((p) => p.section);
+  if (perms.length === 0) {
+    return (
+      <Text variant='inactive' size='small'>
+        no access
+      </Text>
+    );
+  }
+  return (
+    <div className='flex flex-wrap justify-center gap-1'>
+      {perms.map((p) => (
+        <span key={p.section} className='border border-textColor px-1 py-0.5 whitespace-nowrap'>
+          <Text size='small'>
+            {p.section}
+            <span className='text-textInactiveColor'>·{ACCESS_ABBR[p.access ?? ''] ?? '?'}</span>
+          </Text>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+interface Props {
+  accounts: AdminAccount[];
+  isLoading: boolean;
+  currentUsername?: string;
+  canWrite: boolean;
+  onEdit: (account: AdminAccount) => void;
+  onResetPassword: (account: AdminAccount) => void;
+}
+
+export function AccountsTable({
+  accounts,
+  isLoading,
+  currentUsername,
+  canWrite,
+  onEdit,
+  onResetPassword,
+}: Props) {
+  const setDisabled = useSetAccountDisabled();
+  const del = useDeleteAccount();
+  const [toDelete, setToDelete] = useState<AdminAccount | null>(null);
+
+  return (
+    <>
+      <div className='overflow-x-auto w-full'>
+        <table className='w-full border-collapse border border-textColor min-w-max'>
+          <thead className='bg-textInactiveColor h-9'>
+            <tr>
+              {['Username', 'Access', 'Status', 'Created', 'Updated', ''].map((h) => (
+                <th key={h} className='border border-textColor px-2 h-9'>
+                  <Text variant='uppercase' size='small'>
+                    {h}
+                  </Text>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {accounts.length === 0 ? (
+              <tr>
+                <td colSpan={6} className='text-center py-6'>
+                  <Text variant='inactive'>{isLoading ? 'loading…' : 'no accounts'}</Text>
+                </td>
+              </tr>
+            ) : (
+              accounts.map((a) => {
+                const isSelf = !!currentUsername && a.username === currentUsername;
+                return (
+                  <tr key={a.username} className='border-b border-textColor last:border-b-0'>
+                    <td className='border border-textColor px-2 py-1.5 whitespace-nowrap'>
+                      <Text size='small'>
+                        {a.username}
+                        {isSelf && <span className='text-textInactiveColor'> (you)</span>}
+                      </Text>
+                    </td>
+                    <td className='border border-textColor px-2 py-1.5 text-center'>
+                      <AccessSummary account={a} />
+                    </td>
+                    <td className='border border-textColor px-2 py-1.5 text-center'>
+                      <Text size='small' variant={a.disabled ? 'error' : 'default'}>
+                        {a.disabled ? 'disabled' : 'active'}
+                      </Text>
+                    </td>
+                    <td className='border border-textColor px-2 py-1.5 text-center whitespace-nowrap'>
+                      <Text size='small'>{formatDateShort(a.createdAt)}</Text>
+                    </td>
+                    <td className='border border-textColor px-2 py-1.5 text-center whitespace-nowrap'>
+                      <Text size='small'>{formatDateShort(a.updatedAt)}</Text>
+                    </td>
+                    <td className='border border-textColor px-2 py-1.5 text-center whitespace-nowrap'>
+                      {canWrite ? (
+                        <div className='flex items-center justify-center gap-1'>
+                          <Button variant='underline' onClick={() => onEdit(a)}>
+                            edit
+                          </Button>
+                          <span className='text-textInactiveColor'>·</span>
+                          <Button variant='underline' onClick={() => onResetPassword(a)}>
+                            password
+                          </Button>
+                          <span className='text-textInactiveColor'>·</span>
+                          <Button
+                            variant='underline'
+                            disabled={isSelf || setDisabled.isPending}
+                            onClick={() =>
+                              setDisabled.mutate({
+                                username: a.username ?? '',
+                                disabled: !a.disabled,
+                              })
+                            }
+                          >
+                            {a.disabled ? 'enable' : 'disable'}
+                          </Button>
+                          <span className='text-textInactiveColor'>·</span>
+                          <Button
+                            variant='underline'
+                            disabled={isSelf}
+                            onClick={() => setToDelete(a)}
+                          >
+                            delete
+                          </Button>
+                        </div>
+                      ) : (
+                        <Text variant='inactive' size='small'>
+                          read-only
+                        </Text>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <ConfirmationModal
+        open={!!toDelete}
+        onOpenChange={(o) => !o && setToDelete(null)}
+        onConfirm={() => {
+          if (toDelete?.username) del.mutate({ username: toDelete.username });
+          setToDelete(null);
+        }}
+        title='delete account'
+        confirmLabel='delete'
+      >
+        <Text size='small'>
+          Permanently delete <span className='uppercase'>{toDelete?.username}</span> and its
+          permissions? This cannot be undone.
+        </Text>
+      </ConfirmationModal>
+    </>
+  );
+}

--- a/src/components/managers/accounts/components/permission-picker.tsx
+++ b/src/components/managers/accounts/components/permission-picker.tsx
@@ -1,0 +1,142 @@
+import { AccessLevel, AdminPermission, AdminSectionInfo } from 'api/proto-http/admin';
+import { cn } from 'lib/utility';
+import { Button } from 'ui/components/button';
+import Text from 'ui/components/text';
+import { ACCESS } from '../utils/hooks';
+
+const LEVELS: { label: string; value: AccessLevel }[] = [
+  { label: 'none', value: ACCESS.NONE },
+  { label: 'read', value: ACCESS.READ },
+  { label: 'write', value: ACCESS.WRITE },
+];
+
+interface Props {
+  sections: AdminSectionInfo[];
+  value: AdminPermission[];
+  onChange: (next: AdminPermission[]) => void;
+  disabled?: boolean;
+  loading?: boolean;
+}
+
+// Grid of grantable sections × access level. Emits a clean AdminPermission[] with only
+// the sections that carry read or write access (none = omitted).
+export function PermissionPicker({ sections, value, onChange, disabled, loading }: Props) {
+  const levelFor = (key: string): AccessLevel =>
+    value.find((p) => p.section === key)?.access ?? ACCESS.NONE;
+
+  const setLevel = (key: string, level: AccessLevel) => {
+    const rest = value.filter((p) => p.section !== key);
+    onChange(level === ACCESS.NONE ? rest : [...rest, { section: key, access: level }]);
+  };
+
+  const setAll = (level: AccessLevel) => {
+    onChange(
+      level === ACCESS.NONE
+        ? []
+        : sections.filter((s) => s.key).map((s) => ({ section: s.key as string, access: level })),
+    );
+  };
+
+  if (loading) {
+    return (
+      <Text variant='inactive' size='small'>
+        loading sections…
+      </Text>
+    );
+  }
+
+  if (sections.length === 0) {
+    return (
+      <Text variant='inactive' size='small'>
+        no grantable sections
+      </Text>
+    );
+  }
+
+  return (
+    <div className={cn('flex flex-col gap-3', disabled && 'pointer-events-none opacity-40')}>
+      <div className='flex items-center justify-between gap-2'>
+        <Text variant='inactive' size='small'>
+          per-section access
+        </Text>
+        <div className='flex items-center gap-2'>
+          <Text variant='inactive' size='small'>
+            set all:
+          </Text>
+          {LEVELS.map((lvl) => (
+            <Button
+              key={lvl.value}
+              type='button'
+              variant='underline'
+              onClick={() => setAll(lvl.value)}
+              disabled={disabled}
+            >
+              {lvl.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <div className='overflow-x-auto w-full'>
+        <table className='w-full border-collapse border border-textColor min-w-max'>
+          <thead className='bg-textInactiveColor h-9'>
+            <tr>
+              <th className='border border-textColor px-2 text-left'>
+                <Text variant='uppercase' size='small'>
+                  section
+                </Text>
+              </th>
+              <th className='border border-textColor px-2'>
+                <Text variant='uppercase' size='small'>
+                  access
+                </Text>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {sections.map((s) => {
+              const key = s.key ?? '';
+              const current = levelFor(key);
+              return (
+                <tr key={key} className='border-b border-textColor last:border-b-0'>
+                  <td className='border border-textColor px-2 py-1.5 align-top'>
+                    <Text size='small'>{s.title || key}</Text>
+                    {s.description && (
+                      <Text variant='inactive' size='small'>
+                        {s.description}
+                      </Text>
+                    )}
+                  </td>
+                  <td className='border border-textColor px-2 py-1.5'>
+                    <div className='flex items-center gap-0.5'>
+                      {LEVELS.map((lvl) => {
+                        const active = current === lvl.value;
+                        return (
+                          <button
+                            key={lvl.value}
+                            type='button'
+                            disabled={disabled}
+                            onClick={() => setLevel(key, lvl.value)}
+                            className={cn(
+                              'border border-textColor px-2 py-0.5 text-small uppercase cursor-pointer',
+                              active
+                                ? 'bg-textColor text-bgColor'
+                                : 'bg-bgColor text-textColor hover:bg-textInactiveColor',
+                              'disabled:cursor-not-allowed',
+                            )}
+                          >
+                            {lvl.label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/managers/accounts/components/reset-password-modal.tsx
+++ b/src/components/managers/accounts/components/reset-password-modal.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { ConfirmationModal } from 'ui/components/confirmation-modal';
+import Input from 'ui/components/input';
+import Text from 'ui/components/text';
+import { useResetAccountPassword } from '../utils/hooks';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  username: string;
+}
+
+export function ResetPasswordModal({ open, onOpenChange, username }: Props) {
+  const reset = useResetAccountPassword();
+  const [password, setPassword] = useState('');
+
+  useEffect(() => {
+    if (open) setPassword('');
+  }, [open]);
+
+  const handleConfirm = () => {
+    if (!password.trim()) return;
+    reset.mutate({ username, newPassword: password });
+  };
+
+  return (
+    <ConfirmationModal
+      open={open}
+      onOpenChange={onOpenChange}
+      onConfirm={handleConfirm}
+      title={`reset password — ${username}`}
+      confirmLabel='reset'
+      confirmDisabled={!password.trim() || reset.isPending}
+    >
+      <div className='flex flex-col gap-2'>
+        <Text variant='inactive' size='small'>
+          new password for {username}
+        </Text>
+        <Input
+          name='resetPassword'
+          type='text'
+          value={password}
+          autoComplete='new-password'
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
+        />
+      </div>
+    </ConfirmationModal>
+  );
+}

--- a/src/components/managers/accounts/index.tsx
+++ b/src/components/managers/accounts/index.tsx
@@ -1,0 +1,1 @@
+export { Accounts } from './page';

--- a/src/components/managers/accounts/page.tsx
+++ b/src/components/managers/accounts/page.tsx
@@ -1,0 +1,97 @@
+import { AdminAccount } from 'api/proto-http/admin';
+import { useState } from 'react';
+import { Button } from 'ui/components/button';
+import Text from 'ui/components/text';
+import { AccountFormModal } from './components/account-form-modal';
+import { AccountsTable } from './components/accounts-table';
+import { ResetPasswordModal } from './components/reset-password-modal';
+import { useAccountSections, useAccounts } from './utils/hooks';
+import { usePermissions } from './utils/permissions';
+
+export function Accounts() {
+  const {
+    canManageAccounts,
+    canManageAccountsWrite,
+    account: current,
+    resolved,
+  } = usePermissions();
+  const canView = !resolved || canManageAccounts;
+
+  const { data, isLoading, isError, error } = useAccounts(canView);
+  const { data: sectionsData, isLoading: sectionsLoading } = useAccountSections();
+
+  const [formMode, setFormMode] = useState<'create' | 'edit' | null>(null);
+  const [editing, setEditing] = useState<AdminAccount | null>(null);
+  const [resetting, setResetting] = useState<AdminAccount | null>(null);
+
+  const accounts = data?.accounts ?? [];
+  const sections = sectionsData?.sections ?? [];
+
+  if (!canView) {
+    return (
+      <div className='flex flex-col gap-2 border border-textColor p-6'>
+        <Text variant='uppercase' size='large'>
+          admin accounts
+        </Text>
+        <Text variant='inactive'>
+          You don’t have access to the accounts section. Ask a super admin to grant it.
+        </Text>
+      </div>
+    );
+  }
+
+  return (
+    <div className='flex flex-col w-full gap-4 pb-16'>
+      <div className='flex items-center justify-between gap-3'>
+        <Text variant='uppercase' size='large'>
+          admin accounts {accounts.length > 0 && `(${accounts.length})`}
+        </Text>
+        {canManageAccountsWrite && (
+          <Button
+            variant='main'
+            size='lg'
+            onClick={() => {
+              setEditing(null);
+              setFormMode('create');
+            }}
+          >
+            new account
+          </Button>
+        )}
+      </div>
+
+      {isError && (
+        <Text variant='error' size='small'>
+          {error instanceof Error ? error.message : 'Failed to load accounts'}
+        </Text>
+      )}
+
+      <AccountsTable
+        accounts={accounts}
+        isLoading={isLoading}
+        currentUsername={current?.username}
+        canWrite={canManageAccountsWrite}
+        onEdit={(a) => {
+          setEditing(a);
+          setFormMode('edit');
+        }}
+        onResetPassword={(a) => setResetting(a)}
+      />
+
+      <AccountFormModal
+        open={formMode !== null}
+        onOpenChange={(o) => !o && setFormMode(null)}
+        mode={formMode ?? 'create'}
+        account={editing}
+        sections={sections}
+        sectionsLoading={sectionsLoading}
+      />
+
+      <ResetPasswordModal
+        open={resetting !== null}
+        onOpenChange={(o) => !o && setResetting(null)}
+        username={resetting?.username ?? ''}
+      />
+    </div>
+  );
+}

--- a/src/components/managers/accounts/utils/hooks.ts
+++ b/src/components/managers/accounts/utils/hooks.ts
@@ -1,0 +1,146 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { adminService } from 'api/api';
+import { AccessLevel, AdminPermission } from 'api/proto-http/admin';
+import { useSnackBarStore } from 'lib/stores/store';
+
+export const accountsKeys = {
+  all: ['accounts'] as const,
+  current: () => [...accountsKeys.all, 'current'] as const,
+  sections: () => [...accountsKeys.all, 'sections'] as const,
+  list: () => [...accountsKeys.all, 'list'] as const,
+};
+
+// ---- Reads ----
+
+// The calling account's identity + effective permissions. Any authenticated admin
+// may call this; it drives which sections the panel exposes.
+export function useCurrentAccount() {
+  return useQuery({
+    queryKey: accountsKeys.current(),
+    queryFn: () => adminService.GetCurrentAccount({}),
+    staleTime: 5 * 60_000,
+    retry: false,
+  });
+}
+
+// Catalog of grantable sections for the permission picker.
+export function useAccountSections() {
+  return useQuery({
+    queryKey: accountsKeys.sections(),
+    queryFn: () => adminService.ListAccountSections({}),
+    staleTime: 30 * 60_000,
+    retry: false,
+  });
+}
+
+// Every admin account with its permissions. Requires the accounts section (read).
+export function useAccounts(enabled = true) {
+  return useQuery({
+    queryKey: accountsKeys.list(),
+    queryFn: () => adminService.ListAccounts({}),
+    staleTime: 30_000,
+    enabled,
+  });
+}
+
+// ---- Mutations ----
+
+export function useCreateAccount() {
+  const queryClient = useQueryClient();
+  const { showMessage } = useSnackBarStore();
+  return useMutation({
+    mutationFn: (vars: {
+      username: string;
+      password: string;
+      isSuper: boolean;
+      permissions: AdminPermission[];
+    }) =>
+      adminService.CreateAccount({
+        username: vars.username,
+        password: vars.password,
+        isSuper: vars.isSuper,
+        permissions: vars.isSuper ? [] : vars.permissions,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: accountsKeys.list() });
+      showMessage('Account created', 'success');
+    },
+    onError: (error) =>
+      showMessage(error instanceof Error ? error.message : 'Failed to create account', 'error'),
+  });
+}
+
+export function useUpdateAccountPermissions() {
+  const queryClient = useQueryClient();
+  const { showMessage } = useSnackBarStore();
+  return useMutation({
+    mutationFn: (vars: { username: string; isSuper: boolean; permissions: AdminPermission[] }) =>
+      adminService.UpdateAccountPermissions({
+        username: vars.username,
+        isSuper: vars.isSuper,
+        permissions: vars.isSuper ? [] : vars.permissions,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: accountsKeys.list() });
+      queryClient.invalidateQueries({ queryKey: accountsKeys.current() });
+      showMessage('Permissions updated', 'success');
+    },
+    onError: (error) =>
+      showMessage(error instanceof Error ? error.message : 'Failed to update permissions', 'error'),
+  });
+}
+
+export function useSetAccountDisabled() {
+  const queryClient = useQueryClient();
+  const { showMessage } = useSnackBarStore();
+  return useMutation({
+    mutationFn: (vars: { username: string; disabled: boolean }) =>
+      adminService.SetAccountDisabled(vars),
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({ queryKey: accountsKeys.list() });
+      showMessage(vars.disabled ? 'Account disabled' : 'Account enabled', 'success');
+    },
+    onError: (error) =>
+      showMessage(error instanceof Error ? error.message : 'Failed to update account', 'error'),
+  });
+}
+
+export function useResetAccountPassword() {
+  const { showMessage } = useSnackBarStore();
+  return useMutation({
+    mutationFn: (vars: { username: string; newPassword: string }) =>
+      adminService.ResetAccountPassword(vars),
+    onSuccess: () => showMessage('Password reset', 'success'),
+    onError: (error) =>
+      showMessage(error instanceof Error ? error.message : 'Failed to reset password', 'error'),
+  });
+}
+
+export function useDeleteAccount() {
+  const queryClient = useQueryClient();
+  const { showMessage } = useSnackBarStore();
+  return useMutation({
+    mutationFn: (vars: { username: string }) => adminService.DeleteAccount(vars),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: accountsKeys.list() });
+      showMessage('Account deleted', 'success');
+    },
+    onError: (error) =>
+      showMessage(error instanceof Error ? error.message : 'Failed to delete account', 'error'),
+  });
+}
+
+// ---- Access-level helpers ----
+
+export const ACCESS: Record<'NONE' | 'READ' | 'WRITE', AccessLevel> = {
+  NONE: 'ACCESS_LEVEL_UNSPECIFIED',
+  READ: 'ACCESS_LEVEL_READ',
+  WRITE: 'ACCESS_LEVEL_WRITE',
+};
+
+// WRITE implies READ.
+export function accessSatisfies(have: AccessLevel | undefined, need: AccessLevel): boolean {
+  if (need === ACCESS.WRITE) return have === ACCESS.WRITE;
+  if (need === ACCESS.READ) return have === ACCESS.READ || have === ACCESS.WRITE;
+  return true;
+}

--- a/src/components/managers/accounts/utils/permissions.ts
+++ b/src/components/managers/accounts/utils/permissions.ts
@@ -1,0 +1,66 @@
+import { AccessLevel } from 'api/proto-http/admin';
+import { SECTION } from 'constants/routes';
+import { useMemo } from 'react';
+import { ACCESS, accessSatisfies, useAccountSections, useCurrentAccount } from './hooks';
+
+// usePermissions resolves the calling account's effective access so the panel can
+// decide which sections to show.
+//
+// Fail-open by design: while the account or the section catalog is still loading —
+// or when the backend predates RBAC and the call errors — every section is shown.
+// A section is gated only once we have a definitive non-super account AND the section
+// key is one the backend actually publishes in ListAccountSections. Wrong key guesses
+// therefore fail open rather than hiding legitimate navigation. The backend remains the
+// real enforcement boundary; this only tidies the UI.
+export function usePermissions() {
+  const {
+    data: accountData,
+    isLoading: accountLoading,
+    isError: accountError,
+  } = useCurrentAccount();
+  const { data: sectionsData } = useAccountSections();
+
+  const account = accountData?.account;
+  const isSuper = account?.isSuper ?? false;
+
+  const catalog = useMemo(
+    () => new Set((sectionsData?.sections ?? []).map((s) => s.key).filter(Boolean) as string[]),
+    [sectionsData],
+  );
+
+  const grants = useMemo(() => {
+    const map = new Map<string, AccessLevel>();
+    (account?.permissions ?? []).forEach((p) => {
+      if (p.section) map.set(p.section, p.access ?? ACCESS.NONE);
+    });
+    return map;
+  }, [account]);
+
+  // We only start gating once we have a definitive account that is not super.
+  const resolved = !accountLoading && !accountError && !!account;
+
+  const hasSection = useMemo(
+    () =>
+      (section?: string, level: AccessLevel = ACCESS.READ): boolean => {
+        if (!section) return true;
+        if (!resolved || isSuper) return true;
+        // Only gate keys the backend recognises; unknown keys fail open.
+        if (catalog.size > 0 && !catalog.has(section)) return true;
+        return accessSatisfies(grants.get(section), level);
+      },
+    [resolved, isSuper, catalog, grants],
+  );
+
+  return {
+    account,
+    isSuper,
+    isLoading: accountLoading,
+    resolved,
+    hasSection,
+    canRead: (section?: string) => hasSection(section, ACCESS.READ),
+    canWrite: (section?: string) => hasSection(section, ACCESS.WRITE),
+    canManageAccounts: hasSection(SECTION.accounts, ACCESS.READ),
+    canManageAccountsWrite: hasSection(SECTION.accounts, ACCESS.WRITE),
+    sections: sectionsData?.sections ?? [],
+  };
+}

--- a/src/components/managers/order/utility.ts
+++ b/src/components/managers/order/utility.ts
@@ -116,6 +116,8 @@ export const useOrderDetails = (uuid: string) => {
         orderItemIds: orderItemIds.length ? orderItemIds : [],
         reason: payload.reason || undefined,
         refundShipping: isPartial ? payload.refundShipping ?? false : undefined,
+        // Structured reason is additive; unset falls back to the free-text reason above.
+        reasonCode: undefined,
       });
       fetchOrderDetails();
       setSelectedUnitKeys([]);

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -3,7 +3,33 @@ export const BASE_PATH = process.env.NODE_ENV === 'production' ? '/grbpwr-admin-
 type Manager = {
   label: string;
   route: string;
+  // Section key (from AdminService.ListAccountSections) that gates this item. When
+  // omitted the item is always shown. See usePermissions() for the gating rules.
+  section?: string;
 };
+
+// Canonical section keys used to gate admin-panel navigation against an account's
+// RBAC permissions. Keys mirror the backend's ListAccountSections catalog; any key
+// the backend does not publish simply fails open (item stays visible).
+export const SECTION = {
+  analytics: 'analytics',
+  media: 'media',
+  products: 'products',
+  orders: 'orders',
+  hero: 'hero',
+  promo: 'promo',
+  archive: 'archive',
+  settings: 'settings',
+  shipping: 'shipping',
+  support: 'support',
+  members: 'members',
+  models: 'models',
+  fittings: 'fittings',
+  techCards: 'tech_cards',
+  accounts: 'accounts',
+} as const;
+
+export type SectionKey = (typeof SECTION)[keyof typeof SECTION];
 
 export enum ROUTES {
   login = '/',
@@ -42,76 +68,99 @@ export enum ROUTES {
   addTechCard = '/add-tech-card',
   singleTechCard = '/tech-cards/:id',
   techCardPrint = '/tech-cards/:id/print',
+  accounts = '/accounts',
 }
 
-export const SIDE_BAR_ITEMS = [
+export const SIDE_BAR_ITEMS: Manager[] = [
   {
     label: 'ANALYTICS',
     route: ROUTES.main,
+    section: SECTION.analytics,
   },
   {
     label: 'MEDIA',
     route: ROUTES.media,
+    section: SECTION.media,
   },
   {
     label: 'PRODUCTS',
     route: ROUTES.product,
+    section: SECTION.products,
   },
   {
     label: 'ORDERS',
     route: ROUTES.orders,
+    section: SECTION.orders,
   },
   {
     label: 'HERO',
     route: ROUTES.hero,
+    section: SECTION.hero,
   },
   {
     label: 'PROMO',
     route: ROUTES.promo,
+    section: SECTION.promo,
   },
   {
     label: 'TIMELINE',
     route: ROUTES.archives,
+    section: SECTION.archive,
   },
   {
     label: 'SETTINGS',
     route: ROUTES.settings,
+    section: SECTION.settings,
   },
   {
     label: 'SHIPPING',
     route: ROUTES.shipping,
+    section: SECTION.shipping,
   },
   {
     label: 'CUSTOMER SUPPORT',
     route: ROUTES.customerSupport,
+    section: SECTION.support,
   },
   {
     label: 'MEMBERS',
     route: ROUTES.members,
+    section: SECTION.members,
   },
   {
     label: 'MODELS',
     route: ROUTES.models,
+    section: SECTION.models,
   },
   {
     label: 'FITTINGS',
     route: ROUTES.fittings,
+    section: SECTION.fittings,
   },
   {
     label: 'TECH CARDS',
     route: ROUTES.techCards,
+    section: SECTION.techCards,
   },
   {
     label: 'TIER CONFIG',
     route: ROUTES.tierConfig,
+    section: SECTION.members,
   },
   {
     label: 'HACKER',
     route: ROUTES.hacker,
+    section: SECTION.members,
   },
   {
     label: 'TIER AUDIT',
     route: ROUTES.tierAudit,
+    section: SECTION.members,
+  },
+  {
+    label: 'ACCOUNTS',
+    route: ROUTES.accounts,
+    section: SECTION.accounts,
   },
 ];
 
@@ -119,42 +168,57 @@ export const LEFT_SIDE_ITEMS: Manager[] = [
   {
     label: 'analytics',
     route: ROUTES.main,
+    section: SECTION.analytics,
   },
   {
     label: 'media',
     route: ROUTES.media,
+    section: SECTION.media,
   },
   {
     label: 'products',
     route: ROUTES.product,
+    section: SECTION.products,
   },
   {
     label: 'timiline',
     route: ROUTES.archives,
+    section: SECTION.archive,
   },
   {
     label: 'orders',
     route: ROUTES.orders,
+    section: SECTION.orders,
   },
   {
     label: 'hero',
     route: ROUTES.hero,
+    section: SECTION.hero,
   },
   {
     label: 'members',
     route: ROUTES.members,
+    section: SECTION.members,
   },
   {
     label: 'models',
     route: ROUTES.models,
+    section: SECTION.models,
   },
   {
     label: 'fittings',
     route: ROUTES.fittings,
+    section: SECTION.fittings,
   },
   {
     label: 'tech cards',
     route: ROUTES.techCards,
+    section: SECTION.techCards,
+  },
+  {
+    label: 'accounts',
+    route: ROUTES.accounts,
+    section: SECTION.accounts,
   },
   // {
   //   label: 'promo',
@@ -170,5 +234,6 @@ export const RIGHT_SIDE_MANAGERS: Manager[] = [
   {
     label: 'settings',
     route: ROUTES.settings,
+    section: SECTION.settings,
   },
 ];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -83,6 +83,9 @@ const TechCard = lazy(() =>
 const TechCardPrint = lazy(() =>
   import('components/managers/tech-card/print-page').then((m) => ({ default: m.TechCardPrint })),
 );
+const Accounts = lazy(() =>
+  import('components/managers/accounts').then((m) => ({ default: m.Accounts })),
+);
 
 // Configure QueryClient with best practices
 const queryClient = new QueryClient({
@@ -190,6 +193,7 @@ root.render(
                   <Route path={ROUTES.techCards} element={<TechCards />} />
                   <Route path={ROUTES.addTechCard} element={<TechCard />} />
                   <Route path={ROUTES.singleTechCard} element={<TechCard />} />
+                  <Route path={ROUTES.accounts} element={<Accounts />} />
                 </Route>
                 {/* Layout-less protected route: a standalone page so the browser print
                     engine (Safari especially) renders the document in normal flow, with

--- a/src/ui/components/DesktopNavMenu.tsx
+++ b/src/ui/components/DesktopNavMenu.tsx
@@ -1,4 +1,5 @@
 import * as NavigationMenu from '@radix-ui/react-navigation-menu';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
 import { LEFT_SIDE_ITEMS } from 'constants/routes';
 import { cn } from 'lib/utility';
 import { useState } from 'react';
@@ -13,6 +14,8 @@ export function DesktopNavMenu({
   onNavOpenChange: (value: boolean) => void;
 }) {
   const [isNavOpen, setIsNavOpen] = useState(false);
+  const { canRead } = usePermissions();
+  const items = LEFT_SIDE_ITEMS.filter((item) => canRead(item.section));
   return (
     <NavigationMenu.Root
       className={cn('w-full', className)}
@@ -23,7 +26,7 @@ export function DesktopNavMenu({
       }}
     >
       <NavigationMenu.List className='flex items-center'>
-        {LEFT_SIDE_ITEMS.map(({ label, route }, id) => (
+        {items.map(({ label, route }, id) => (
           <NavigationMenu.Item key={route}>
             <Button asChild>
               <Link

--- a/src/ui/components/MobileNavMenu.tsx
+++ b/src/ui/components/MobileNavMenu.tsx
@@ -4,6 +4,7 @@ import * as DialogPrimitives from '@radix-ui/react-dialog';
 
 import { useState } from 'react';
 
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
 import { SIDE_BAR_ITEMS } from 'constants/routes';
 import { Link } from 'react-router-dom';
 import { Button } from './button';
@@ -11,6 +12,8 @@ import Text from './text';
 
 export function MobileNavMenu() {
   const [open, setOpen] = useState(false);
+  const { canRead } = usePermissions();
+  const items = SIDE_BAR_ITEMS.filter((item) => canRead(item.section));
 
   return (
     <DialogPrimitives.Root open={open} onOpenChange={setOpen}>
@@ -31,7 +34,7 @@ export function MobileNavMenu() {
               </div>
             </DialogPrimitives.Close>
             <div className='flex flex-col gap-5'>
-              {SIDE_BAR_ITEMS.map(({ label, route }, id) => (
+              {items.map(({ label, route }, id) => (
                 <DialogPrimitives.Close asChild key={id}>
                   <Button asChild>
                     <Link to={route}>{label}</Link>

--- a/src/ui/layout.tsx
+++ b/src/ui/layout.tsx
@@ -1,4 +1,5 @@
-import { ROUTES } from 'constants/routes';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
+import { ROUTES, SECTION } from 'constants/routes';
 import { cn } from 'lib/utility';
 import { FC, ReactNode, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
@@ -13,6 +14,7 @@ interface LayoutProps {
 export const Layout: FC<LayoutProps> = ({ children }) => {
   const navigate = useNavigate();
   const [isNavOpen, setIsNavOpen] = useState(false);
+  const { canRead } = usePermissions();
 
   const handleLogout = () => {
     localStorage.removeItem('authToken');
@@ -48,31 +50,47 @@ export const Layout: FC<LayoutProps> = ({ children }) => {
 
         <div className='flex grow basis-0 items-center justify-end'>
           <div className='relative w-full lg:w-auto flex justify-end lg:justify-start'>
-            <Button
-              asChild
-              className='px-2 underline-offset-2 hover:underline transition-colors hover:opacity-70 lg:block hidden whitespace-nowrap'
-            >
-              <Link to={ROUTES.promo}>promo</Link>
-            </Button>
-            <div className='flex justify-end lg:justify-start'>
+            {canRead(SECTION.promo) && (
               <Button
                 asChild
                 className='px-2 underline-offset-2 hover:underline transition-colors hover:opacity-70 lg:block hidden whitespace-nowrap'
               >
-                <Link to={ROUTES.customerSupport}>support</Link>
+                <Link to={ROUTES.promo}>promo</Link>
               </Button>
-              <Button
-                asChild
-                className='px-2 underline-offset-2 hover:underline transition-colors hover:opacity-70 lg:block hidden'
-              >
-                <Link to={ROUTES.shipping}>shipping</Link>
-              </Button>
-              <Button
-                asChild
-                className='px-2 underline-offset-2 hover:underline transition-colors hover:opacity-70 lg:block hidden'
-              >
-                <Link to={ROUTES.settings}>settings</Link>
-              </Button>
+            )}
+            <div className='flex justify-end lg:justify-start'>
+              {canRead(SECTION.support) && (
+                <Button
+                  asChild
+                  className='px-2 underline-offset-2 hover:underline transition-colors hover:opacity-70 lg:block hidden whitespace-nowrap'
+                >
+                  <Link to={ROUTES.customerSupport}>support</Link>
+                </Button>
+              )}
+              {canRead(SECTION.shipping) && (
+                <Button
+                  asChild
+                  className='px-2 underline-offset-2 hover:underline transition-colors hover:opacity-70 lg:block hidden'
+                >
+                  <Link to={ROUTES.shipping}>shipping</Link>
+                </Button>
+              )}
+              {canRead(SECTION.settings) && (
+                <Button
+                  asChild
+                  className='px-2 underline-offset-2 hover:underline transition-colors hover:opacity-70 lg:block hidden'
+                >
+                  <Link to={ROUTES.settings}>settings</Link>
+                </Button>
+              )}
+              {canRead(SECTION.accounts) && (
+                <Button
+                  asChild
+                  className='px-2 underline-offset-2 hover:underline transition-colors hover:opacity-70 lg:block hidden'
+                >
+                  <Link to={ROUTES.accounts}>accounts</Link>
+                </Button>
+              )}
               <Button
                 className='px-2  underline-offset-2 hover:underline transition-colors hover:opacity-70 cursor-pointer'
                 onClick={handleLogout}


### PR DESCRIPTION
Promotes `beta` to `master`.

Includes the **admin accounts RBAC** feature (#323): management UI at `/accounts`, permission picker driven by `ListAccountSections`, and nav/section gating via `GetCurrentAccount`. Proto bumped to `59e11d3`; `proto-http` admin client regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)