### PR TITLE
gate order-detail write actions behind orders WRITE permission

### DIFF
--- a/src/components/managers/custom-orders/components/custom-order-form.tsx
+++ b/src/components/managers/custom-orders/components/custom-order-form.tsx
@@ -2,8 +2,9 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { adminService } from 'api/api';
 import type { CreateCustomOrderRequest } from 'api/proto-http/admin';
 import { common_Dictionary, common_Product } from 'api/proto-http/admin';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
 import { getFilteredSizes } from 'components/managers/product/utility/sizes';
-import { ROUTES } from 'constants/routes';
+import { ROUTES, SECTION } from 'constants/routes';
 import { useDictionary } from 'lib/providers/dictionary-provider';
 import { useSnackBarStore } from 'lib/stores/store';
 import { useEffect, useMemo } from 'react';
@@ -61,6 +62,7 @@ export function CustomOrderForm({
 }: CustomOrderFormProps) {
   const { dictionary } = useDictionary();
   const { showMessage } = useSnackBarStore();
+  const { canWrite } = usePermissions();
   const currency = dictionary?.baseCurrency || '';
   const navigate = useNavigate();
 
@@ -160,7 +162,7 @@ export function CustomOrderForm({
                   triggerClassName='w-full uppercase'
                 />
               )}
-              {selectedProducts.length > 0 && (
+              {selectedProducts.length > 0 && canWrite(SECTION.orders) && (
                 <Button
                   type='submit'
                   variant='main'

--- a/src/components/managers/order/components/comment.tsx
+++ b/src/components/managers/order/components/comment.tsx
@@ -5,7 +5,13 @@ import { useFormContext } from 'react-hook-form';
 import { useSnackBarStore } from 'lib/stores/store';
 import TextareaField from 'ui/form/fields/textarea-field';
 
-export function Comment({ orderDetails }: { orderDetails?: common_OrderFull }) {
+export function Comment({
+  orderDetails,
+  canEdit = true,
+}: {
+  orderDetails?: common_OrderFull;
+  canEdit?: boolean;
+}) {
   const { showMessage } = useSnackBarStore();
   const { setValue } = useFormContext();
 
@@ -34,7 +40,8 @@ export function Comment({ orderDetails }: { orderDetails?: common_OrderFull }) {
       placeholder='leave comments here'
       showCharCount
       maxLength={1500}
-      upsertButton={true}
+      readOnly={!canEdit}
+      upsertButton={canEdit}
       onUpsert={onUpsert}
       className='placeholder:uppercase placeholder:text-textInactiveColor'
     />

--- a/src/components/managers/order/components/shipping-billing-toggle.tsx
+++ b/src/components/managers/order/components/shipping-billing-toggle.tsx
@@ -10,6 +10,7 @@ interface Props {
   isPrinting: boolean;
   orderStatus: string | undefined;
   isEdit: boolean;
+  canEdit?: boolean;
   trackingNumber: string;
   toggleTrackNumber: () => void;
   handleTrackingNumberChange: (event: any) => void;
@@ -21,6 +22,7 @@ export function ShippingBillingToggle({
   isPrinting,
   orderStatus,
   isEdit,
+  canEdit = true,
   trackingNumber,
   toggleTrackNumber,
   handleTrackingNumberChange,
@@ -72,6 +74,7 @@ export function ShippingBillingToggle({
         <TrackingNumber
           isEdit={isEdit}
           isPrinting={isPrinting}
+          canEdit={canEdit}
           trackingNumber={trackingNumber}
           orderStatus={orderStatus || ''}
           orderDetails={orderDetails}

--- a/src/components/managers/order/components/shipping-information/tracking-number.tsx
+++ b/src/components/managers/order/components/shipping-information/tracking-number.tsx
@@ -6,6 +6,7 @@ import { NewTrackCode } from './new-track-code';
 interface Props {
   isEdit: boolean;
   isPrinting: boolean;
+  canEdit?: boolean;
   trackingNumber: string;
   orderStatus: string;
   orderDetails: common_OrderFull | undefined;
@@ -17,6 +18,7 @@ interface Props {
 export function TrackingNumber({
   isEdit,
   isPrinting,
+  canEdit = true,
   trackingNumber,
   orderStatus,
   orderDetails,
@@ -51,7 +53,7 @@ export function TrackingNumber({
                 <Text variant='uppercase'>
                   tracking number: {orderDetails?.shipment?.trackingCode}
                 </Text>
-                {orderStatus === 'SHIPPED' && (
+                {canEdit && orderStatus === 'SHIPPED' && (
                   <Button
                     variant='main'
                     className='px-1 cursor-pointer'

--- a/src/components/managers/order/page.tsx
+++ b/src/components/managers/order/page.tsx
@@ -2,7 +2,8 @@ import {
   formatDateShort,
   getStatusColor,
 } from 'components/managers/orders-catalog/components/utility';
-import { ROUTES } from 'constants/routes';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
+import { ROUTES, SECTION } from 'constants/routes';
 import { cn } from 'lib/utility';
 import { useState } from 'react';
 import { createPortal } from 'react-dom';
@@ -81,6 +82,8 @@ export function OrderDetails() {
   } = useOrderDetails(uuid || '');
 
   const [isRefundModalOpen, setIsRefundModalOpen] = useState(false);
+  const { canWrite } = usePermissions();
+  const canEditOrder = canWrite(SECTION.orders);
 
   const form = useForm<{ refundReason: string; notes: string }>({
     defaultValues: { refundReason: '', notes: '' },
@@ -207,7 +210,7 @@ export function OrderDetails() {
               </Section>
 
               <Section title='comment' className='print:hidden'>
-                <Comment orderDetails={orderDetails} />
+                <Comment orderDetails={orderDetails} canEdit={canEditOrder} />
               </Section>
             </div>
 
@@ -223,6 +226,7 @@ export function OrderDetails() {
                   isPrinting={isPrinting}
                   orderStatus={orderStatus}
                   isEdit={isEdit}
+                  canEdit={canEditOrder}
                   trackingNumber={trackingNumber}
                   toggleTrackNumber={toggleTrackNumber}
                   handleTrackingNumberChange={handleTrackingNumberChange}
@@ -234,7 +238,7 @@ export function OrderDetails() {
                 <Payment orderDetails={orderDetails} isPrinting={isPrinting} />
               </Section>
 
-              {orderStatus === 'CONFIRMED' && !orderDetails?.shipment?.trackingCode && (
+              {canEditOrder && orderStatus === 'CONFIRMED' && !orderDetails?.shipment?.trackingCode && (
                 <Section title='tracking' className='print:hidden'>
                   <NewTrackCode
                     isPrinting={isPrinting}
@@ -248,7 +252,7 @@ export function OrderDetails() {
           </div>
         )}
 
-        {(showDeliver || showRefund) && (
+        {canEditOrder && (showDeliver || showRefund) && (
           <div className='fixed inset-x-0 bottom-0 z-40 flex items-center justify-end gap-2 border-t border-textColor bg-bgColor px-3 py-2 print:hidden'>
             {showDeliver && (
               <Button variant='main' size='lg' className='uppercase' onClick={markAsDelivered}>


### PR DESCRIPTION
## What

Extends the account-permissions (RBAC) gating to the order-detail screen and the custom-order form, so a user with `orders` **READ** but not **WRITE** can view orders without any write affordances.

Hidden for read-only users (via `canWrite(SECTION.orders)`):
- mark-as-delivered / refund action bar (`order/page.tsx`)
- "leave comment" upsert button + notes field made `readOnly` (`order/components/comment.tsx`)
- tracking-number editor — both the standalone CONFIRMED "tracking" section and the SHIPPED "edit" toggle inside shipping & billing (`order/page.tsx`, `shipping-billing-toggle.tsx`, `tracking-number.tsx`)
- "create order" submit on the custom-order form (`custom-orders/components/custom-order-form.tsx`)

`canEdit` defaults to `true` throughout, so behavior is unchanged for super accounts and while permissions load (fail-open, consistent with the rest of the feature — the backend remains the real enforcement).

## Notes

- 5 files, +27/−9. No functional change for users who have `orders` WRITE.
- Pre-existing `tsc` errors on `beta` (analytics `KpiCards`/`PersistentKpiBar`, `hero` newsletter, `ui/sidebar-items.tsx`) are unrelated to this change and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)