### PR TITLE
Release: accounts UX polish

### DIFF
--- a/src/components/managers/accounts/components/account-form-modal.tsx
+++ b/src/components/managers/accounts/components/account-form-modal.tsx
@@ -17,6 +17,17 @@ interface Props {
   sectionsLoading?: boolean;
 }
 
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className='flex flex-col gap-1'>
+      <Text variant='label' size='small'>
+        {label}
+      </Text>
+      {children}
+    </label>
+  );
+}
+
 export function AccountFormModal({
   open,
   onOpenChange,
@@ -75,60 +86,64 @@ export function AccountFormModal({
     <DialogPrimitives.Root open={open} onOpenChange={onOpenChange}>
       <DialogPrimitives.Portal>
         <DialogPrimitives.Overlay className='fixed inset-0 z-20 h-screen bg-overlay' />
-        <DialogPrimitives.Content className='fixed inset-x-2.5 top-1/2 z-50 flex max-h-[90vh] w-auto -translate-y-1/2 flex-col overflow-y-auto border border-textInactiveColor bg-bgColor p-3 text-textColor lg:inset-x-auto lg:left-1/2 lg:w-[560px] lg:-translate-x-1/2'>
-          <div className='mb-3 flex items-center justify-between gap-2 border-b border-textColor pb-2'>
-            <DialogPrimitives.Title className='text-lg uppercase'>
-              {isEdit ? `edit — ${username}` : 'new account'}
+        <DialogPrimitives.Content className='fixed inset-x-2.5 top-1/2 z-50 flex max-h-[90vh] w-auto -translate-y-1/2 flex-col overflow-y-auto border border-textColor bg-bgColor text-textColor lg:inset-x-auto lg:left-1/2 lg:w-[560px] lg:-translate-x-1/2'>
+          <div className='sticky top-0 z-10 flex items-center justify-between gap-2 border-b border-textColor bg-bgColor px-4 py-3'>
+            <DialogPrimitives.Title className='text-lg uppercase break-all'>
+              {isEdit ? username : 'new account'}
             </DialogPrimitives.Title>
             <DialogPrimitives.Close asChild>
-              <Button type='button' className='cursor-pointer'>
+              <Button type='button' className='shrink-0 cursor-pointer'>
                 [x]
               </Button>
             </DialogPrimitives.Close>
           </div>
           <DialogPrimitives.Description className='sr-only'>
-            {isEdit ? 'Edit admin account permissions' : 'Create a new admin account'}
+            {isEdit ? 'Edit admin account access' : 'Create a new admin account'}
           </DialogPrimitives.Description>
 
-          <div className='flex flex-col gap-4'>
-            {!isEdit && (
-              <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
-                <div className='flex flex-col gap-1'>
-                  <Text variant='inactive' size='small'>
-                    username
-                  </Text>
+          <div className='flex flex-col gap-5 p-4'>
+            {isEdit ? (
+              <Text variant='label' size='small'>
+                Change the password from the account’s “password” action.
+              </Text>
+            ) : (
+              <div className='grid grid-cols-1 gap-4 sm:grid-cols-2'>
+                <Field label='username'>
                   <Input
                     name='newUsername'
                     value={username}
                     autoComplete='off'
+                    className='h-9'
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                       setUsername(e.target.value)
                     }
                   />
-                </div>
-                <div className='flex flex-col gap-1'>
-                  <Text variant='inactive' size='small'>
-                    password
-                  </Text>
+                </Field>
+                <Field label='password'>
                   <Input
                     name='newPassword'
                     type='text'
                     value={password}
                     autoComplete='new-password'
+                    className='h-9'
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                       setPassword(e.target.value)
                     }
                   />
-                </div>
+                </Field>
               </div>
             )}
 
-            <div className='border border-textColor p-3'>
-              <ToggleSwitch
-                checked={isSuper}
-                label='super admin — full access to every section'
-                onCheckedChange={setIsSuper}
-              />
+            <div className='flex items-start justify-between gap-4 border border-textColor p-3'>
+              <div className='min-w-0'>
+                <Text size='small' className='uppercase'>
+                  super admin
+                </Text>
+                <Text variant='label' size='small'>
+                  Full access to every section. Per-section grants are ignored.
+                </Text>
+              </div>
+              <ToggleSwitch checked={isSuper} onCheckedChange={setIsSuper} />
             </div>
 
             {!isSuper && (
@@ -147,7 +162,7 @@ export function AccountFormModal({
             )}
           </div>
 
-          <div className='mt-4 flex justify-end gap-2'>
+          <div className='sticky bottom-0 flex justify-end gap-2 border-t border-textColor bg-bgColor px-4 py-3'>
             <Button type='button' onClick={() => onOpenChange(false)} variant='secondary' size='lg'>
               cancel
             </Button>
@@ -159,7 +174,7 @@ export function AccountFormModal({
               loading={pending}
               disabled={pending}
             >
-              {isEdit ? 'save' : 'create'}
+              {isEdit ? 'save changes' : 'create account'}
             </Button>
           </div>
         </DialogPrimitives.Content>

--- a/src/components/managers/accounts/components/accounts-table.tsx
+++ b/src/components/managers/accounts/components/accounts-table.tsx
@@ -1,4 +1,5 @@
 import { AdminAccount } from 'api/proto-http/admin';
+import { cn } from 'lib/utility';
 import { useState } from 'react';
 import { Button } from 'ui/components/button';
 import { ConfirmationModal } from 'ui/components/confirmation-modal';
@@ -7,16 +8,31 @@ import { formatDateShort } from '../../orders-catalog/components/utility';
 import { ACCESS, useDeleteAccount, useSetAccountDisabled } from '../utils/hooks';
 
 const ACCESS_ABBR: Record<string, string> = {
-  [ACCESS.READ]: 'r',
-  [ACCESS.WRITE]: 'w',
+  [ACCESS.READ]: 'R',
+  [ACCESS.WRITE]: 'W',
 };
 
-function AccessSummary({ account }: { account: AdminAccount }) {
+function StatusBadge({ disabled }: { disabled?: boolean }) {
+  return (
+    <span
+      className={cn(
+        'shrink-0 border px-1.5 py-0.5',
+        disabled ? 'border-error' : 'border-textColor',
+      )}
+    >
+      <Text variant={disabled ? 'error' : 'uppercase'} size='small'>
+        {disabled ? 'disabled' : 'active'}
+      </Text>
+    </span>
+  );
+}
+
+function AccessChips({ account }: { account: AdminAccount }) {
   if (account.isSuper) {
     return (
-      <span className='border border-textColor px-1.5 py-0.5'>
-        <Text variant='uppercase' size='small'>
-          super
+      <span className='inline-flex border border-textColor bg-textColor px-1.5 py-0.5'>
+        <Text size='small' className='uppercase text-bgColor'>
+          super · full access
         </Text>
       </span>
     );
@@ -24,18 +40,18 @@ function AccessSummary({ account }: { account: AdminAccount }) {
   const perms = (account.permissions ?? []).filter((p) => p.section);
   if (perms.length === 0) {
     return (
-      <Text variant='inactive' size='small'>
-        no access
+      <Text variant='label' size='small'>
+        no sections granted
       </Text>
     );
   }
   return (
-    <div className='flex flex-wrap justify-center gap-1'>
+    <div className='flex flex-wrap gap-1'>
       {perms.map((p) => (
-        <span key={p.section} className='border border-textColor px-1 py-0.5 whitespace-nowrap'>
-          <Text size='small'>
+        <span key={p.section} className='whitespace-nowrap border border-textColor px-1.5 py-0.5'>
+          <Text size='small' className='uppercase'>
             {p.section}
-            <span className='text-textInactiveColor'>·{ACCESS_ABBR[p.access ?? ''] ?? '?'}</span>
+            <span className='text-labelColor'> {ACCESS_ABBR[p.access ?? ''] ?? '?'}</span>
           </Text>
         </span>
       ))}
@@ -64,97 +80,89 @@ export function AccountsTable({
   const del = useDeleteAccount();
   const [toDelete, setToDelete] = useState<AdminAccount | null>(null);
 
+  if (isLoading) {
+    return (
+      <div className='border border-textColor'>
+        {[0, 1, 2].map((i) => (
+          <div
+            key={i}
+            className={cn(
+              'h-24 animate-pulse bg-textInactiveColor/30',
+              i > 0 && 'border-t border-textColor',
+            )}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (accounts.length === 0) {
+    return (
+      <div className='flex flex-col items-center gap-1 border border-textColor p-10 text-center'>
+        <Text variant='uppercase'>no accounts yet</Text>
+        <Text variant='label' size='small'>
+          create the first admin account to grant scoped or full access.
+        </Text>
+      </div>
+    );
+  }
+
   return (
     <>
-      <div className='overflow-x-auto w-full'>
-        <table className='w-full border-collapse border border-textColor min-w-max'>
-          <thead className='bg-textInactiveColor h-9'>
-            <tr>
-              {['Username', 'Access', 'Status', 'Created', 'Updated', ''].map((h) => (
-                <th key={h} className='border border-textColor px-2 h-9'>
-                  <Text variant='uppercase' size='small'>
-                    {h}
+      <div className='border border-textColor'>
+        {accounts.map((a, i) => {
+          const isSelf = !!currentUsername && a.username === currentUsername;
+          return (
+            <div
+              key={a.username}
+              className={cn('flex flex-col gap-3 p-3 sm:p-4', i > 0 && 'border-t border-textColor')}
+            >
+              <div className='flex flex-wrap items-center justify-between gap-2'>
+                <div className='flex items-baseline gap-2'>
+                  <Text size='large' className='uppercase break-all'>
+                    {a.username}
                   </Text>
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {accounts.length === 0 ? (
-              <tr>
-                <td colSpan={6} className='text-center py-6'>
-                  <Text variant='inactive'>{isLoading ? 'loading…' : 'no accounts'}</Text>
-                </td>
-              </tr>
-            ) : (
-              accounts.map((a) => {
-                const isSelf = !!currentUsername && a.username === currentUsername;
-                return (
-                  <tr key={a.username} className='border-b border-textColor last:border-b-0'>
-                    <td className='border border-textColor px-2 py-1.5 whitespace-nowrap'>
-                      <Text size='small'>
-                        {a.username}
-                        {isSelf && <span className='text-textInactiveColor'> (you)</span>}
-                      </Text>
-                    </td>
-                    <td className='border border-textColor px-2 py-1.5 text-center'>
-                      <AccessSummary account={a} />
-                    </td>
-                    <td className='border border-textColor px-2 py-1.5 text-center'>
-                      <Text size='small' variant={a.disabled ? 'error' : 'default'}>
-                        {a.disabled ? 'disabled' : 'active'}
-                      </Text>
-                    </td>
-                    <td className='border border-textColor px-2 py-1.5 text-center whitespace-nowrap'>
-                      <Text size='small'>{formatDateShort(a.createdAt)}</Text>
-                    </td>
-                    <td className='border border-textColor px-2 py-1.5 text-center whitespace-nowrap'>
-                      <Text size='small'>{formatDateShort(a.updatedAt)}</Text>
-                    </td>
-                    <td className='border border-textColor px-2 py-1.5 text-center whitespace-nowrap'>
-                      {canWrite ? (
-                        <div className='flex items-center justify-center gap-1'>
-                          <Button variant='underline' onClick={() => onEdit(a)}>
-                            edit
-                          </Button>
-                          <span className='text-textInactiveColor'>·</span>
-                          <Button variant='underline' onClick={() => onResetPassword(a)}>
-                            password
-                          </Button>
-                          <span className='text-textInactiveColor'>·</span>
-                          <Button
-                            variant='underline'
-                            disabled={isSelf || setDisabled.isPending}
-                            onClick={() =>
-                              setDisabled.mutate({
-                                username: a.username ?? '',
-                                disabled: !a.disabled,
-                              })
-                            }
-                          >
-                            {a.disabled ? 'enable' : 'disable'}
-                          </Button>
-                          <span className='text-textInactiveColor'>·</span>
-                          <Button
-                            variant='underline'
-                            disabled={isSelf}
-                            onClick={() => setToDelete(a)}
-                          >
-                            delete
-                          </Button>
-                        </div>
-                      ) : (
-                        <Text variant='inactive' size='small'>
-                          read-only
-                        </Text>
-                      )}
-                    </td>
-                  </tr>
-                );
-              })
-            )}
-          </tbody>
-        </table>
+                  {isSelf && (
+                    <Text variant='label' size='small'>
+                      you
+                    </Text>
+                  )}
+                </div>
+                <StatusBadge disabled={a.disabled} />
+              </div>
+
+              <AccessChips account={a} />
+
+              <div className='flex flex-wrap items-center justify-between gap-x-4 gap-y-2 border-t border-textInactiveColor pt-2'>
+                <Text variant='label' size='small'>
+                  created {formatDateShort(a.createdAt)} · updated {formatDateShort(a.updatedAt)}
+                </Text>
+                {canWrite && (
+                  <div className='flex flex-wrap items-center gap-x-3 gap-y-1'>
+                    <Button variant='underline' onClick={() => onEdit(a)}>
+                      edit
+                    </Button>
+                    <Button variant='underline' onClick={() => onResetPassword(a)}>
+                      password
+                    </Button>
+                    <Button
+                      variant='underline'
+                      disabled={isSelf || setDisabled.isPending}
+                      onClick={() =>
+                        setDisabled.mutate({ username: a.username ?? '', disabled: !a.disabled })
+                      }
+                    >
+                      {a.disabled ? 'enable' : 'disable'}
+                    </Button>
+                    <Button variant='underline' disabled={isSelf} onClick={() => setToDelete(a)}>
+                      delete
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
       </div>
 
       <ConfirmationModal
@@ -165,7 +173,7 @@ export function AccountsTable({
           setToDelete(null);
         }}
         title='delete account'
-        confirmLabel='delete'
+        confirmLabel='delete account'
       >
         <Text size='small'>
           Permanently delete <span className='uppercase'>{toDelete?.username}</span> and its

--- a/src/components/managers/accounts/components/permission-picker.tsx
+++ b/src/components/managers/accounts/components/permission-picker.tsx
@@ -10,6 +10,45 @@ const LEVELS: { label: string; value: AccessLevel }[] = [
   { label: 'write', value: ACCESS.WRITE },
 ];
 
+// Connected 3-segment control. Active segment is the inverse fill (brutalist
+// monochrome "selected"); inactive segments use labelColor (AA) not the decorative
+// inactive gray.
+function AccessControl({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: AccessLevel;
+  onChange: (v: AccessLevel) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div role='group' aria-label='access level' className='flex shrink-0 border border-textColor'>
+      {LEVELS.map((lvl, i) => {
+        const active = value === lvl.value;
+        return (
+          <button
+            key={lvl.value}
+            type='button'
+            aria-pressed={active}
+            disabled={disabled}
+            onClick={() => onChange(lvl.value)}
+            className={cn(
+              'px-3 py-1 text-textBaseSize uppercase transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-textColor disabled:cursor-not-allowed',
+              i > 0 && 'border-l border-textColor',
+              active
+                ? 'bg-textColor text-bgColor'
+                : 'bg-bgColor text-labelColor hover:bg-textInactiveColor hover:text-textColor',
+            )}
+          >
+            {lvl.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 interface Props {
   sections: AdminSectionInfo[];
   value: AdminPermission[];
@@ -18,8 +57,8 @@ interface Props {
   loading?: boolean;
 }
 
-// Grid of grantable sections × access level. Emits a clean AdminPermission[] with only
-// the sections that carry read or write access (none = omitted).
+// Grid of grantable sections × access level. Emits a clean AdminPermission[] carrying
+// only the sections with read or write access (none = omitted).
 export function PermissionPicker({ sections, value, onChange, disabled, loading }: Props) {
   const levelFor = (key: string): AccessLevel =>
     value.find((p) => p.section === key)?.access ?? ACCESS.NONE;
@@ -29,45 +68,57 @@ export function PermissionPicker({ sections, value, onChange, disabled, loading 
     onChange(level === ACCESS.NONE ? rest : [...rest, { section: key, access: level }]);
   };
 
-  const setAll = (level: AccessLevel) => {
+  const setAll = (level: AccessLevel) =>
     onChange(
       level === ACCESS.NONE
         ? []
         : sections.filter((s) => s.key).map((s) => ({ section: s.key as string, access: level })),
     );
-  };
+
+  const grantedCount = value.filter((p) => p.access && p.access !== ACCESS.NONE).length;
 
   if (loading) {
     return (
-      <Text variant='inactive' size='small'>
-        loading sections…
-      </Text>
+      <div className='border border-textColor'>
+        {[0, 1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className={cn(
+              'h-12 animate-pulse bg-textInactiveColor/40',
+              i > 0 && 'border-t border-textColor',
+            )}
+          />
+        ))}
+      </div>
     );
   }
 
   if (sections.length === 0) {
     return (
-      <Text variant='inactive' size='small'>
-        no grantable sections
-      </Text>
+      <div className='border border-textColor p-4'>
+        <Text variant='label' size='small'>
+          no grantable sections
+        </Text>
+      </div>
     );
   }
 
   return (
-    <div className={cn('flex flex-col gap-3', disabled && 'pointer-events-none opacity-40')}>
-      <div className='flex items-center justify-between gap-2'>
-        <Text variant='inactive' size='small'>
-          per-section access
+    <div className={cn('flex flex-col gap-2', disabled && 'pointer-events-none opacity-40')}>
+      <div className='flex flex-wrap items-center justify-between gap-x-4 gap-y-1'>
+        <Text variant='uppercase' size='small'>
+          sections{grantedCount > 0 && ` · ${grantedCount} granted`}
         </Text>
         <div className='flex items-center gap-2'>
-          <Text variant='inactive' size='small'>
-            set all:
+          <Text variant='label' size='small'>
+            set all
           </Text>
           {LEVELS.map((lvl) => (
             <Button
               key={lvl.value}
               type='button'
               variant='underline'
+              className='text-small uppercase'
               onClick={() => setAll(lvl.value)}
               disabled={disabled}
             >
@@ -77,65 +128,38 @@ export function PermissionPicker({ sections, value, onChange, disabled, loading 
         </div>
       </div>
 
-      <div className='overflow-x-auto w-full'>
-        <table className='w-full border-collapse border border-textColor min-w-max'>
-          <thead className='bg-textInactiveColor h-9'>
-            <tr>
-              <th className='border border-textColor px-2 text-left'>
-                <Text variant='uppercase' size='small'>
-                  section
+      <div className='border border-textColor'>
+        {sections.map((s, i) => {
+          const key = s.key ?? '';
+          const current = levelFor(key);
+          const granted = current !== ACCESS.NONE;
+          return (
+            <div
+              key={key}
+              className={cn(
+                'flex flex-wrap items-center justify-between gap-x-4 gap-y-2 p-3',
+                i > 0 && 'border-t border-textColor',
+                granted && 'bg-textInactiveColor/20',
+              )}
+            >
+              <div className='min-w-0 flex-1'>
+                <Text size='small' className='uppercase'>
+                  {s.title || key}
                 </Text>
-              </th>
-              <th className='border border-textColor px-2'>
-                <Text variant='uppercase' size='small'>
-                  access
-                </Text>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {sections.map((s) => {
-              const key = s.key ?? '';
-              const current = levelFor(key);
-              return (
-                <tr key={key} className='border-b border-textColor last:border-b-0'>
-                  <td className='border border-textColor px-2 py-1.5 align-top'>
-                    <Text size='small'>{s.title || key}</Text>
-                    {s.description && (
-                      <Text variant='inactive' size='small'>
-                        {s.description}
-                      </Text>
-                    )}
-                  </td>
-                  <td className='border border-textColor px-2 py-1.5'>
-                    <div className='flex items-center gap-0.5'>
-                      {LEVELS.map((lvl) => {
-                        const active = current === lvl.value;
-                        return (
-                          <button
-                            key={lvl.value}
-                            type='button'
-                            disabled={disabled}
-                            onClick={() => setLevel(key, lvl.value)}
-                            className={cn(
-                              'border border-textColor px-2 py-0.5 text-small uppercase cursor-pointer',
-                              active
-                                ? 'bg-textColor text-bgColor'
-                                : 'bg-bgColor text-textColor hover:bg-textInactiveColor',
-                              'disabled:cursor-not-allowed',
-                            )}
-                          >
-                            {lvl.label}
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+                {s.description && (
+                  <Text variant='label' size='small'>
+                    {s.description}
+                  </Text>
+                )}
+              </div>
+              <AccessControl
+                value={current}
+                onChange={(lvl) => setLevel(key, lvl)}
+                disabled={disabled}
+              />
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/managers/accounts/components/reset-password-modal.tsx
+++ b/src/components/managers/accounts/components/reset-password-modal.tsx
@@ -28,12 +28,12 @@ export function ResetPasswordModal({ open, onOpenChange, username }: Props) {
       open={open}
       onOpenChange={onOpenChange}
       onConfirm={handleConfirm}
-      title={`reset password — ${username}`}
-      confirmLabel='reset'
+      title={`reset password · ${username}`}
+      confirmLabel='reset password'
       confirmDisabled={!password.trim() || reset.isPending}
     >
-      <div className='flex flex-col gap-2'>
-        <Text variant='inactive' size='small'>
+      <label className='flex flex-col gap-1'>
+        <Text variant='label' size='small'>
           new password for {username}
         </Text>
         <Input
@@ -41,9 +41,10 @@ export function ResetPasswordModal({ open, onOpenChange, username }: Props) {
           type='text'
           value={password}
           autoComplete='new-password'
+          className='h-9'
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
         />
-      </div>
+      </label>
     </ConfirmationModal>
   );
 }

--- a/src/components/managers/accounts/page.tsx
+++ b/src/components/managers/accounts/page.tsx
@@ -29,23 +29,28 @@ export function Accounts() {
 
   if (!canView) {
     return (
-      <div className='flex flex-col gap-2 border border-textColor p-6'>
+      <div className='mx-auto flex max-w-md flex-col items-center gap-2 border border-textColor p-10 text-center'>
         <Text variant='uppercase' size='large'>
           admin accounts
         </Text>
-        <Text variant='inactive'>
-          You don’t have access to the accounts section. Ask a super admin to grant it.
+        <Text variant='label' size='small'>
+          You don’t have access to this section. Ask a super admin to grant it.
         </Text>
       </div>
     );
   }
 
   return (
-    <div className='flex flex-col w-full gap-4 pb-16'>
-      <div className='flex items-center justify-between gap-3'>
-        <Text variant='uppercase' size='large'>
-          admin accounts {accounts.length > 0 && `(${accounts.length})`}
-        </Text>
+    <div className='flex w-full flex-col gap-4 pb-16'>
+      <div className='flex flex-wrap items-end justify-between gap-3 border-b border-textColor pb-3'>
+        <div className='flex flex-col gap-1'>
+          <Text variant='uppercase' size='large'>
+            admin accounts{accounts.length > 0 && ` · ${accounts.length}`}
+          </Text>
+          <Text variant='label' size='small'>
+            Super accounts see everything; scoped accounts see only the sections they’re granted.
+          </Text>
+        </div>
         {canManageAccountsWrite && (
           <Button
             variant='main'
@@ -55,7 +60,7 @@ export function Accounts() {
               setFormMode('create');
             }}
           >
-            new account
+            + new account
           </Button>
         )}
       </div>


### PR DESCRIPTION
Promotes `beta` to `master`: admin accounts UX polish (#325) on top of the accounts RBAC feature.

Responsive record-row layout (no horizontal scroll), AA text colors, permission-aware controls that hide entirely for read-only viewers, loading/empty states. Brutalist monochrome preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)