### PR TITLE
Read-only enforcement, mobile nav overflow, dynamic landing

### DIFF
--- a/src/components/managers/accounts/utils/permissions.ts
+++ b/src/components/managers/accounts/utils/permissions.ts
@@ -1,5 +1,5 @@
 import { AccessLevel } from 'api/proto-http/admin';
-import { SECTION } from 'constants/routes';
+import { SECTION, SIDE_BAR_ITEMS } from 'constants/routes';
 import { useMemo } from 'react';
 import { ACCESS, accessSatisfies, useAccountSections, useCurrentAccount } from './hooks';
 
@@ -51,12 +51,20 @@ export function usePermissions() {
     [resolved, isSuper, catalog, grants],
   );
 
+  // First navigable section the account can read, in sidebar order. Used to land
+  // scoped accounts on a page they can actually open instead of the analytics home.
+  const homeRoute = useMemo(() => {
+    const item = SIDE_BAR_ITEMS.find((it) => hasSection(it.section, ACCESS.READ));
+    return item?.route ?? null;
+  }, [hasSection]);
+
   return {
     account,
     isSuper,
     isLoading: accountLoading,
     resolved,
     hasSection,
+    homeRoute,
     canRead: (section?: string) => hasSection(section, ACCESS.READ),
     canWrite: (section?: string) => hasSection(section, ACCESS.WRITE),
     canManageAccounts: hasSection(SECTION.accounts, ACCESS.READ),

--- a/src/components/managers/archive/components/index.tsx
+++ b/src/components/managers/archive/components/index.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { common_ArchiveFull } from 'api/proto-http/admin';
-import { ROUTES } from 'constants/routes';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
+import { ROUTES, SECTION } from 'constants/routes';
 import { useBlockNavigation } from 'hooks/useBlockNavigation';
 import { useSnackBarStore } from 'lib/stores/store';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -56,6 +57,7 @@ export function ArchiveForm({
 }) {
   const { showMessage } = useSnackBarStore();
   const navigate = useNavigate();
+  const { canWrite } = usePermissions();
 
   // Resolved read model → form (+ the resolved-product cache, keyed by block uid).
   const initial = useMemo(
@@ -279,17 +281,19 @@ export function ArchiveForm({
               </span>
             )}
           </div>
-          <Button
-            type='button'
-            variant='main'
-            size='lg'
-            className='uppercase cursor-pointer'
-            disabled={(isEditMode && !hasChanges) || isSaving}
-            loading={isSaving}
-            onClick={handleSaveClick}
-          >
-            {isEditMode ? 'save' : 'create'}
-          </Button>
+          {canWrite(SECTION.archive) && (
+            <Button
+              type='button'
+              variant='main'
+              size='lg'
+              className='uppercase cursor-pointer'
+              disabled={(isEditMode && !hasChanges) || isSaving}
+              loading={isSaving}
+              onClick={handleSaveClick}
+            >
+              {isEditMode ? 'save' : 'create'}
+            </Button>
+          )}
         </div>
 
         <section className='space-y-4'>

--- a/src/components/managers/archives/index.tsx
+++ b/src/components/managers/archives/index.tsx
@@ -1,4 +1,5 @@
-import { ROUTES } from 'constants/routes';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
+import { ROUTES, SECTION } from 'constants/routes';
 import { useCallback, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Button } from 'ui/components/button';
@@ -6,6 +7,7 @@ import Text from 'ui/components/text';
 import { ListArchive } from './components/archive-list';
 
 export function Archives() {
+  const { canWrite } = usePermissions();
   const [count, setCount] = useState({ loaded: 0, hasMore: false });
 
   const handleCount = useCallback((loaded: number, hasMore: boolean) => {
@@ -28,9 +30,11 @@ export function Archives() {
             </Text>
           )}
         </div>
-        <Button size='lg' variant='main' className='uppercase' asChild>
-          <Link to={ROUTES.addArchive}>create new</Link>
-        </Button>
+        {canWrite(SECTION.archive) && (
+          <Button size='lg' variant='main' className='uppercase' asChild>
+            <Link to={ROUTES.addArchive}>create new</Link>
+          </Button>
+        )}
       </div>
 
       <ListArchive onCountChange={handleCount} />

--- a/src/components/managers/fitting/components/index.tsx
+++ b/src/components/managers/fitting/components/index.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { common_Fitting } from 'api/proto-http/admin';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
 import {
   useCreateFitting,
   useUpdateFitting,
@@ -7,7 +8,7 @@ import {
 import { ModelMeasurementsView } from 'components/managers/model/components/measurements-view';
 import { useAllModels } from 'components/managers/models/components/useModelQuery';
 import { fittingStatusOptions, fittingVerdictOptions } from 'constants/filter';
-import { ROUTES } from 'constants/routes';
+import { ROUTES, SECTION } from 'constants/routes';
 import { useSnackBarStore } from 'lib/stores/store';
 import { useMemo } from 'react';
 import { useForm } from 'react-hook-form';
@@ -64,6 +65,7 @@ export function FittingForm({
   const navigate = useNavigate();
   const createFitting = useCreateFitting();
   const updateFitting = useUpdateFitting();
+  const { canWrite } = usePermissions();
   const { data: models } = useAllModels();
   const [searchParams] = useSearchParams();
   // Deep-link from the tech card editor: /add-fitting?techCardId=123 pre-links the style.
@@ -189,17 +191,19 @@ export function FittingForm({
           >
             cancel
           </Button>
-          <Button
-            type='button'
-            variant='main'
-            size='lg'
-            className='uppercase cursor-pointer'
-            disabled={(isEditMode && !form.formState.isDirty) || form.formState.isSubmitting}
-            loading={form.formState.isSubmitting}
-            onClick={() => form.handleSubmit(handleSubmit)()}
-          >
-            {isEditMode ? 'save' : 'add'}
-          </Button>
+          {canWrite(SECTION.fittings) && (
+            <Button
+              type='button'
+              variant='main'
+              size='lg'
+              className='uppercase cursor-pointer'
+              disabled={(isEditMode && !form.formState.isDirty) || form.formState.isSubmitting}
+              loading={form.formState.isSubmitting}
+              onClick={() => form.handleSubmit(handleSubmit)()}
+            >
+              {isEditMode ? 'save' : 'add'}
+            </Button>
+          )}
         </div>
       </div>
     </Form>

--- a/src/components/managers/fittings/components/fitting-card-list.tsx
+++ b/src/components/managers/fittings/components/fitting-card-list.tsx
@@ -1,3 +1,5 @@
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
+import { SECTION } from 'constants/routes';
 import { useSnackBarStore } from 'lib/stores/store';
 import { useEffect, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
@@ -17,6 +19,7 @@ export function FittingCardList() {
   const navigate = useNavigate();
   const { showMessage } = useSnackBarStore();
   const deleteFitting = useDeleteFitting();
+  const canEdit = usePermissions().canWrite(SECTION.fittings);
 
   const [productId, setProductId] = useState(0);
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteFittings(
@@ -111,17 +114,19 @@ export function FittingCardList() {
                     {fitting.media?.length ?? 0} photo(s)
                   </Text>
                 </div>
-                <Button
-                  type='button'
-                  aria-label='delete fitting'
-                  onClick={(e: React.MouseEvent) => {
-                    e.stopPropagation();
-                    setPendingDelete({ id });
-                  }}
-                  className='absolute right-1 top-1 z-20 border border-textColor bg-bgColor px-1.5 leading-none opacity-100 transition-opacity lg:opacity-0 lg:group-hover:opacity-100'
-                >
-                  ✕
-                </Button>
+                {canEdit && (
+                  <Button
+                    type='button'
+                    aria-label='delete fitting'
+                    onClick={(e: React.MouseEvent) => {
+                      e.stopPropagation();
+                      setPendingDelete({ id });
+                    }}
+                    className='absolute right-1 top-1 z-20 border border-textColor bg-bgColor px-1.5 leading-none opacity-100 transition-opacity lg:opacity-0 lg:group-hover:opacity-100'
+                  >
+                    ✕
+                  </Button>
+                )}
               </div>
             );
           })}

--- a/src/components/managers/fittings/index.tsx
+++ b/src/components/managers/fittings/index.tsx
@@ -1,19 +1,23 @@
-import { ROUTES } from 'constants/routes';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
+import { ROUTES, SECTION } from 'constants/routes';
 import { Link } from 'react-router-dom';
 import { Button } from 'ui/components/button';
 import Text from 'ui/components/text';
 import { FittingCardList } from './components/fitting-card-list';
 
 export function Fittings() {
+  const { canWrite } = usePermissions();
   return (
     <div className='flex flex-col gap-6 pb-16'>
       <div className='-mx-2.5 flex flex-wrap items-center justify-between gap-3 border-b border-textColor bg-bgColor px-2.5 py-3'>
         <Text variant='uppercase' size='large'>
           fittings
         </Text>
-        <Button size='lg' variant='main' className='uppercase' asChild>
-          <Link to={ROUTES.addFitting}>create new</Link>
-        </Button>
+        {canWrite(SECTION.fittings) && (
+          <Button size='lg' variant='main' className='uppercase' asChild>
+            <Link to={ROUTES.addFitting}>create new</Link>
+          </Button>
+        )}
       </div>
 
       <FittingCardList />

--- a/src/components/managers/hero/components/index.tsx
+++ b/src/components/managers/hero/components/index.tsx
@@ -1,5 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
+import { SECTION } from 'constants/routes';
 import { useBlockNavigation } from 'hooks/useBlockNavigation';
 import { useSnackBarStore } from 'lib/stores/store';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -23,6 +25,7 @@ import { useProductSelection } from './useProductSelection';
 export function Hero() {
   const { data: heroData, isLoading, isError, refetch } = useHero();
   const saveHero = useSaveHero();
+  const { canWrite } = usePermissions();
   const { showMessage } = useSnackBarStore();
   const entityRefs = useRef<{ [uid: string]: HTMLDivElement | null }>({});
   const productsByEntityUidRef = useRef<Record<string, any[]>>({});
@@ -272,28 +275,30 @@ export function Hero() {
               </span>
             )}
           </div>
-          <div className='flex items-center gap-2'>
-            <Button
-              type='button'
-              variant='secondary'
-              size='lg'
-              className='uppercase'
-              onClick={() => setNavOpen(true)}
-            >
-              nav featured
-            </Button>
-            <Button
-              size='lg'
-              variant='main'
-              type='button'
-              onClick={handlePublishClick}
-              disabled={isLoading || isError || form.formState.isSubmitting || saveHero.isPending}
-              loading={saveHero.isPending}
-              className='uppercase'
-            >
-              save
-            </Button>
-          </div>
+          {canWrite(SECTION.hero) && (
+            <div className='flex items-center gap-2'>
+              <Button
+                type='button'
+                variant='secondary'
+                size='lg'
+                className='uppercase'
+                onClick={() => setNavOpen(true)}
+              >
+                nav featured
+              </Button>
+              <Button
+                size='lg'
+                variant='main'
+                type='button'
+                onClick={handlePublishClick}
+                disabled={isLoading || isError || form.formState.isSubmitting || saveHero.isPending}
+                loading={saveHero.isPending}
+                className='uppercase'
+              >
+                save
+              </Button>
+            </div>
+          )}
         </div>
 
         {isLoading ? (

--- a/src/components/managers/media/index.tsx
+++ b/src/components/managers/media/index.tsx
@@ -1,4 +1,6 @@
 import { common_MediaFull } from 'api/proto-http/admin';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
+import { SECTION } from 'constants/routes';
 import { useEffect, useRef, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { Button } from 'ui/components/button';
@@ -42,6 +44,7 @@ export function MediaManager({
   const [videoSizes, setVideoSizes] = useState<Record<number, VideoSize>>({});
 
   const pendingFilesHook = usePendingFiles();
+  const { canWrite } = usePermissions();
 
   // Standalone page shows a header + toolbar; the embedded selector (selectionMode) stays minimal.
   const isStandalone = !selectionMode;
@@ -128,7 +131,9 @@ export function MediaManager({
             )}
           </div>
           <div className='flex flex-wrap items-center gap-2'>
-            {showFilters && <Filter type={type} order={order} setType={setType} setOrder={setOrder} />}
+            {showFilters && (
+              <Filter type={type} order={order} setType={setType} setOrder={setOrder} />
+            )}
             {pendingPlate}
             <input
               ref={fileInputRef}
@@ -138,9 +143,11 @@ export function MediaManager({
               className='hidden'
               onChange={handleFileChange}
             />
-            <Button variant='main' size='lg' onClick={handleUploadClick}>
-              upload
-            </Button>
+            {canWrite(SECTION.media) && (
+              <Button variant='main' size='lg' onClick={handleUploadClick}>
+                upload
+              </Button>
+            )}
           </div>
         </div>
       ) : (

--- a/src/components/managers/membership/hacker/components/accounts.tsx
+++ b/src/components/managers/membership/hacker/components/accounts.tsx
@@ -1,3 +1,5 @@
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
+import { SECTION } from 'constants/routes';
 import { useNavigate } from 'react-router-dom';
 import { Button } from 'ui/components/button';
 import Text from 'ui/components/text';
@@ -9,6 +11,7 @@ export function HackerAccounts() {
   const { data, isLoading } = useHackerAccounts();
   const revoke = useRevokeHackerStatus();
   const navigate = useNavigate();
+  const { canWrite } = usePermissions();
 
   const members = data?.members ?? [];
 
@@ -60,13 +63,17 @@ export function HackerAccounts() {
                     <Button variant='underline' onClick={() => navigate(`/members/${m.userId}`)}>
                       view
                     </Button>
-                    <span className='px-1'>·</span>
-                    <Button
-                      variant='underline'
-                      onClick={() => revoke.mutate({ userId: m.userId! })}
-                    >
-                      revoke
-                    </Button>
+                    {canWrite(SECTION.members) && (
+                      <>
+                        <span className='px-1'>·</span>
+                        <Button
+                          variant='underline'
+                          onClick={() => revoke.mutate({ userId: m.userId! })}
+                        >
+                          revoke
+                        </Button>
+                      </>
+                    )}
                   </td>
                 </tr>
               ))

--- a/src/components/managers/membership/hacker/components/invites.tsx
+++ b/src/components/managers/membership/hacker/components/invites.tsx
@@ -1,4 +1,6 @@
 import { GenerateHackerInviteResponse } from 'api/proto-http/admin';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
+import { SECTION } from 'constants/routes';
 import { useState } from 'react';
 import { Button } from 'ui/components/button';
 import { CopyToClipboard } from 'ui/components/copyToClipboard';
@@ -16,6 +18,7 @@ export function HackerInvites() {
   const revoke = useRevokeHackerInvite();
   const [activeOnly, setActiveOnly] = useState(true);
   const { data, isLoading } = useHackerInvites(activeOnly);
+  const { canWrite } = usePermissions();
 
   const [email, setEmail] = useState('');
   const [expiresInDays, setExpiresInDays] = useState('14');
@@ -45,36 +48,40 @@ export function HackerInvites() {
       </Text>
 
       {/* Generate */}
-      <div className='flex flex-wrap gap-3 items-end'>
-        <div className='flex flex-col gap-1'>
-          <Text variant='inactive' size='small'>
-            Pre-bound email (optional)
-          </Text>
-          <Input
-            name='inviteEmail'
-            type='email'
-            placeholder='someone@example.com'
-            value={email}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
-            className='w-56'
-          />
+      {canWrite(SECTION.members) && (
+        <div className='flex flex-wrap gap-3 items-end'>
+          <div className='flex flex-col gap-1'>
+            <Text variant='inactive' size='small'>
+              Pre-bound email (optional)
+            </Text>
+            <Input
+              name='inviteEmail'
+              type='email'
+              placeholder='someone@example.com'
+              value={email}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
+              className='w-56'
+            />
+          </div>
+          <div className='flex flex-col gap-1'>
+            <Text variant='inactive' size='small'>
+              Expires in (days)
+            </Text>
+            <Input
+              name='expiresInDays'
+              type='number'
+              value={expiresInDays}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setExpiresInDays(e.target.value)
+              }
+              className='w-24'
+            />
+          </div>
+          <Button variant='main' size='lg' onClick={handleGenerate} loading={generate.isPending}>
+            Generate invite
+          </Button>
         </div>
-        <div className='flex flex-col gap-1'>
-          <Text variant='inactive' size='small'>
-            Expires in (days)
-          </Text>
-          <Input
-            name='expiresInDays'
-            type='number'
-            value={expiresInDays}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setExpiresInDays(e.target.value)}
-            className='w-24'
-          />
-        </div>
-        <Button variant='main' size='lg' onClick={handleGenerate} loading={generate.isPending}>
-          Generate invite
-        </Button>
-      </div>
+      )}
 
       {lastGenerated && (
         <div className='flex flex-col gap-1 border border-textColor bg-highlightColor/10 p-3'>
@@ -151,7 +158,7 @@ export function HackerInvites() {
                       <Text size='small'>{statusLabel}</Text>
                     </td>
                     <td className='border border-textColor text-center px-2'>
-                      {inv.active && (
+                      {inv.active && canWrite(SECTION.members) && (
                         <Button
                           variant='underline'
                           onClick={() => revoke.mutate({ inviteId: inv.id! })}

--- a/src/components/managers/membership/member-details/components/member-actions.tsx
+++ b/src/components/managers/membership/member-details/components/member-actions.tsx
@@ -1,4 +1,6 @@
 import { Member, TierCode } from 'api/proto-http/admin';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
+import { SECTION } from 'constants/routes';
 import { useState } from 'react';
 import { ConfirmationModal } from 'ui/components/confirmation-modal';
 import { Button } from 'ui/components/button';
@@ -22,6 +24,7 @@ export function MemberActions({ member }: { member: Member }) {
   const softDelete = useSoftDeleteMember();
   const hardErase = useHardEraseMember();
   const revokeHacker = useRevokeHackerStatus();
+  const { canWrite } = usePermissions();
 
   const [newTier, setNewTier] = useState<TierCode>(member.currentTier ?? 'TIER_CODE_MEMBER');
   const [reason, setReason] = useState('');
@@ -38,6 +41,8 @@ export function MemberActions({ member }: { member: Member }) {
   const tierChanged = newTier !== member.currentTier;
   const statusChanged = status !== member.status;
   const isHacker = member.currentTier === 'TIER_CODE_HACKER';
+
+  if (!canWrite(SECTION.members)) return null;
 
   const handleOverride = () => {
     if (!tierChanged || !reason.trim()) return;
@@ -137,7 +142,12 @@ export function MemberActions({ member }: { member: Member }) {
 
       {/* Communication + destructive */}
       <div className='flex flex-wrap gap-2'>
-        <Button variant='secondary' size='lg' onClick={() => setEmailOpen(true)} disabled={isErased}>
+        <Button
+          variant='secondary'
+          size='lg'
+          onClick={() => setEmailOpen(true)}
+          disabled={isErased}
+        >
           Send custom email
         </Button>
         <Button

--- a/src/components/managers/membership/tier-config/page.tsx
+++ b/src/components/managers/membership/tier-config/page.tsx
@@ -1,5 +1,6 @@
 import { TierConfigEntry } from 'api/proto-http/admin';
-import { ROUTES } from 'constants/routes';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
+import { ROUTES, SECTION } from 'constants/routes';
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Button } from 'ui/components/button';
@@ -12,6 +13,7 @@ export function TierConfig() {
   const { data, isLoading, isError, error } = useTierConfig();
   const update = useUpdateTierConfig();
   const [entries, setEntries] = useState<TierConfigEntry[]>([]);
+  const { canWrite } = usePermissions();
 
   useEffect(() => {
     if (data?.entries) setEntries(data.entries.map((e) => ({ ...e })));
@@ -146,7 +148,7 @@ export function TierConfig() {
         ))}
       </div>
 
-      {entries.length > 0 && (
+      {canWrite(SECTION.members) && entries.length > 0 && (
         <div className='fixed inset-x-0 bottom-0 z-40 flex items-center justify-between gap-3 border-t border-textColor bg-bgColor px-3 py-2'>
           <Text variant='inactive' size='small'>
             {dirty ? 'unsaved changes' : ' '}

--- a/src/components/managers/model/components/index.tsx
+++ b/src/components/managers/model/components/index.tsx
@@ -1,12 +1,13 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { common_Model } from 'api/proto-http/admin';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
 import { FittingsReadonlyList } from 'components/managers/fittings/components/fittings-readonly-list';
 import {
   useCreateModel,
   useUpdateModel,
 } from 'components/managers/models/components/useModelQuery';
 import { genderOptions } from 'constants/filter';
-import { ROUTES } from 'constants/routes';
+import { ROUTES, SECTION } from 'constants/routes';
 import { useSnackBarStore } from 'lib/stores/store';
 import { useForm } from 'react-hook-form';
 import { Link, useNavigate } from 'react-router-dom';
@@ -59,6 +60,7 @@ export function ModelForm({
   const navigate = useNavigate();
   const createModel = useCreateModel();
   const updateModel = useUpdateModel();
+  const { canWrite } = usePermissions();
 
   const form = useForm<ModelFormData>({
     resolver: zodResolver(modelSchema),
@@ -147,17 +149,19 @@ export function ModelForm({
           >
             cancel
           </Button>
-          <Button
-            type='button'
-            variant='main'
-            size='lg'
-            className='uppercase cursor-pointer'
-            disabled={(isEditMode && !form.formState.isDirty) || form.formState.isSubmitting}
-            loading={form.formState.isSubmitting}
-            onClick={() => form.handleSubmit(handleSubmit)()}
-          >
-            {isEditMode ? 'save' : 'add'}
-          </Button>
+          {canWrite(SECTION.models) && (
+            <Button
+              type='button'
+              variant='main'
+              size='lg'
+              className='uppercase cursor-pointer'
+              disabled={(isEditMode && !form.formState.isDirty) || form.formState.isSubmitting}
+              loading={form.formState.isSubmitting}
+              onClick={() => form.handleSubmit(handleSubmit)()}
+            >
+              {isEditMode ? 'save' : 'add'}
+            </Button>
+          )}
         </div>
       </div>
     </Form>

--- a/src/components/managers/models/components/model-card-list.tsx
+++ b/src/components/managers/models/components/model-card-list.tsx
@@ -1,4 +1,6 @@
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
 import { genderOptions } from 'constants/filter';
+import { SECTION } from 'constants/routes';
 import { useDictionary } from 'lib/providers/dictionary-provider';
 import { useSnackBarStore } from 'lib/stores/store';
 import { useEffect, useState } from 'react';
@@ -25,6 +27,7 @@ export function ModelCardList() {
   const { dictionary } = useDictionary();
   const { showMessage } = useSnackBarStore();
   const deleteModel = useDeleteModel();
+  const canEdit = usePermissions().canWrite(SECTION.models);
 
   const [gender, setGender] = useState<string>(ALL);
   const [name, setName] = useState('');
@@ -133,17 +136,19 @@ export function ModelCardList() {
                     {insert?.measurements?.length ?? 0} meas.
                   </Text>
                 </div>
-                <Button
-                  type='button'
-                  aria-label='delete model'
-                  onClick={(e: React.MouseEvent) => {
-                    e.stopPropagation();
-                    setPendingDelete({ id, name: insert?.name || `model ${id}` });
-                  }}
-                  className='absolute right-1 top-1 z-20 border border-textColor bg-bgColor px-1.5 leading-none opacity-100 transition-opacity lg:opacity-0 lg:group-hover:opacity-100'
-                >
-                  ✕
-                </Button>
+                {canEdit && (
+                  <Button
+                    type='button'
+                    aria-label='delete model'
+                    onClick={(e: React.MouseEvent) => {
+                      e.stopPropagation();
+                      setPendingDelete({ id, name: insert?.name || `model ${id}` });
+                    }}
+                    className='absolute right-1 top-1 z-20 border border-textColor bg-bgColor px-1.5 leading-none opacity-100 transition-opacity lg:opacity-0 lg:group-hover:opacity-100'
+                  >
+                    ✕
+                  </Button>
+                )}
               </div>
             );
           })}

--- a/src/components/managers/models/index.tsx
+++ b/src/components/managers/models/index.tsx
@@ -1,19 +1,23 @@
-import { ROUTES } from 'constants/routes';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
+import { ROUTES, SECTION } from 'constants/routes';
 import { Link } from 'react-router-dom';
 import { Button } from 'ui/components/button';
 import Text from 'ui/components/text';
 import { ModelCardList } from './components/model-card-list';
 
 export function Models() {
+  const { canWrite } = usePermissions();
   return (
     <div className='flex flex-col gap-6 pb-16'>
       <div className='-mx-2.5 flex flex-wrap items-center justify-between gap-3 border-b border-textColor bg-bgColor px-2.5 py-3'>
         <Text variant='uppercase' size='large'>
           models
         </Text>
-        <Button size='lg' variant='main' className='uppercase' asChild>
-          <Link to={ROUTES.addModel}>create new</Link>
-        </Button>
+        {canWrite(SECTION.models) && (
+          <Button size='lg' variant='main' className='uppercase' asChild>
+            <Link to={ROUTES.addModel}>create new</Link>
+          </Button>
+        )}
       </div>
 
       <ModelCardList />

--- a/src/components/managers/orders-catalog/page.tsx
+++ b/src/components/managers/orders-catalog/page.tsx
@@ -1,6 +1,7 @@
 import { common_OrderStatusEnum } from 'api/proto-http/admin';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
 import { statusOptions } from 'constants/filter';
-import { ROUTES } from 'constants/routes';
+import { ROUTES, SECTION } from 'constants/routes';
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Button } from 'ui/components/button';
@@ -21,6 +22,7 @@ export function OrdersCatalog() {
   const [debouncedEmail, setDebouncedEmail] = useState<string>('');
   const [debouncedOrderSearch, setDebouncedOrderSearch] = useState<string>('');
   const [showReport, setShowReport] = useState(false);
+  const { canWrite } = usePermissions();
 
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedEmail(email), 500);
@@ -43,7 +45,9 @@ export function OrdersCatalog() {
   const busy = isLoading || isFetchingNextPage;
 
   const toggleSort = () =>
-    setOrderFactor((prev) => (prev === 'ORDER_FACTOR_ASC' ? 'ORDER_FACTOR_DESC' : 'ORDER_FACTOR_ASC'));
+    setOrderFactor((prev) =>
+      prev === 'ORDER_FACTOR_ASC' ? 'ORDER_FACTOR_DESC' : 'ORDER_FACTOR_ASC',
+    );
 
   const hasFilters = !!email || !!orderSearch || !!status;
   const resetFilters = () => {
@@ -75,9 +79,11 @@ export function OrdersCatalog() {
           >
             stock report
           </Button>
-          <Button variant='main' size='lg' className='uppercase' asChild>
-            <Link to={ROUTES.customOrders}>create custom order</Link>
-          </Button>
+          {canWrite(SECTION.orders) && (
+            <Button variant='main' size='lg' className='uppercase' asChild>
+              <Link to={ROUTES.customOrders}>create custom order</Link>
+            </Button>
+          )}
         </div>
       </div>
 
@@ -121,9 +127,7 @@ export function OrdersCatalog() {
             label='Status'
             options={[{ value: 'all', label: 'all' }, ...statusOptions]}
             value={status || 'all'}
-            onChange={(v: string) =>
-              setStatus(v === 'all' ? '' : (v as common_OrderStatusEnum))
-            }
+            onChange={(v: string) => setStatus(v === 'all' ? '' : (v as common_OrderStatusEnum))}
             disabled={busy}
             compact
           />

--- a/src/components/managers/product/components/index.tsx
+++ b/src/components/managers/product/components/index.tsx
@@ -1,8 +1,9 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { adminService } from 'api/api';
 import { common_ProductFull, common_SizeWithMeasurementInsert } from 'api/proto-http/admin';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
 import { FittingsReadonlyList } from 'components/managers/fittings/components/fittings-readonly-list';
-import { ROUTES } from 'constants/routes';
+import { ROUTES, SECTION } from 'constants/routes';
 import { useSnackBarStore } from 'lib/stores/store';
 import { useEffect, useState } from 'react';
 import { FieldErrors, useForm } from 'react-hook-form';
@@ -42,6 +43,7 @@ export function ProductForm({
   const [mediaClearKey, setMediaClearKey] = useState(0);
   const editMode = isEditMode || isAddingProduct;
   const navigate = useNavigate();
+  const { canWrite } = usePermissions();
 
   const initialValues =
     product && (!isAddingProduct || isCopyMode) ? mapProductFullToFormData(product) : defaultData;
@@ -239,42 +241,44 @@ export function ProductForm({
         <Text variant='inactive' size='small'>
           {editMode && isFormChanged ? 'unsaved changes' : ' '}
         </Text>
-        <div className='flex items-center gap-2'>
-          {!editMode ? (
-            <Button
-              type='button'
-              variant='main'
-              size='lg'
-              className='uppercase cursor-pointer'
-              onClick={() => onEditModeChange(true)}
-            >
-              edit
-            </Button>
-          ) : (
-            <>
-              <Button
-                type='button'
-                variant='secondary'
-                size='lg'
-                className='uppercase cursor-pointer'
-                onClick={handleCancel}
-              >
-                cancel
-              </Button>
+        {canWrite(SECTION.products) && (
+          <div className='flex items-center gap-2'>
+            {!editMode ? (
               <Button
                 type='button'
                 variant='main'
                 size='lg'
                 className='uppercase cursor-pointer'
-                disabled={(isEditMode && !isFormChanged) || form.formState.isSubmitting}
-                loading={form.formState.isSubmitting}
-                onClick={submitForm}
+                onClick={() => onEditModeChange(true)}
               >
-                {isAddingProduct ? (isCopyMode ? 'create copy' : 'create') : 'save'}
+                edit
               </Button>
-            </>
-          )}
-        </div>
+            ) : (
+              <>
+                <Button
+                  type='button'
+                  variant='secondary'
+                  size='lg'
+                  className='uppercase cursor-pointer'
+                  onClick={handleCancel}
+                >
+                  cancel
+                </Button>
+                <Button
+                  type='button'
+                  variant='main'
+                  size='lg'
+                  className='uppercase cursor-pointer'
+                  disabled={(isEditMode && !isFormChanged) || form.formState.isSubmitting}
+                  loading={form.formState.isSubmitting}
+                  onClick={submitForm}
+                >
+                  {isAddingProduct ? (isCopyMode ? 'create copy' : 'create') : 'save'}
+                </Button>
+              </>
+            )}
+          </div>
+        )}
       </div>
     </Form>
   );

--- a/src/components/managers/products-catalog/components/product-item.tsx
+++ b/src/components/managers/products-catalog/components/product-item.tsx
@@ -1,7 +1,8 @@
 import { CheckIcon } from '@radix-ui/react-icons';
 import { adminService } from 'api/api';
 import { common_Product } from 'api/proto-http/admin';
-import { ROUTES } from 'constants/routes';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
+import { ROUTES, SECTION } from 'constants/routes';
 import { isVideo } from 'lib/features/filterContentType';
 import { useSnackBarStore } from 'lib/stores/store';
 import { cn } from 'lib/utility';
@@ -25,6 +26,7 @@ export function ProductItem({
   const { showMessage } = useSnackBarStore();
   const [confirmDelete, setConfirmDelete] = useState<number | undefined>(undefined);
   const navigate = useNavigate();
+  const canEdit = usePermissions().canWrite(SECTION.products);
 
   async function handleDeleteItem(id: number | undefined, e: React.MouseEvent) {
     e.stopPropagation();
@@ -71,23 +73,27 @@ export function ProductItem({
             </Text>
           </span>
         )}
-        <Button
-          onClick={(e: React.MouseEvent) => handleDeleteItem(product.id, e)}
-          className={cn(
-            'absolute top-1 right-1 z-30 border border-textColor bg-bgColor px-1 leading-none block md:hidden md:group-hover:block',
-            { '!block !bg-textColor !text-bgColor': confirmDelete === product.id },
-          )}
-        >
-          {confirmDelete === product.id ? <CheckIcon /> : '[x]'}
-        </Button>
-        <Button
-          size='lg'
-          className='absolute bottom-0 left-0 z-30'
-          variant='main'
-          onClick={(e: React.MouseEvent) => handleCopyProduct(product.id, e)}
-        >
-          copy
-        </Button>
+        {canEdit && (
+          <Button
+            onClick={(e: React.MouseEvent) => handleDeleteItem(product.id, e)}
+            className={cn(
+              'absolute top-1 right-1 z-30 border border-textColor bg-bgColor px-1 leading-none block md:hidden md:group-hover:block',
+              { '!block !bg-textColor !text-bgColor': confirmDelete === product.id },
+            )}
+          >
+            {confirmDelete === product.id ? <CheckIcon /> : '[x]'}
+          </Button>
+        )}
+        {canEdit && (
+          <Button
+            size='lg'
+            className='absolute bottom-0 left-0 z-30'
+            variant='main'
+            onClick={(e: React.MouseEvent) => handleCopyProduct(product.id, e)}
+          >
+            copy
+          </Button>
+        )}
         {isHidden && <Overlay cover='container' />}
       </div>
       <Text className='w-full break-words' variant='underLineWithColor'>

--- a/src/components/managers/products-catalog/page.tsx
+++ b/src/components/managers/products-catalog/page.tsx
@@ -1,7 +1,8 @@
 import { adminService } from 'api/api';
 import { common_Product } from 'api/proto-http/admin';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
 import { DEFAULT_PRODUCT_LIMIT } from 'constants/filter';
-import { ROUTES } from 'constants/routes';
+import { ROUTES, SECTION } from 'constants/routes';
 import { useDictionary } from 'lib/providers/dictionary-provider';
 import debounce from 'lodash/debounce';
 import { useCallback, useEffect, useState } from 'react';
@@ -23,6 +24,7 @@ export default function ProductsCatalog() {
   const [count, setCount] = useState({ loaded: 0, hasMore: false });
   const { dictionary } = useDictionary();
   const baseCurrency = dictionary?.baseCurrency || 'USD';
+  const { canWrite } = usePermissions();
 
   function toggleModal() {
     setIsModalOpen(!isModalOpen);
@@ -95,14 +97,11 @@ export default function ProductsCatalog() {
           >
             filter +
           </Button>
-          <Button
-            variant='main'
-            size='lg'
-            className='uppercase'
-            onClick={handleCreateNewProduct}
-          >
-            create new
-          </Button>
+          {canWrite(SECTION.products) && (
+            <Button variant='main' size='lg' className='uppercase' onClick={handleCreateNewProduct}>
+              create new
+            </Button>
+          )}
         </div>
       </div>
 

--- a/src/components/managers/promo/components/promo-table.tsx
+++ b/src/components/managers/promo/components/promo-table.tsx
@@ -1,5 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
 import { formatDateShort } from 'components/managers/orders-catalog/components/utility';
+import { SECTION } from 'constants/routes';
 import { cn } from 'lib/utility';
 import { useForm } from 'react-hook-form';
 import { Button } from 'ui/components/button';
@@ -26,6 +28,9 @@ export function PromoTable({ promos }: { promos: Promo[] }) {
     submitCreate,
   } = usePromo();
 
+  const { canWrite } = usePermissions();
+  const canEdit = canWrite(SECTION.promo);
+
   const form = useForm<PromoDraftSchema>({
     resolver: zodResolver(promoDraftSchema),
     defaultValues: emptyPromoDraft,
@@ -41,6 +46,7 @@ export function PromoTable({ promos }: { promos: Promo[] }) {
             <CheckboxCommon
               name='allowed'
               checked={isAllowed}
+              disabled={!canEdit}
               onChange={() => handleDisablePromo(p.promoCodeInsert?.code || '')}
             />
           </div>
@@ -78,6 +84,7 @@ export function PromoTable({ promos }: { promos: Promo[] }) {
       ),
     },
   ];
+  const visibleColumns = COLUMNS.filter((c) => c.label !== 'Delete' || canEdit);
   return (
     <div className='w-full flex flex-col gap-4'>
       <ConfirmationModal
@@ -87,24 +94,26 @@ export function PromoTable({ promos }: { promos: Promo[] }) {
       >
         {confirm.message}
       </ConfirmationModal>
-      <div className='flex justify-end'>
-        <Button
-          variant='main'
-          size='lg'
-          onClick={() => {
-            startCreate();
-            form.reset(emptyPromoDraft);
-          }}
-          disabled={isCreating}
-        >
-          Create
-        </Button>
-      </div>
+      {canEdit && (
+        <div className='flex justify-end'>
+          <Button
+            variant='main'
+            size='lg'
+            onClick={() => {
+              startCreate();
+              form.reset(emptyPromoDraft);
+            }}
+            disabled={isCreating}
+          >
+            Create
+          </Button>
+        </div>
+      )}
       <div className='overflow-x-auto w-full'>
         <table className='w-full border-collapse border-2 border-textColor min-w-max'>
           <thead className='bg-textInactiveColor h-7 overflow-x-scroll'>
             <tr className='border-b border-textColor'>
-              {COLUMNS.map((col) => (
+              {visibleColumns.map((col) => (
                 <th
                   key={col.label}
                   className='text-center min-w-1 border border-r border-textColor'
@@ -123,7 +132,7 @@ export function PromoTable({ promos }: { promos: Promo[] }) {
                 key={p.promoCodeInsert?.code}
                 className={cn(!p.promoCodeInsert?.allowed && 'bg-textInactiveColor')}
               >
-                {COLUMNS.map((col) => (
+                {visibleColumns.map((col) => (
                   <td
                     key={col.label}
                     className={cn('border border-r border-textColor text-center px-2', {

--- a/src/components/managers/settings/index.tsx
+++ b/src/components/managers/settings/index.tsx
@@ -1,6 +1,8 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { adminService } from 'api/api';
 import { UpdateSettingsRequest } from 'api/proto-http/admin';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
+import { SECTION } from 'constants/routes';
 import { useDictionary } from 'lib/providers/dictionary-provider';
 import { useSnackBarStore } from 'lib/stores/store';
 import { useMemo, useState } from 'react';
@@ -49,6 +51,7 @@ export function Settings() {
   const { dictionary, refetch } = useDictionary();
   const showMessage = useSnackBarStore((state) => state.showMessage);
   const [isLoading, setIsLoading] = useState(false);
+  const { canWrite } = usePermissions();
 
   const initialValues = useMemo(
     () => (dictionary ? transformDictionaryToSettings(dictionary) : defaultSettings),
@@ -143,22 +146,24 @@ export function Settings() {
         </Section>
       </form>
 
-      <div className='fixed inset-x-0 bottom-0 z-40 flex items-center justify-between gap-3 border-t border-textColor bg-bgColor px-3 py-2'>
-        <Text variant='inactive' size='small'>
-          {isDirty ? 'unsaved changes' : ' '}
-        </Text>
-        <Button
-          type='button'
-          size='lg'
-          variant='main'
-          className='uppercase cursor-pointer'
-          disabled={isLoading || !isDirty}
-          loading={isLoading}
-          onClick={() => form.handleSubmit(handleSave)()}
-        >
-          save
-        </Button>
-      </div>
+      {canWrite(SECTION.settings) && (
+        <div className='fixed inset-x-0 bottom-0 z-40 flex items-center justify-between gap-3 border-t border-textColor bg-bgColor px-3 py-2'>
+          <Text variant='inactive' size='small'>
+            {isDirty ? 'unsaved changes' : ' '}
+          </Text>
+          <Button
+            type='button'
+            size='lg'
+            variant='main'
+            className='uppercase cursor-pointer'
+            disabled={isLoading || !isDirty}
+            loading={isLoading}
+            onClick={() => form.handleSubmit(handleSave)()}
+          >
+            save
+          </Button>
+        </div>
+      )}
     </Form>
   );
 }

--- a/src/components/managers/shipping/index.tsx
+++ b/src/components/managers/shipping/index.tsx
@@ -1,5 +1,7 @@
 import { common_ShipmentCarrier } from 'api/proto-http/admin';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
 import { CURRENCIES } from 'constants/constants';
+import { SECTION } from 'constants/routes';
 import { useDictionary } from 'lib/providers/dictionary-provider';
 import { cn } from 'lib/utility';
 import { useMemo, useState } from 'react';
@@ -19,6 +21,7 @@ export function Shipping() {
   const [currency, setCurrency] = useState(currencyOptions[0]?.value ?? '');
   const [upsertOpen, setUpsertOpen] = useState(false);
   const [editingCarrierId, setEditingCarrierId] = useState<number | undefined>();
+  const { canWrite } = usePermissions();
 
   const COLUMNS: {
     label: string;
@@ -83,9 +86,11 @@ export function Shipping() {
         <Text variant='uppercase' size='large' className='font-bold'>
           shipment carriers
         </Text>
-        <Button type='button' size='lg' variant='main' onClick={handleCreateCarrier}>
-          add
-        </Button>
+        {canWrite(SECTION.shipping) && (
+          <Button type='button' size='lg' variant='main' onClick={handleCreateCarrier}>
+            add
+          </Button>
+        )}
       </div>
       <div className='overflow-x-auto w-full'>
         <table className='w-full border-collapse border-2 border-textColor min-w-max'>

--- a/src/components/managers/tech-card/components/index.tsx
+++ b/src/components/managers/tech-card/components/index.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { common_TechCard } from 'api/proto-http/admin';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
 import {
   useCreateTechCard,
   useUpdateTechCard,
@@ -14,7 +15,7 @@ import {
   techCardMeasurementUnitOptions,
   techCardStageOptions,
 } from 'constants/filter';
-import { ROUTES } from 'constants/routes';
+import { ROUTES, SECTION } from 'constants/routes';
 import { useSnackBarStore } from 'lib/stores/store';
 import { useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
@@ -122,6 +123,7 @@ export function TechCardForm({
   const navigate = useNavigate();
   const createTechCard = useCreateTechCard();
   const updateTechCard = useUpdateTechCard();
+  const { canWrite } = usePermissions();
 
   const numId = id ? parseInt(id, 10) : undefined;
 
@@ -250,43 +252,44 @@ export function TechCardForm({
                 </Link>
               </Button>
             )}
-            {frozen ? (
-              <Button
-                type='button'
-                variant='main'
-                size='lg'
-                className='uppercase'
-                loading={saving}
-                onClick={() => submitWithApproval(DRAFT)}
-              >
-                re-open to draft
-              </Button>
-            ) : (
-              <>
-                <Button
-                  type='button'
-                  variant='secondary'
-                  size='lg'
-                  className='uppercase'
-                  title={canRelease ? '' : 'Approve every colourway lab-dip before release'}
-                  disabled={!canRelease || saving}
-                  onClick={() => submitWithApproval(RELEASED)}
-                >
-                  release ▸
-                </Button>
+            {canWrite(SECTION.techCards) &&
+              (frozen ? (
                 <Button
                   type='button'
                   variant='main'
                   size='lg'
                   className='uppercase'
-                  disabled={(isEditMode && !form.formState.isDirty) || saving}
                   loading={saving}
-                  onClick={save}
+                  onClick={() => submitWithApproval(DRAFT)}
                 >
-                  {isEditMode ? 'save' : 'add'}
+                  re-open to draft
                 </Button>
-              </>
-            )}
+              ) : (
+                <>
+                  <Button
+                    type='button'
+                    variant='secondary'
+                    size='lg'
+                    className='uppercase'
+                    title={canRelease ? '' : 'Approve every colourway lab-dip before release'}
+                    disabled={!canRelease || saving}
+                    onClick={() => submitWithApproval(RELEASED)}
+                  >
+                    release ▸
+                  </Button>
+                  <Button
+                    type='button'
+                    variant='main'
+                    size='lg'
+                    className='uppercase'
+                    disabled={(isEditMode && !form.formState.isDirty) || saving}
+                    loading={saving}
+                    onClick={save}
+                  >
+                    {isEditMode ? 'save' : 'add'}
+                  </Button>
+                </>
+              ))}
           </div>
         </div>
 

--- a/src/components/managers/tech-cards/components/tech-card-list.tsx
+++ b/src/components/managers/tech-cards/components/tech-card-list.tsx
@@ -1,5 +1,7 @@
 import { common_TechCardStage } from 'api/proto-http/admin';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
 import { techCardStageOptions } from 'constants/filter';
+import { SECTION } from 'constants/routes';
 import { useSnackBarStore } from 'lib/stores/store';
 import { useEffect, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
@@ -42,6 +44,7 @@ export function TechCardList() {
   const navigate = useNavigate();
   const { showMessage } = useSnackBarStore();
   const deleteTechCard = useDeleteTechCard();
+  const canEdit = usePermissions().canWrite(SECTION.techCards);
 
   const [name, setName] = useState('');
   const [stage, setStage] = useState<common_TechCardStage>(ALL_STAGES);
@@ -162,17 +165,19 @@ export function TechCardList() {
                       </Text>
                     </td>
                     <td className='px-2 py-2'>
-                      <Button
-                        type='button'
-                        aria-label='delete tech card'
-                        onClick={(e: React.MouseEvent) => {
-                          e.stopPropagation();
-                          setPendingDelete({ id });
-                        }}
-                        className='border border-textColor bg-bgColor px-1.5 leading-none'
-                      >
-                        ✕
-                      </Button>
+                      {canEdit && (
+                        <Button
+                          type='button'
+                          aria-label='delete tech card'
+                          onClick={(e: React.MouseEvent) => {
+                            e.stopPropagation();
+                            setPendingDelete({ id });
+                          }}
+                          className='border border-textColor bg-bgColor px-1.5 leading-none'
+                        >
+                          ✕
+                        </Button>
+                      )}
                     </td>
                   </tr>
                 );

--- a/src/components/managers/tech-cards/index.tsx
+++ b/src/components/managers/tech-cards/index.tsx
@@ -1,19 +1,23 @@
-import { ROUTES } from 'constants/routes';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
+import { ROUTES, SECTION } from 'constants/routes';
 import { Link } from 'react-router-dom';
 import { Button } from 'ui/components/button';
 import Text from 'ui/components/text';
 import { TechCardList } from './components/tech-card-list';
 
 export function TechCards() {
+  const { canWrite } = usePermissions();
   return (
     <div className='flex flex-col gap-6 pb-16'>
       <div className='-mx-2.5 flex flex-wrap items-center justify-between gap-3 border-b border-textColor bg-bgColor px-2.5 py-3'>
         <Text variant='uppercase' size='large'>
           tech cards
         </Text>
-        <Button size='lg' variant='main' className='uppercase' asChild>
-          <Link to={ROUTES.addTechCard}>create new</Link>
-        </Button>
+        {canWrite(SECTION.techCards) && (
+          <Button size='lg' variant='main' className='uppercase' asChild>
+            <Link to={ROUTES.addTechCard}>create new</Link>
+          </Button>
+        )}
       </div>
 
       <TechCardList />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,13 +6,14 @@ import { Archive } from 'components/managers/archive';
 import { Archives } from 'components/managers/archives';
 import { CustomerPage } from 'components/managers/customer-support';
 import { Shipping } from 'components/managers/shipping';
-import { ROUTES } from 'constants/routes';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
+import { ROUTES, SECTION } from 'constants/routes';
 import { ContextProvider } from 'context';
 import { DictionaryProvider } from 'lib/providers/dictionary-provider';
 import { lazy, StrictMode, Suspense } from 'react';
 import { createRoot } from 'react-dom/client';
 import { ErrorBoundary, type FallbackProps } from 'react-error-boundary';
-import { BrowserRouter, Outlet, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Navigate, Outlet, Route, Routes } from 'react-router-dom';
 import { Layout } from 'ui/layout';
 import './global.css';
 
@@ -121,6 +122,20 @@ const LoadingFallback = () => (
   </div>
 );
 
+// The /main landing is analytics. Scoped accounts without analytics access are
+// redirected to the first section they can open, instead of a permission error.
+const AnalyticsHome = () => {
+  const { canRead, homeRoute, isLoading } = usePermissions();
+  if (isLoading) return <LoadingFallback />;
+  if (canRead(SECTION.analytics)) return <Analitic />;
+  if (homeRoute && homeRoute !== ROUTES.main) return <Navigate to={homeRoute} replace />;
+  return (
+    <div style={{ padding: '2rem', textAlign: 'center' }}>
+      No sections are available for your account. Ask a super admin to grant access.
+    </div>
+  );
+};
+
 const ProtectedLayout = () => (
   <ProtectedRoute>
     {/* Mounted inside the auth gate so the dictionary is fetched only once a
@@ -162,7 +177,7 @@ root.render(
               <Routes>
                 <Route path={ROUTES.login} element={<LoginBlock />} />
                 <Route path='/' element={<ProtectedLayout />}>
-                  <Route path={ROUTES.main} element={<Analitic />} />
+                  <Route path={ROUTES.main} element={<AnalyticsHome />} />
                   <Route path={ROUTES.media} element={<MediaManager disabled={true} />} />
                   <Route path={ROUTES.singleProduct} element={<Product />} />
                   <Route path={ROUTES.product} element={<ProductsCatalog />} />

--- a/src/ui/components/MobileNavMenu.tsx
+++ b/src/ui/components/MobileNavMenu.tsx
@@ -24,21 +24,25 @@ export function MobileNavMenu() {
       </DialogPrimitives.Trigger>
       <DialogPrimitives.Portal>
         <DialogPrimitives.Overlay className='fixed inset-0 z-40 h-screen bg-overlay' />
-        <DialogPrimitives.Content className='fixed inset-x-2 bottom-2 top-2 z-50 border border-textInactiveColor bg-bgColor px-2.5 pb-4 pt-5'>
-          <DialogPrimitives.Title className='sr-only'>managers</DialogPrimitives.Title>
-          <div className='flex h-full flex-col gap-10'>
+        <DialogPrimitives.Content className='fixed inset-x-2 bottom-2 top-2 z-50 flex flex-col border border-textColor bg-bgColor'>
+          <div className='flex items-center justify-between border-b border-textColor px-2.5 py-3'>
+            <DialogPrimitives.Title asChild>
+              <Text variant='uppercase'>managers</Text>
+            </DialogPrimitives.Title>
             <DialogPrimitives.Close asChild>
-              <div className='flex items-center justify-between'>
-                <Text variant='uppercase'>managers</Text>
-                <Button>[x]</Button>
-              </div>
+              <Button className='cursor-pointer'>[x]</Button>
             </DialogPrimitives.Close>
-            <div className='flex flex-col gap-5'>
+          </div>
+          <div className='min-h-0 flex-1 overflow-y-auto p-2.5'>
+            <div className='grid grid-cols-2 gap-2'>
               {items.map(({ label, route }, id) => (
                 <DialogPrimitives.Close asChild key={id}>
-                  <Button asChild>
-                    <Link to={route}>{label}</Link>
-                  </Button>
+                  <Link
+                    to={route}
+                    className='flex min-h-12 items-center justify-center border border-textColor px-2 py-3 text-center leading-tight uppercase transition-colors hover:bg-textColor hover:text-bgColor active:opacity-80'
+                  >
+                    {label}
+                  </Link>
                 </DialogPrimitives.Close>
               ))}
             </div>


### PR DESCRIPTION
Three RBAC UX fixes on top of the accounts feature.

### 1. Mobile nav overflow
The "managers" menu is now a scrollable 2-column grid of bordered tiles (≥48px tap targets) with a sticky header, instead of a fixed single column that spilled past the container on small screens.

### 2. Dynamic landing
`/main` is the analytics dashboard. An account without `analytics` read is redirected to the **first section it can actually open** (sidebar order) instead of hitting a permission error. Shows a clear "no sections available" message if it has none. Waits for permissions to resolve first; super accounts and older backends are unaffected.

### 3. Read-only sections hide their write controls
`usePermissions().canWrite(section)` gates every primary write affordance, so a read-only account can view but not edit:
- **List create/upload**: products, timeline, models, fittings, tech-cards, media, orders, shipping
- **Single-surface saves**: hero publish, settings, tier-config
- **Membership**: member-actions cluster, hacker generate/revoke, promo create/delete/allow-toggle
- **Per-item deletes**: product/model/fitting/tech-card cards
- **Item-editor save/create clusters**: product, archive, model, fitting, tech-card

Gating **fail-opens** for super accounts, while permissions load, and on backends that predate RBAC, so nothing disappears for full-access users. The backend remains the real enforcement boundary.

### Verification
`tsc` clean (only pre-existing WIP errors remain); full `vite build` passes; Prettier-formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)