### PR TITLE
Release: analytics @26a19e8 backend consumption (drop verdict, margin, lift, god-object split)

### DIFF
--- a/docs/analytics-backend-asks.md
+++ b/docs/analytics-backend-asks.md
@@ -1,6 +1,6 @@
 ---
 title: Analytics — Backend Follow-ups (grbpwr-proto)
-date: 2026-07-10
+date: 2026-07-11
 tags: [analytics, backend, grbpwr-proto, roadmap]
 ---
 
@@ -9,29 +9,42 @@ tags: [analytics, backend, grbpwr-proto, roadmap]
 Hand-off list from the decision-first dashboard rework (branch `analytics-decision-first`).
 Each item is a concrete `grbpwr-proto` / gateway change. Ordered by value × effort.
 
-## Already delivered in this proto bump (consumed by the frontend)
+## Delivered & consumed by the frontend
+
+Earlier proto bump:
 
 - `RefundReason` enum + `RefundOrderRequest.reasonCode` — wired in the refund modal.
 - `InventoryHealthRow.{reorderPoint,targetDaysCover,leadTimeDays,needsReorder,hasTarget}`
   + `UpsertInventoryTargets` RPC — powers the **Reorder-now** list + target entry form.
 - `CampaignAttributionRow.{spend,roas}` + `UpsertChannelSpend` RPC — powers ROAS + spend entry.
-- `BusinessMetrics.contributionMargin` — shown in the Revenue P&L block.
 
-## Still needed (prioritized)
+`@26a19e8` proto bump (this follow-up round — asks #1/#2/#3/#4/#6/#7/#8/#10 below):
+
+- #1 **Margin on `SlowMoverRow` + `RevenueParetoRow`** (`unitCost/revenueCost/grossMargin/grossMarginPct/hasCost`)
+  — Margin column on the Slow movers table (markdown headroom).
+- #2 **`MarginMetrics.paymentFees`** + redefined `contributionMargin` — Payment-fees line in the Revenue P&L.
+- #3 **`MarginMetrics.uncostedProductIds`** — "N products missing cost" hint on the margin block.
+- #4 **`GetMetricsResponse.sellThroughByDrop`** (`SellThroughByDropRow`: collection, units bought/sold/remaining,
+  sellThroughPct, revenue, grossMargin(Pct), hasCost, daysTo50pct) — new **Drop verdict** section in Products.
+- #6 **`SizeRunEfficiencyRow.{unitsBought,unitsSold,sellThroughPct}`** — true unit sell-through in the size-run table.
+- #7 **`CrossSellPair.{support,confidence,lift}`** — cross-sell table now ranks by lift, shows attach rate.
+- #8 **`MetricWithComparison.{sampleSize,marginOfError}`** — alert gating prefers `sampleSize`; `formatPercentWithBand`
+  renders "12.0% ± 2.4" (applied to refund rate; lights up as backend extends MoE coverage).
+- #10 **`BusinessMetrics` god-object split** into `CommerceCoreMetrics / MarginMetrics / TrafficMetrics / EmailMetrics`
+  — all frontend reads migrated to the sub-messages.
+
+## Available in the contract but not yet consumed (deliberate)
+
+| # | Ask | Status | Note |
+|---|-----|--------|------|
+| 5 | **`GetDashboard` decision RPC** (+ `DashboardAlert`) | Shipped in proto, not wired | Building a single decision-first page would duplicate the current tabbed dashboard. Deferred as an architecture decision, not an oversight — revisit if we want to retire the tabs. |
+| 11 | **`GetAlertSettings` / `UpsertAlertSettings` + `AlertSettings`** | Shipped in proto, not wired | Alert thresholds still live as constants in `executiveAlerts.ts`. A small settings form would move them server-side; low priority until ops actually want to tune them. |
+
+## Still needed
 
 | # | Ask | Value | Effort | Why |
 |---|-----|-------|--------|-----|
-| 1 | **Margin on `SlowMoverRow` + `RevenueParetoRow`** — add `unitCost/revenueCost/grossMargin/grossMarginPct/hasCost` (mirror `ProductMetric`). | High | S | The markdown/liquidate decision on Slow movers & Dead stock is margin-blind. Rows already carry `productId`; margin is already computed for `ProductMetric`. **This was thought delivered but is not** — only `ProductMetric` carries margin today. |
-| 2 | **`paymentFees` on `BusinessMetrics`** (capture Stripe `balance_transaction.fee`), and redefine `contributionMargin = grossMargin − totalShippingCost − paymentFees`; make COGS net of promo/sale discount. | High | M | Processor fees + discount erosion are a silent 2–3pp leak. Contribution margin € should become the dashboard's headline number. |
-| 3 | **Cost coverage activation** — `uncostedProductIds` (or a small "products missing cost" endpoint) on the margin block. | High | S | The whole margin suite is dark until costs are entered; show operators exactly which products to cost. |
-| 4 | **Drop/release cohort** — tag orders+products with a release id; add `SellThroughByDropRow {dropId, dropName, releasedAt, unitsBought, unitsSold, sellThroughPct, daysTo50pct, revenue, grossMargin}` behind a new `METRICS_SECTION_DROP_SELL_THROUGH`. | High | M | The core KPI of a drop brand, currently absent. Turns tiny daily samples into decision-grade per-drop totals and makes compare honest (this drop vs last drop, not WoW across a drop boundary). Unlocks a real "Drop verdict" zone. |
-| 5 | **`GetDashboard` decision RPC** — one opinionated DB-trusted payload (money + server-computed alerts + top movers by margin + reorder/clear lists + current-drop sell-through). Keep sectioned `GetMetrics` for drill-down. | Med | L | Enables collapsing the 4 tabs into one decision-first page without fetching the ~90-field `BusinessMetrics` god-object per tab. |
-| 6 | **True size-run sell-through** — `SizeRunEfficiencyRow` currently uses "sold at least once". Add `unitsBought`/`unitsSold` so efficiency = sold ÷ bought. | Med | M | Frontend only has a coarse proxy; real overbuy detection needs buy quantities. |
-| 7 | **Cross-sell lift** — add marginal frequencies (or a precomputed `lift`) to `crossSellPairs`. | Med | S | Raw co-occurrence is chance-dominated at low N; frontend floors at count≥3 but can't compute observed/expected. |
-| 8 | **`sampleSize` on `MetricWithComparison`** — the n a rate/comparison is computed over. | Med | M | Lets the UI suppress or show ± bands instead of hardcoded floors. (`sampleSize` exists on `ClvDistribution` only today; `currentMetricValue()` already reads it defensively.) |
-| 9 | **Fix `ordersByStatus`** — count each order's current/terminal status once, not transitions (its sum currently exceeds the order count). | Med | S | Removes the cancellation-denominator workaround; makes any status breakdown honest. |
-| 10 | **Split `BusinessMetrics` god-object** into CommerceCore / Margin / Traffic(GA4) / Email sub-messages. | Med | L | Type-separates DB-trusted from GA4-estimated so a consumer can't accidentally headline a sampled number; stops every tab paying the full computation. |
-| 11 | **Move alert thresholds server-side / into settings** (`executiveAlerts.ts`: `REVENUE_DROP_ALERT_PCT`, `CANCELLATION_SHARE_ALERT`, `MIN_ORDERS_FOR_ALERT`, `MIN_SESSIONS_FOR_ALERT`, …). | Low | M | Lets ops tune floors to their volume without a frontend deploy. |
+| 9 | **Fix `ordersByStatus`** — count each order's current/terminal status once, not transitions (its sum currently exceeds the order count). | Med | S | Removes the cancellation-denominator workaround (`orderCancellationSharePercent` still divides by `ordersCount`, not the status-row sum); makes any status breakdown honest. |
 
 ## Explicitly NOT worth building
 

--- a/src/api/proto-http/admin/index.ts
+++ b/src/api/proto-http/admin/index.ts
@@ -55,7 +55,13 @@ export type MetricsSection =
   | "METRICS_SECTION_NOTIFY_ME_INTENT"
   | "METRICS_SECTION_GEOGRAPHY"
   | "METRICS_SECTION_CUSTOMER_SEGMENTATION"
-  | "METRICS_SECTION_RFM";
+  | "METRICS_SECTION_RFM"
+  | "METRICS_SECTION_SELL_THROUGH_BY_DROP";
+export type AlertSeverity =
+  | "ALERT_SEVERITY_UNSPECIFIED"
+  | "ALERT_SEVERITY_INFO"
+  | "ALERT_SEVERITY_WARNING"
+  | "ALERT_SEVERITY_CRITICAL";
 // RefundReason is the canonical, structured refund/return reason used by the return-analysis
 // breakdown. Keys mirror the historical free-text buckets.
 export type RefundReason =
@@ -984,30 +990,49 @@ export type GetMetricsResponse = {
   geography: GeographySection | undefined;
   customerSegments: CustomerSegmentRow[] | undefined;
   rfmAnalysis: RFMSegmentRow[] | undefined;
+  sellThroughByDrop: SellThroughByDropRow[] | undefined;
 };
 
+// BusinessMetrics groups the overview metrics by data provenance so consumers can tell
+// DB-trusted figures from GA4-estimated ones at a glance. BREAKING: replaces the former
+// ~90-field flat message — read metrics from commerce / margin / traffic / email instead.
 export type BusinessMetrics = {
   period: TimeRange | undefined;
   comparePeriod: TimeRange | undefined;
+  commerce: CommerceCoreMetrics | undefined;
+  margin: MarginMetrics | undefined;
+  traffic: TrafficMetrics | undefined;
+  email: EmailMetrics | undefined;
+};
+
+export type TimeRange = {
+  from: wellKnownTimestamp | undefined;
+  to: wellKnownTimestamp | undefined;
+};
+
+// CommerceCoreMetrics is the DB-authoritative commerce view: sales, customers, discounts,
+// shipping, plus their breakdowns and daily series.
+export type CommerceCoreMetrics = {
   revenue: MetricWithComparison | undefined;
   ordersCount: MetricWithComparison | undefined;
+  totalPlacedOrders: MetricWithComparison | undefined;
   avgOrderValue: MetricWithComparison | undefined;
   itemsPerOrder: MetricWithComparison | undefined;
   refundRate: MetricWithComparison | undefined;
-  // Share of orders with a promo_code attached (customer_order.promo_id). Unrelated to total_discount
-  // when discounts come only from product sale percentages — see product_sale_discount / promo_code_discount.
   promoUsageRate: MetricWithComparison | undefined;
-  // Gross revenue at list prices (before any discounts or refunds) + shipping.
-  // Includes original order value of fully refunded orders (status=Refunded).
-  // Revenue = GrossRevenue - ProductSaleDiscount - PromoCodeDiscount - TotalRefunded.
   grossRevenue: MetricWithComparison | undefined;
   totalRefunded: MetricWithComparison | undefined;
-  // Sum of product_sale_discount + promo_code_discount (base currency, net-revenue order statuses).
   totalDiscount: MetricWithComparison | undefined;
-  // Line-item sale % off list price (not from promo codes).
   productSaleDiscount: MetricWithComparison | undefined;
-  // Extra % off subtotal from an applied promo_code (orders with promo_id only).
   promoCodeDiscount: MetricWithComparison | undefined;
+  newSubscribers: MetricWithComparison | undefined;
+  newCustomers: MetricWithComparison | undefined;
+  repeatCustomersRate: MetricWithComparison | undefined;
+  avgOrdersPerCustomer: MetricWithComparison | undefined;
+  avgDaysBetweenOrders: MetricWithComparison | undefined;
+  avgShippingCost: MetricWithComparison | undefined;
+  totalShippingCost: MetricWithComparison | undefined;
+  clvDistribution: CLVStats | undefined;
   revenueByCountry: GeographyMetric[] | undefined;
   revenueByCity: GeographyMetric[] | undefined;
   revenueByRegion: RegionMetric[] | undefined;
@@ -1018,17 +1043,9 @@ export type BusinessMetrics = {
   topProductsByQuantity: ProductMetric[] | undefined;
   revenueByCategory: CategoryMetric[] | undefined;
   crossSellPairs: CrossSellPair[] | undefined;
-  newSubscribers: MetricWithComparison | undefined;
-  repeatCustomersRate: MetricWithComparison | undefined;
-  avgOrdersPerCustomer: MetricWithComparison | undefined;
-  avgDaysBetweenOrders: MetricWithComparison | undefined;
-  clvDistribution: CLVStats | undefined;
   revenueByPromo: PromoMetric[] | undefined;
-  // orders_by_status is every order PLACED in the period bucketed by its current status
-  // (one order per bucket), so it sums to total_placed_orders, NOT to orders_count.
-  // orders_count counts only net-revenue statuses (confirmed/shipped/delivered/partially_refunded),
-  // so cancelled/refunded/pending_return orders are excluded from it. Use total_placed_orders
-  // as the denominator for status shares such as cancellation% / refund%.
+  // Every order PLACED in the period bucketed by its current status (one per bucket); sums to
+  // total_placed_orders, not orders_count.
   ordersByStatus: StatusCount[] | undefined;
   revenueByDay: TimeSeriesPoint[] | undefined;
   ordersByDay: TimeSeriesPoint[] | undefined;
@@ -1052,65 +1069,6 @@ export type BusinessMetrics = {
   returningCustomersByDayCompare: TimeSeriesPoint[] | undefined;
   shippedByDayCompare: TimeSeriesPoint[] | undefined;
   deliveredByDayCompare: TimeSeriesPoint[] | undefined;
-  // GA4 Traffic & Engagement
-  sessions: MetricWithComparison | undefined;
-  users: MetricWithComparison | undefined;
-  newUsers: MetricWithComparison | undefined;
-  pageViews: MetricWithComparison | undefined;
-  bounceRate: MetricWithComparison | undefined;
-  // Average engagement time per session (seconds), derived from GA4
-  // userEngagementDuration / sessions at sync — not raw averageSessionDuration
-  // (wall-clock first-to-last event, often inflated by background tabs).
-  avgSessionDuration: MetricWithComparison | undefined;
-  pagesPerSession: MetricWithComparison | undefined;
-  conversionRate: MetricWithComparison | undefined;
-  revenuePerSession: MetricWithComparison | undefined;
-  sessionsByCountry: GeographySessionMetric[] | undefined;
-  topProductsByViews: ProductViewMetric[] | undefined;
-  trafficBySource: TrafficSourceMetric[] | undefined;
-  trafficByDevice: DeviceMetric[] | undefined;
-  sessionsByDay: TimeSeriesPoint[] | undefined;
-  usersByDay: TimeSeriesPoint[] | undefined;
-  pageViewsByDay: TimeSeriesPoint[] | undefined;
-  conversionRateByDay: TimeSeriesPoint[] | undefined;
-  sessionsByDayCompare: TimeSeriesPoint[] | undefined;
-  usersByDayCompare: TimeSeriesPoint[] | undefined;
-  pageViewsByDayCompare: TimeSeriesPoint[] | undefined;
-  conversionRateByDayCompare: TimeSeriesPoint[] | undefined;
-  // Email delivery metrics (from Resend webhooks)
-  emailsSent: MetricWithComparison | undefined;
-  emailsDelivered: MetricWithComparison | undefined;
-  emailDeliveryRate: MetricWithComparison | undefined;
-  emailOpenRate: MetricWithComparison | undefined;
-  emailClickRate: MetricWithComparison | undefined;
-  emailBounceRate: MetricWithComparison | undefined;
-  // Customer acquisition aggregate (sum of new_customers_by_day series)
-  newCustomers: MetricWithComparison | undefined;
-  // Shipping / logistics metrics
-  avgShippingCost: MetricWithComparison | undefined;
-  totalShippingCost: MetricWithComparison | undefined;
-  // Total orders PLACED in the period, regardless of status (sum of orders_by_status).
-  // Distinct from orders_count, which counts only net-revenue statuses. Use this as the
-  // denominator when deriving status shares (cancellation rate, refund rate, etc.).
-  totalPlacedOrders: MetricWithComparison | undefined;
-  // Margin metrics, derived from product.cost_price (per-unit COGS in base currency).
-  // Computed ONLY over line items whose product has a cost set, so revenue_cost and the
-  // margins are on the "costed" subset of revenue — gross_margin_pct.caveat and
-  // cost_coverage_pct report how much of revenue that subset is. COGS is net of the
-  // refund proration but NOT reduced by promo/sale discounts (a discount lowers revenue,
-  // not the cost of the goods).
-  revenueCost: MetricWithComparison | undefined;
-  grossMargin: MetricWithComparison | undefined;
-  grossMarginPct: MetricWithComparison | undefined;
-  contributionMargin: MetricWithComparison | undefined;
-  // Share (%) of net product revenue (base currency) whose product has a cost set — the
-  // fraction the margin figures above are computed over. 100 = full cost coverage.
-  costCoveragePct: number | undefined;
-};
-
-export type TimeRange = {
-  from: wellKnownTimestamp | undefined;
-  to: wellKnownTimestamp | undefined;
 };
 
 export type MetricWithComparison = {
@@ -1124,6 +1082,21 @@ export type MetricWithComparison = {
   changeAbsolute: number | undefined;
   // Optional tooltip/caveat text to clarify metric interpretation (e.g., data limitations, calculation notes).
   caveat: string | undefined;
+  // Number of observations behind the metric (orders, sessions, customers…). 0 = not
+  // populated. Prefer gating a metric on this (e.g. hide/greytext when sample_size < 30)
+  // over an arbitrary display floor.
+  sampleSize: number | undefined;
+  // 95% confidence-interval half-width in the metric's own units (e.g. ±2.4 for a 12.0%
+  // rate). Populated only for true count-proportions (conversion, promo usage); 0 = not
+  // computed. Frontend can render "12.0% ± 2.4" instead of guessing significance from a floor.
+  marginOfError: number | undefined;
+};
+
+export type CLVStats = {
+  mean: googletype_Decimal | undefined;
+  median: googletype_Decimal | undefined;
+  p90: googletype_Decimal | undefined;
+  sampleSize: number | undefined;
 };
 
 export type GeographyMetric = {
@@ -1187,13 +1160,9 @@ export type CrossSellPair = {
   productAName: string | undefined;
   productBName: string | undefined;
   count: number | undefined;
-};
-
-export type CLVStats = {
-  mean: googletype_Decimal | undefined;
-  median: googletype_Decimal | undefined;
-  p90: googletype_Decimal | undefined;
-  sampleSize: number | undefined;
+  support: number | undefined;
+  confidence: number | undefined;
+  lift: number | undefined;
 };
 
 export type PromoMetric = {
@@ -1212,6 +1181,44 @@ export type TimeSeriesPoint = {
   date: wellKnownTimestamp | undefined;
   value: googletype_Decimal | undefined;
   count: number | undefined;
+};
+
+// MarginMetrics is the DB-trusted COGS / margin view (from product.cost_price), computed over
+// the "costed" revenue subset; cost_coverage_pct says how much of revenue that subset is.
+export type MarginMetrics = {
+  revenueCost: MetricWithComparison | undefined;
+  grossMargin: MetricWithComparison | undefined;
+  grossMarginPct: MetricWithComparison | undefined;
+  paymentFees: MetricWithComparison | undefined;
+  contributionMargin: MetricWithComparison | undefined;
+  costCoveragePct: number | undefined;
+  uncostedProductIds: number[] | undefined;
+};
+
+// TrafficMetrics is the GA4-estimated traffic / engagement / conversion view. These figures
+// are sampled/modelled by GA4 — treat as directional, not DB-exact.
+export type TrafficMetrics = {
+  sessions: MetricWithComparison | undefined;
+  users: MetricWithComparison | undefined;
+  newUsers: MetricWithComparison | undefined;
+  pageViews: MetricWithComparison | undefined;
+  bounceRate: MetricWithComparison | undefined;
+  avgSessionDuration: MetricWithComparison | undefined;
+  pagesPerSession: MetricWithComparison | undefined;
+  conversionRate: MetricWithComparison | undefined;
+  revenuePerSession: MetricWithComparison | undefined;
+  sessionsByCountry: GeographySessionMetric[] | undefined;
+  topProductsByViews: ProductViewMetric[] | undefined;
+  trafficBySource: TrafficSourceMetric[] | undefined;
+  trafficByDevice: DeviceMetric[] | undefined;
+  sessionsByDay: TimeSeriesPoint[] | undefined;
+  usersByDay: TimeSeriesPoint[] | undefined;
+  pageViewsByDay: TimeSeriesPoint[] | undefined;
+  conversionRateByDay: TimeSeriesPoint[] | undefined;
+  sessionsByDayCompare: TimeSeriesPoint[] | undefined;
+  usersByDayCompare: TimeSeriesPoint[] | undefined;
+  pageViewsByDayCompare: TimeSeriesPoint[] | undefined;
+  conversionRateByDayCompare: TimeSeriesPoint[] | undefined;
 };
 
 export type GeographySessionMetric = {
@@ -1246,6 +1253,16 @@ export type DeviceMetric = {
   sessions: number | undefined;
   users: number | undefined;
   conversionRate: number | undefined;
+};
+
+// EmailMetrics is the Resend email-delivery view.
+export type EmailMetrics = {
+  emailsSent: MetricWithComparison | undefined;
+  emailsDelivered: MetricWithComparison | undefined;
+  emailDeliveryRate: MetricWithComparison | undefined;
+  emailOpenRate: MetricWithComparison | undefined;
+  emailClickRate: MetricWithComparison | undefined;
+  emailBounceRate: MetricWithComparison | undefined;
 };
 
 export type FunnelSection = {
@@ -1436,6 +1453,16 @@ export type RevenueParetoRow = {
   productName: string | undefined;
   revenue: googletype_Decimal | undefined;
   cumulativePct: number | undefined;
+  // Margin fields (mirror ProductMetric). Populated only when the product has a cost_price;
+  // has_cost=false ⇒ the cost is unknown, so treat margins as N/A, not as 100%. Note the
+  // margin here is computed on this row's own `revenue` basis (gross list revenue, Σ price×qty),
+  // so revenue_cost is Σ(cost × qty) on the same un-adjusted basis — internally consistent
+  // with `revenue`, but not directly comparable to the refund/discount-adjusted BusinessMetrics margin.
+  unitCost: googletype_Decimal | undefined;
+  revenueCost: googletype_Decimal | undefined;
+  grossMargin: googletype_Decimal | undefined;
+  grossMarginPct: number | undefined;
+  hasCost: boolean | undefined;
 };
 
 export type SpendingCurvePoint = {
@@ -1457,14 +1484,22 @@ export type InventoryHealthRow = {
   sizeName: string | undefined;
   quantity: number | undefined;
   avgDailySales: number | undefined;
+  // Days of cover at the current sales rate. When is_selling is false there were no sales in
+  // the window, so this carries a large sentinel (sorts dead stock last) — read is_selling,
+  // not a magic number, and render days of cover as N/A in that case.
   daysOnHand: number | undefined;
-  // Optional per-SKU targets (0 = unset) and the server-side reorder decision derived
-  // from them. needs_reorder is meaningful only when has_target is true.
+  // Optional per-SKU targets (0 = unset) and the server-side reorder decision derived from
+  // them. needs_reorder is meaningful only when has_target is true; setting a target is the
+  // operator's opt-in that this SKU is continuity stock (limited drops get no target, hence
+  // no reorder noise — days of cover is misleading for them).
   reorderPoint: number | undefined;
   targetDaysCover: number | undefined;
   leadTimeDays: number | undefined;
   needsReorder: boolean | undefined;
   hasTarget: boolean | undefined;
+  // True when the SKU sold at least one unit in the window. Replaces the client-side
+  // qty/avgDailySales sentinel check: gate any days-of-cover display on this.
+  isSelling: boolean | undefined;
 };
 
 export type SizeRunEfficiencyRow = {
@@ -1473,6 +1508,9 @@ export type SizeRunEfficiencyRow = {
   totalSizes: number | undefined;
   soldThroughSizes: number | undefined;
   efficiencyPct: number | undefined;
+  unitsBought: number | undefined;
+  unitsSold: number | undefined;
+  sellThroughPct: number | undefined;
 };
 
 export type SlowMoverRow = {
@@ -1484,6 +1522,15 @@ export type SlowMoverRow = {
   lastSaleDate: wellKnownTimestamp | undefined;
   productHidden: boolean | undefined;
   totalViews: number | undefined;
+  // Margin fields (mirror ProductMetric). Populated only when the product has a cost_price;
+  // has_cost=false ⇒ the cost is unknown, so treat margins as N/A, not as 100%. Computed on
+  // this row's `revenue` (the refund/FX/discount-adjusted net revenue), so revenue_cost is the
+  // refund-adjusted COGS — the same basis as the BusinessMetrics and product-breakdown margins.
+  unitCost: googletype_Decimal | undefined;
+  revenueCost: googletype_Decimal | undefined;
+  grossMargin: googletype_Decimal | undefined;
+  grossMarginPct: number | undefined;
+  hasCost: boolean | undefined;
 };
 
 export type ReturnByProductRow = {
@@ -1577,6 +1624,9 @@ export type CampaignAttributionRow = {
   // zero when none is recorded for the channel; roas is 0 unless spend > 0.
   spend: googletype_Decimal | undefined;
   roas: number | undefined;
+  // CAC = spend / conversions (0 unless both > 0). Attribution-based, so directional for an
+  // organic-heavy channel mix rather than an exact acquisition cost.
+  cac: number | undefined;
 };
 
 // AddToCartRateAnalysis contains both per-product aggregate data for scatter plot
@@ -1702,6 +1752,82 @@ export type RFMSegmentRow = {
   lastPurchase: wellKnownTimestamp | undefined;
   orderCount: number | undefined;
   totalSpent: googletype_Decimal | undefined;
+};
+
+// SellThroughByDropRow aggregates a release/drop cohort (product.collection) into
+// decision-grade totals, so tiny per-day/per-SKU samples roll up to a statistically
+// meaningful drop-level view. sell_through_pct = units_sold / (units_sold +
+// units_remaining) × 100 over the whole drop, computed lifetime (current state), not
+// windowed — sell-through is inherently cumulative. Sorted by revenue desc.
+export type SellThroughByDropRow = {
+  collection: string | undefined;
+  productCount: number | undefined;
+  unitsSold: number | undefined;
+  unitsRemaining: number | undefined;
+  sellThroughPct: number | undefined;
+  revenue: googletype_Decimal | undefined;
+  unitsBought: number | undefined;
+  grossMargin: googletype_Decimal | undefined;
+  grossMarginPct: number | undefined;
+  hasCost: boolean | undefined;
+  daysTo50pct?: number;
+};
+
+export type GetDashboardRequest = {
+  // Period spec, same grammar as GetMetrics (7d, 30d, 90d, today, WTD, MTD, QTD, YTD).
+  period: string | undefined;
+  // Optional window end (defaults to now). The period is measured back from here.
+  endAt: wellKnownTimestamp | undefined;
+  // Max rows per action list (top-by-margin, reorder, clear, drops). 0 = server default.
+  limit: number | undefined;
+};
+
+// DashboardAlert is a server-computed, threshold-driven alert. Rate-based alerts are gated on
+// a minimum order count, so they never fire on a statistically meaningless sample.
+export type DashboardAlert = {
+  severity: AlertSeverity | undefined;
+  code: string | undefined;
+  title: string | undefined;
+  detail: string | undefined;
+};
+
+export type GetDashboardResponse = {
+  period: TimeRange | undefined;
+  revenue: googletype_Decimal | undefined;
+  orders: number | undefined;
+  grossMargin: googletype_Decimal | undefined;
+  grossMarginPct: number | undefined;
+  contributionMargin: googletype_Decimal | undefined;
+  costCoveragePct: number | undefined;
+  caveat: string | undefined;
+  uncostedProductIds: number[] | undefined;
+  alerts: DashboardAlert[] | undefined;
+  topByMargin: ProductMetric[] | undefined;
+  reorder: InventoryHealthRow[] | undefined;
+  clear: SlowMoverRow[] | undefined;
+  drops: SellThroughByDropRow[] | undefined;
+};
+
+// AlertSettings are the operator-tunable thresholds behind the dashboard alerts.
+export type AlertSettings = {
+  coverageWarnPct: number | undefined;
+  refundRateWarnPct: number | undefined;
+  rateFloorN: number | undefined;
+  contributionTrustPct: number | undefined;
+};
+
+export type GetAlertSettingsRequest = {
+};
+
+export type GetAlertSettingsResponse = {
+  settings: AlertSettings | undefined;
+};
+
+export type UpsertAlertSettingsRequest = {
+  settings: AlertSettings | undefined;
+};
+
+export type UpsertAlertSettingsResponse = {
 };
 
 export type RefundOrderRequest = {
@@ -2427,6 +2553,160 @@ export type DeleteFittingRequest = {
 };
 
 export type DeleteFittingResponse = {
+};
+
+export type AddTaskRequest = {
+  task: common_TaskInsert | undefined;
+  board: common_TaskBoard | undefined;
+  status: common_TaskStatus | undefined;
+};
+
+// TaskInsert is the writable CONTENT of a task (create/update). Placement on the
+// board — board, status, position — is deliberately NOT here: it is set at
+// AddTask and changed only via MoveTask, so a content edit can never silently
+// re-file a card into another lane/column or reorder it. Other server-managed
+// fields (id, created_by, timestamps, resolved media) also live on Task.
+export type common_TaskInsert = {
+  title: string | undefined;
+  description: string | undefined;
+  assignee: string | undefined;
+  priority: common_TaskPriority | undefined;
+  dueDate: wellKnownTimestamp | undefined;
+  labels: string[] | undefined;
+  mediaIds: number[] | undefined;
+  // Optional typed links to existing admin entities (0 / "" = none). Follows the
+  // fitting precedent (several nullable typed FKs, NOT a polymorphic entity_type
+  // ref) so a card can deep-link to the artifact it is about while that artifact
+  // keeps its own state machine (techcard stage/approval, fitting verdict, …).
+  // Each target has a single-get RPC so the card can resolve a title/thumbnail.
+  techCardId: number | undefined;
+  productId: number | undefined;
+  orderUuid: string | undefined;
+  archiveId: number | undefined;
+};
+
+export type common_TaskPriority =
+  | "TASK_PRIORITY_UNKNOWN"
+  | "TASK_PRIORITY_LOW"
+  | "TASK_PRIORITY_MEDIUM"
+  | "TASK_PRIORITY_HIGH"
+  | "TASK_PRIORITY_URGENT";
+// TaskBoard is the department lane a task lives in. Fixed taxonomy for now; a
+// task belongs to exactly one board. Extend by appending members (never reuse
+// numbers) — 0 stays UNKNOWN per proto3 convention.
+export type common_TaskBoard =
+  | "TASK_BOARD_UNKNOWN"
+  | "TASK_BOARD_DEVELOPMENT"
+  | "TASK_BOARD_DESIGN"
+  | "TASK_BOARD_MARKETING"
+  | "TASK_BOARD_PRODUCTION"
+  | "TASK_BOARD_SOURCING"
+  | "TASK_BOARD_CONTENT";
+// TaskStatus is the kanban column. A drag between columns is a status change.
+export type common_TaskStatus =
+  | "TASK_STATUS_UNKNOWN"
+  | "TASK_STATUS_BACKLOG"
+  | "TASK_STATUS_TODO"
+  | "TASK_STATUS_IN_PROGRESS"
+  | "TASK_STATUS_REVIEW"
+  | "TASK_STATUS_DONE";
+export type AddTaskResponse = {
+  id: number | undefined;
+};
+
+export type GetTaskRequest = {
+  id: number | undefined;
+};
+
+export type GetTaskResponse = {
+  task: common_Task | undefined;
+};
+
+// Task is a stored kanban card: its content (TaskInsert), its placement on the
+// board (board/status/position — server-managed, set by AddTask and mutated only
+// by MoveTask), resolved media, and server-stamped identity/timestamps.
+export type common_Task = {
+  id: number | undefined;
+  task: common_TaskInsert | undefined;
+  board: common_TaskBoard | undefined;
+  status: common_TaskStatus | undefined;
+  position: number | undefined;
+  media: common_MediaFull[] | undefined;
+  createdBy: string | undefined;
+  createdAt: wellKnownTimestamp | undefined;
+  updatedAt: wellKnownTimestamp | undefined;
+};
+
+export type UpdateTaskRequest = {
+  id: number | undefined;
+  task: common_TaskInsert | undefined;
+};
+
+export type UpdateTaskResponse = {
+};
+
+export type MoveTaskRequest = {
+  id: number | undefined;
+  board: common_TaskBoard | undefined;
+  status: common_TaskStatus | undefined;
+  position: number | undefined;
+};
+
+export type MoveTaskResponse = {
+};
+
+export type DeleteTaskRequest = {
+  id: number | undefined;
+};
+
+export type DeleteTaskResponse = {
+};
+
+export type ListTasksRequest = {
+  board: common_TaskBoard | undefined;
+  status: common_TaskStatus | undefined;
+  assignee: string | undefined;
+  limit: number | undefined;
+  offset: number | undefined;
+  orderFactor: common_OrderFactor | undefined;
+  techCardId: number | undefined;
+  productId: number | undefined;
+};
+
+export type ListTasksResponse = {
+  tasks: common_Task[] | undefined;
+  total: number | undefined;
+};
+
+export type AddTaskCommentRequest = {
+  comment: common_TaskCommentInsert | undefined;
+};
+
+// TaskCommentInsert is the writable payload for a comment. author is set
+// server-side from the caller's JWT (not client-supplied).
+export type common_TaskCommentInsert = {
+  taskId: number | undefined;
+  body: string | undefined;
+};
+
+export type AddTaskCommentResponse = {
+  id: number | undefined;
+};
+
+export type ListTaskCommentsRequest = {
+  taskId: number | undefined;
+};
+
+export type ListTaskCommentsResponse = {
+  comments: common_TaskComment[] | undefined;
+};
+
+export type common_TaskComment = {
+  id: number | undefined;
+  taskId: number | undefined;
+  author: string | undefined;
+  body: string | undefined;
+  createdAt: wellKnownTimestamp | undefined;
 };
 
 export type UpdateSettingsRequest = {
@@ -3542,6 +3822,14 @@ export interface AdminService {
   // order_sequence, entry_products, revenue_pareto, spending_curve, category_loyalty,
   // inventory_health, size_run_efficiency.
   GetMetrics(request: GetMetricsRequest): Promise<GetMetricsResponse>;
+  // GetDashboard returns a small, DB-trusted decision payload: headline revenue/orders/margin
+  // (+ caveat), server-computed alerts, and short action lists (top by margin €, reorder,
+  // clear, drop sell-through). Use GetMetrics for deep, sectioned drill-down.
+  GetDashboard(request: GetDashboardRequest): Promise<GetDashboardResponse>;
+  // Reads the operator-tunable thresholds behind the dashboard alerts.
+  GetAlertSettings(request: GetAlertSettingsRequest): Promise<GetAlertSettingsResponse>;
+  // Updates the operator-tunable dashboard alert thresholds.
+  UpsertAlertSettings(request: UpsertAlertSettingsRequest): Promise<UpsertAlertSettingsResponse>;
   // Sets per-SKU inventory reorder targets used by the inventory-health metrics.
   UpsertInventoryTargets(request: UpsertInventoryTargetsRequest): Promise<UpsertInventoryTargetsResponse>;
   // Records operator-entered marketing spend per channel per day, used for ROAS.
@@ -3583,6 +3871,31 @@ export interface AdminService {
   // Declared last on purpose (see ListModels ordering note) so GET /fitting/list
   // is not shadowed by GET /fitting/{id}.
   ListFittings(request: ListFittingsRequest): Promise<ListFittingsResponse>;
+  // AddTask creates a new kanban task from its content plus placement (target
+  // board + optional initial column). Server sets created_by (from JWT) and
+  // appends the card to the end of its (board,status) column (position).
+  AddTask(request: AddTaskRequest): Promise<AddTaskResponse>;
+  // GetTask returns a task by id.
+  GetTask(request: GetTaskRequest): Promise<GetTaskResponse>;
+  // UpdateTask replaces a task's content (title, description, assignee, priority,
+  // due_date, labels, media, entity links). Placement — board, column (status),
+  // ordering — is NOT touched here; it changes only through MoveTask.
+  UpdateTask(request: UpdateTaskRequest): Promise<UpdateTaskResponse>;
+  // MoveTask changes a task's placement: its board, its column (status), and/or
+  // its order within a column (position) — a card can be dragged across columns
+  // and across boards. This is the drag-and-drop endpoint; the server
+  // re-sequences sibling positions as needed.
+  MoveTask(request: MoveTaskRequest): Promise<MoveTaskResponse>;
+  // DeleteTask deletes a task by id (cascades its comments).
+  DeleteTask(request: DeleteTaskRequest): Promise<DeleteTaskResponse>;
+  // AddTaskComment appends a comment to a task. Server sets author from JWT.
+  AddTaskComment(request: AddTaskCommentRequest): Promise<AddTaskCommentResponse>;
+  // ListTaskComments returns a task's comments, oldest first.
+  ListTaskComments(request: ListTaskCommentsRequest): Promise<ListTaskCommentsResponse>;
+  // ListTasks lists tasks with optional board/status/assignee filters. Declared
+  // last (see route-ordering note above) so GET /task/list is not shadowed by
+  // GET /task/{id}.
+  ListTasks(request: ListTasksRequest): Promise<ListTasksResponse>;
   // CreateTechCard creates a new tech card (техкарта) with its nested sections.
   CreateTechCard(request: CreateTechCardRequest): Promise<CreateTechCardResponse>;
   // GetTechCard returns a tech card by id with its nested sections resolved.
@@ -4269,6 +4582,66 @@ export function createAdminServiceClient(
         method: "GetMetrics",
       }) as Promise<GetMetricsResponse>;
     },
+    GetDashboard(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/dashboard`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      if (request.period) {
+        queryParams.push(`period=${encodeURIComponent(request.period.toString())}`)
+      }
+      if (request.endAt) {
+        queryParams.push(`endAt=${encodeURIComponent(request.endAt.toString())}`)
+      }
+      if (request.limit) {
+        queryParams.push(`limit=${encodeURIComponent(request.limit.toString())}`)
+      }
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "GET",
+        body,
+      }, {
+        service: "AdminService",
+        method: "GetDashboard",
+      }) as Promise<GetDashboardResponse>;
+    },
+    GetAlertSettings(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/dashboard/alert-settings`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "GET",
+        body,
+      }, {
+        service: "AdminService",
+        method: "GetAlertSettings",
+      }) as Promise<GetAlertSettingsResponse>;
+    },
+    UpsertAlertSettings(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/dashboard/alert-settings/upsert`; // eslint-disable-line quotes
+      const body = JSON.stringify(request);
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "POST",
+        body,
+      }, {
+        service: "AdminService",
+        method: "UpsertAlertSettings",
+      }) as Promise<UpsertAlertSettingsResponse>;
+    },
     UpsertInventoryTargets(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
       const path = `api/admin/metrics/inventory/targets/upsert`; // eslint-disable-line quotes
       const body = JSON.stringify(request);
@@ -4665,6 +5038,175 @@ export function createAdminServiceClient(
         service: "AdminService",
         method: "ListFittings",
       }) as Promise<ListFittingsResponse>;
+    },
+    AddTask(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/task/add`; // eslint-disable-line quotes
+      const body = JSON.stringify(request);
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "POST",
+        body,
+      }, {
+        service: "AdminService",
+        method: "AddTask",
+      }) as Promise<AddTaskResponse>;
+    },
+    GetTask(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      if (!request.id) {
+        throw new Error("missing required field request.id");
+      }
+      const path = `api/admin/task/${request.id}`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "GET",
+        body,
+      }, {
+        service: "AdminService",
+        method: "GetTask",
+      }) as Promise<GetTaskResponse>;
+    },
+    UpdateTask(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/task/update`; // eslint-disable-line quotes
+      const body = JSON.stringify(request);
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "POST",
+        body,
+      }, {
+        service: "AdminService",
+        method: "UpdateTask",
+      }) as Promise<UpdateTaskResponse>;
+    },
+    MoveTask(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/task/move`; // eslint-disable-line quotes
+      const body = JSON.stringify(request);
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "POST",
+        body,
+      }, {
+        service: "AdminService",
+        method: "MoveTask",
+      }) as Promise<MoveTaskResponse>;
+    },
+    DeleteTask(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      if (!request.id) {
+        throw new Error("missing required field request.id");
+      }
+      const path = `api/admin/task/${request.id}`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "DELETE",
+        body,
+      }, {
+        service: "AdminService",
+        method: "DeleteTask",
+      }) as Promise<DeleteTaskResponse>;
+    },
+    AddTaskComment(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/task/comment/add`; // eslint-disable-line quotes
+      const body = JSON.stringify(request);
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "POST",
+        body,
+      }, {
+        service: "AdminService",
+        method: "AddTaskComment",
+      }) as Promise<AddTaskCommentResponse>;
+    },
+    ListTaskComments(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      if (!request.taskId) {
+        throw new Error("missing required field request.task_id");
+      }
+      const path = `api/admin/task/${request.taskId}/comments`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "GET",
+        body,
+      }, {
+        service: "AdminService",
+        method: "ListTaskComments",
+      }) as Promise<ListTaskCommentsResponse>;
+    },
+    ListTasks(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/task/list`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      if (request.board) {
+        queryParams.push(`board=${encodeURIComponent(request.board.toString())}`)
+      }
+      if (request.status) {
+        queryParams.push(`status=${encodeURIComponent(request.status.toString())}`)
+      }
+      if (request.assignee) {
+        queryParams.push(`assignee=${encodeURIComponent(request.assignee.toString())}`)
+      }
+      if (request.limit) {
+        queryParams.push(`limit=${encodeURIComponent(request.limit.toString())}`)
+      }
+      if (request.offset) {
+        queryParams.push(`offset=${encodeURIComponent(request.offset.toString())}`)
+      }
+      if (request.orderFactor) {
+        queryParams.push(`orderFactor=${encodeURIComponent(request.orderFactor.toString())}`)
+      }
+      if (request.techCardId) {
+        queryParams.push(`techCardId=${encodeURIComponent(request.techCardId.toString())}`)
+      }
+      if (request.productId) {
+        queryParams.push(`productId=${encodeURIComponent(request.productId.toString())}`)
+      }
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "GET",
+        body,
+      }, {
+        service: "AdminService",
+        method: "ListTasks",
+      }) as Promise<ListTasksResponse>;
     },
     CreateTechCard(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
       const path = `api/admin/tech-card/add`; // eslint-disable-line quotes

--- a/src/api/proto-http/common/index.ts
+++ b/src/api/proto-http/common/index.ts
@@ -1451,6 +1451,85 @@ export type SupportTicket = {
   internalNotes: string | undefined;
 };
 
+// TaskBoard is the department lane a task lives in. Fixed taxonomy for now; a
+// task belongs to exactly one board. Extend by appending members (never reuse
+// numbers) — 0 stays UNKNOWN per proto3 convention.
+export type TaskBoard =
+  | "TASK_BOARD_UNKNOWN"
+  | "TASK_BOARD_DEVELOPMENT"
+  | "TASK_BOARD_DESIGN"
+  | "TASK_BOARD_MARKETING"
+  | "TASK_BOARD_PRODUCTION"
+  | "TASK_BOARD_SOURCING"
+  | "TASK_BOARD_CONTENT";
+// TaskStatus is the kanban column. A drag between columns is a status change.
+export type TaskStatus =
+  | "TASK_STATUS_UNKNOWN"
+  | "TASK_STATUS_BACKLOG"
+  | "TASK_STATUS_TODO"
+  | "TASK_STATUS_IN_PROGRESS"
+  | "TASK_STATUS_REVIEW"
+  | "TASK_STATUS_DONE";
+export type TaskPriority =
+  | "TASK_PRIORITY_UNKNOWN"
+  | "TASK_PRIORITY_LOW"
+  | "TASK_PRIORITY_MEDIUM"
+  | "TASK_PRIORITY_HIGH"
+  | "TASK_PRIORITY_URGENT";
+// TaskInsert is the writable CONTENT of a task (create/update). Placement on the
+// board — board, status, position — is deliberately NOT here: it is set at
+// AddTask and changed only via MoveTask, so a content edit can never silently
+// re-file a card into another lane/column or reorder it. Other server-managed
+// fields (id, created_by, timestamps, resolved media) also live on Task.
+export type TaskInsert = {
+  title: string | undefined;
+  description: string | undefined;
+  assignee: string | undefined;
+  priority: TaskPriority | undefined;
+  dueDate: wellKnownTimestamp | undefined;
+  labels: string[] | undefined;
+  mediaIds: number[] | undefined;
+  // Optional typed links to existing admin entities (0 / "" = none). Follows the
+  // fitting precedent (several nullable typed FKs, NOT a polymorphic entity_type
+  // ref) so a card can deep-link to the artifact it is about while that artifact
+  // keeps its own state machine (techcard stage/approval, fitting verdict, …).
+  // Each target has a single-get RPC so the card can resolve a title/thumbnail.
+  techCardId: number | undefined;
+  productId: number | undefined;
+  orderUuid: string | undefined;
+  archiveId: number | undefined;
+};
+
+// Task is a stored kanban card: its content (TaskInsert), its placement on the
+// board (board/status/position — server-managed, set by AddTask and mutated only
+// by MoveTask), resolved media, and server-stamped identity/timestamps.
+export type Task = {
+  id: number | undefined;
+  task: TaskInsert | undefined;
+  board: TaskBoard | undefined;
+  status: TaskStatus | undefined;
+  position: number | undefined;
+  media: MediaFull[] | undefined;
+  createdBy: string | undefined;
+  createdAt: wellKnownTimestamp | undefined;
+  updatedAt: wellKnownTimestamp | undefined;
+};
+
+// TaskCommentInsert is the writable payload for a comment. author is set
+// server-side from the caller's JWT (not client-supplied).
+export type TaskCommentInsert = {
+  taskId: number | undefined;
+  body: string | undefined;
+};
+
+export type TaskComment = {
+  id: number | undefined;
+  taskId: number | undefined;
+  author: string | undefined;
+  body: string | undefined;
+  createdAt: wellKnownTimestamp | undefined;
+};
+
 // TechCardStage is the development stage of a tech pack: prototype, fit sample,
 // salesman sample, pre-production, production.
 export type TechCardStage =

--- a/src/components/managers/page/components/CrossSellTable.tsx
+++ b/src/components/managers/page/components/CrossSellTable.tsx
@@ -26,9 +26,7 @@ export const CrossSellTable: FC<CrossSellTableProps> = ({ metrics }) => {
   const pairs = all
     .filter((p) => (p.count ?? 0) >= MIN_SUPPORT)
     .filter((p) => (hasLift ? (p.lift ?? 0) >= MIN_LIFT : true))
-    .sort((a, b) =>
-      hasLift ? (b.lift ?? 0) - (a.lift ?? 0) : (b.count ?? 0) - (a.count ?? 0),
-    )
+    .sort((a, b) => (hasLift ? (b.lift ?? 0) - (a.lift ?? 0) : (b.count ?? 0) - (a.count ?? 0)))
     .slice(0, 20);
 
   if (pairs.length === 0) return null;
@@ -68,9 +66,7 @@ export const CrossSellTable: FC<CrossSellTableProps> = ({ metrics }) => {
                   </td>
                   {/* Confidence = P(B|A): of orders with A, the share that also bought B. */}
                   <td className='p-2 text-right'>{pct(p.confidence)}</td>
-                  {hasLift && (
-                    <td className={`p-2 text-right ${liftClass}`}>{lift.toFixed(1)}×</td>
-                  )}
+                  {hasLift && <td className={`p-2 text-right ${liftClass}`}>{lift.toFixed(1)}×</td>}
                 </tr>
               );
             })}

--- a/src/components/managers/page/components/CrossSellTable.tsx
+++ b/src/components/managers/page/components/CrossSellTable.tsx
@@ -9,9 +9,28 @@ interface CrossSellTableProps {
 
 // A pair bought together once or twice is chance, not a bundling signal — require real support.
 const MIN_SUPPORT = 3;
+// Lift > 1 means the pair sells together MORE than their solo rates predict. At/below 1 the
+// co-occurrence is just two popular items crossing paths — not a bundle worth merchandising.
+const MIN_LIFT = 1;
+
+/** confidence/support are 0–1 probabilities from the backend; show as whole percents. */
+function pct(fraction: number | undefined): string {
+  return `${Math.round((fraction ?? 0) * 100)}%`;
+}
 
 export const CrossSellTable: FC<CrossSellTableProps> = ({ metrics }) => {
-  const pairs = (metrics?.crossSellPairs ?? []).filter((p) => (p.count ?? 0) >= MIN_SUPPORT);
+  const all = metrics?.commerce?.crossSellPairs ?? [];
+  // Backend now ships lift; when present, rank by association strength and drop chance pairs.
+  // Fall back to raw-count support if an older payload omits lift.
+  const hasLift = all.some((p) => p.lift != null);
+  const pairs = all
+    .filter((p) => (p.count ?? 0) >= MIN_SUPPORT)
+    .filter((p) => (hasLift ? (p.lift ?? 0) >= MIN_LIFT : true))
+    .sort((a, b) =>
+      hasLift ? (b.lift ?? 0) - (a.lift ?? 0) : (b.count ?? 0) - (a.count ?? 0),
+    )
+    .slice(0, 20);
+
   if (pairs.length === 0) return null;
 
   return (
@@ -25,27 +44,43 @@ export const CrossSellTable: FC<CrossSellTableProps> = ({ metrics }) => {
             <tr className='border-b border-textInactiveColor'>
               <th className='text-left p-2 uppercase'>Product A</th>
               <th className='text-left p-2 uppercase'>Product B</th>
-              <th className='text-right p-2 uppercase'>Count</th>
+              <th className='text-right p-2 uppercase'>Together</th>
+              <th className='text-right p-2 uppercase'>Attach rate</th>
+              {hasLift && <th className='text-right p-2 uppercase'>Lift</th>}
             </tr>
           </thead>
           <tbody>
-            {pairs.map((p, i) => (
-              <tr key={i} className='border-b border-textInactiveColor last:border-0'>
-                <td className='p-2'>
-                  <ProductNameLink productId={p.productAId} productName={p.productAName} />
-                </td>
-                <td className='p-2'>
-                  <ProductNameLink productId={p.productBId} productName={p.productBName} />
-                </td>
-                <td className='p-2 text-right'>{p.count ?? 0}</td>
-              </tr>
-            ))}
+            {pairs.map((p, i) => {
+              const lift = p.lift ?? 0;
+              // >1.5× is a strong bundle worth a cross-sell slot; 1–1.5× is mild.
+              const liftClass =
+                lift >= 1.5 ? 'text-green-600 font-bold' : lift > 1 ? 'font-bold' : '';
+              return (
+                <tr key={i} className='border-b border-textInactiveColor last:border-0'>
+                  <td className='p-2'>
+                    <ProductNameLink productId={p.productAId} productName={p.productAName} />
+                  </td>
+                  <td className='p-2'>
+                    <ProductNameLink productId={p.productBId} productName={p.productBName} />
+                  </td>
+                  <td className='p-2 text-right' title={`support ${pct(p.support)} of all orders`}>
+                    {p.count ?? 0}
+                  </td>
+                  {/* Confidence = P(B|A): of orders with A, the share that also bought B. */}
+                  <td className='p-2 text-right'>{pct(p.confidence)}</td>
+                  {hasLift && (
+                    <td className={`p-2 text-right ${liftClass}`}>{lift.toFixed(1)}×</td>
+                  )}
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>
       <Text className='text-xs text-textInactiveColor'>
-        Only pairs bought together {MIN_SUPPORT}+ times. Raw co-occurrence — a true lift score (vs
-        how often each sells alone) needs marginal frequencies from the backend.
+        {hasLift
+          ? `Pairs bought together ${MIN_SUPPORT}+ times, ranked by lift. Lift = how much more often the pair sells together than their solo rates predict (>1× = a real bundle, not chance). Attach rate is the share of A's orders that also bought B.`
+          : `Only pairs bought together ${MIN_SUPPORT}+ times.`}
       </Text>
     </div>
   );

--- a/src/components/managers/page/components/DropVerdictTable.tsx
+++ b/src/components/managers/page/components/DropVerdictTable.tsx
@@ -30,8 +30,8 @@ export const DropVerdictTable: FC<DropVerdictTableProps> = ({ sellThroughByDrop 
         Drop verdict
       </Text>
       <Text className='text-xs text-textInactiveColor mb-4 block'>
-        Per-release sell-through — the drop-brand KPI. Whole-drop totals, so the read is decision-grade
-        even when a single day is only a handful of orders.
+        Per-release sell-through — the drop-brand KPI. Whole-drop totals, so the read is
+        decision-grade even when a single day is only a handful of orders.
       </Text>
       <div className='overflow-x-auto'>
         <table className='w-full text-xs'>

--- a/src/components/managers/page/components/DropVerdictTable.tsx
+++ b/src/components/managers/page/components/DropVerdictTable.tsx
@@ -1,0 +1,148 @@
+import type { SellThroughByDropRow } from 'api/proto-http/admin';
+import { FC } from 'react';
+import Text from 'ui/components/text';
+import { formatCurrency, formatNumber, parseDecimal } from '../utils';
+
+interface DropVerdictTableProps {
+  sellThroughByDrop: SellThroughByDropRow[] | undefined;
+}
+
+// Sell-through verdict bands. A drop brand lives or dies on how much of a release clears —
+// these are the coarse "reprint / hold / cut" buckets, not precise targets.
+function verdict(pct: number): { label: string; cls: string } {
+  if (pct >= 75) return { label: 'Strong', cls: 'text-green-600' };
+  if (pct >= 40) return { label: 'OK', cls: 'text-textColor' };
+  return { label: 'Weak', cls: 'text-warning' };
+}
+
+export const DropVerdictTable: FC<DropVerdictTableProps> = ({ sellThroughByDrop }) => {
+  if (!sellThroughByDrop || sellThroughByDrop.length === 0) return null;
+
+  // Biggest drops first — that's where the money and the reprint decision live.
+  const rows = [...sellThroughByDrop].sort(
+    (a, b) => parseDecimal(b.revenue) - parseDecimal(a.revenue),
+  );
+  const anyCosted = rows.some((r) => r.hasCost);
+
+  return (
+    <div className='border border-textInactiveColor p-4'>
+      <Text variant='uppercase' className='font-bold mb-1 block'>
+        Drop verdict
+      </Text>
+      <Text className='text-xs text-textInactiveColor mb-4 block'>
+        Per-release sell-through — the drop-brand KPI. Whole-drop totals, so the read is decision-grade
+        even when a single day is only a handful of orders.
+      </Text>
+      <div className='overflow-x-auto'>
+        <table className='w-full text-xs'>
+          <thead>
+            <tr className='border-b border-textInactiveColor'>
+              <th className='text-left p-2'>
+                <Text variant='uppercase' className='text-[10px]'>
+                  Drop
+                </Text>
+              </th>
+              <th className='text-right p-2'>
+                <Text variant='uppercase' className='text-[10px]'>
+                  Products
+                </Text>
+              </th>
+              <th className='text-right p-2'>
+                <Text variant='uppercase' className='text-[10px]'>
+                  Units sold / bought
+                </Text>
+              </th>
+              <th className='text-right p-2'>
+                <Text variant='uppercase' className='text-[10px]'>
+                  Sell-through %
+                </Text>
+              </th>
+              <th className='text-right p-2'>
+                <Text variant='uppercase' className='text-[10px]'>
+                  Days to 50%
+                </Text>
+              </th>
+              <th className='text-right p-2'>
+                <Text variant='uppercase' className='text-[10px]'>
+                  Revenue
+                </Text>
+              </th>
+              <th className='text-right p-2'>
+                <Text variant='uppercase' className='text-[10px]'>
+                  Margin
+                </Text>
+              </th>
+              <th className='text-right p-2'>
+                <Text variant='uppercase' className='text-[10px]'>
+                  Verdict
+                </Text>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, idx) => {
+              const pct = row.sellThroughPct || 0;
+              const v = verdict(pct);
+              return (
+                <tr key={idx} className='border-b border-textInactiveColor hover:bg-bgSecondary'>
+                  <td className='p-2'>
+                    <Text className='font-bold'>{row.collection || 'Untagged'}</Text>
+                  </td>
+                  <td className='p-2 text-right'>
+                    <Text>{formatNumber(row.productCount || 0)}</Text>
+                  </td>
+                  <td className='p-2 text-right'>
+                    <Text>
+                      {formatNumber(row.unitsSold || 0)}/{formatNumber(row.unitsBought || 0)}
+                    </Text>
+                  </td>
+                  <td className='p-2 text-right'>
+                    <Text className={`font-bold ${v.cls}`}>{pct.toFixed(1)}%</Text>
+                  </td>
+                  <td className='p-2 text-right'>
+                    {row.daysTo50pct != null ? (
+                      <Text>{formatNumber(row.daysTo50pct)}d</Text>
+                    ) : (
+                      <Text variant='inactive' title='Has not reached 50% sell-through yet'>
+                        —
+                      </Text>
+                    )}
+                  </td>
+                  <td className='p-2 text-right'>
+                    <Text>{formatCurrency(parseDecimal(row.revenue))}</Text>
+                  </td>
+                  <td
+                    className='p-2 text-right'
+                    title={
+                      row.hasCost
+                        ? `Gross margin ${formatCurrency(parseDecimal(row.grossMargin))}`
+                        : 'No product cost set for this drop'
+                    }
+                  >
+                    {row.hasCost && row.grossMarginPct != null ? (
+                      <Text>{row.grossMarginPct.toFixed(0)}%</Text>
+                    ) : (
+                      <Text variant='inactive'>N/A</Text>
+                    )}
+                  </td>
+                  <td className='p-2 text-right'>
+                    <Text variant='uppercase' className={`text-[10px] font-bold ${v.cls}`}>
+                      {v.label}
+                    </Text>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <div className='mt-3 text-xs text-textInactiveColor space-y-1'>
+        <Text>
+          Sell-through = units sold ÷ units bought. Days-to-50% is how fast the release cleared its
+          first half; blank = not there yet. Strong ≥75% · OK ≥40% · Weak below.
+        </Text>
+        {!anyCosted && <Text>Set product costs to see per-drop margin.</Text>}
+      </div>
+    </div>
+  );
+};

--- a/src/components/managers/page/components/GeographyCharts.tsx
+++ b/src/components/managers/page/components/GeographyCharts.tsx
@@ -82,7 +82,7 @@ interface GeographyChartsProps {
 // flips on a single large order — cut. This is DB revenue, so it's trustworthy (unlike GA4 geo).
 export const GeographyCharts: FC<GeographyChartsProps> = ({ metrics }) => {
   if (!metrics) return null;
-  const data = geoToChartData(metrics.revenueByCountry);
+  const data = geoToChartData(metrics.commerce?.revenueByCountry);
   if (data.length === 0) return null;
 
   return (

--- a/src/components/managers/page/components/PersistentKpiBar.tsx
+++ b/src/components/managers/page/components/PersistentKpiBar.tsx
@@ -46,12 +46,14 @@ function coverageNote(costCoverage: number): string | null {
 function getKpiMetrics(metrics: BusinessMetrics | undefined, compareEnabled: boolean): KpiMetric[] {
   if (!metrics) return [];
 
-  const revenue = getMetricComparison(metrics.revenue as any);
-  const orders = getMetricComparison(metrics.ordersCount as any);
-  const grossMarginPct = getMetricComparison(metrics.grossMarginPct as any);
-  const contributionMargin = getMetricComparison(metrics.contributionMargin as any);
+  const commerce = metrics.commerce;
+  const margin = metrics.margin;
+  const revenue = getMetricComparison(commerce?.revenue as any);
+  const orders = getMetricComparison(commerce?.ordersCount as any);
+  const grossMarginPct = getMetricComparison(margin?.grossMarginPct as any);
+  const contributionMargin = getMetricComparison(margin?.contributionMargin as any);
   // Share (%) of revenue whose product has a cost set — margin is computed only over it.
-  const costCoverage = metrics.costCoveragePct ?? 0;
+  const costCoverage = margin?.costCoveragePct ?? 0;
   const costed = costCoverage > 0;
 
   return [

--- a/src/components/managers/page/components/ProductCharts.tsx
+++ b/src/components/managers/page/components/ProductCharts.tsx
@@ -29,8 +29,9 @@ export const ProductCharts: FC<ProductChartsProps> = ({ metrics }) => {
   const navigate = useNavigate();
   if (!metrics) return null;
 
+  const commerce = metrics.commerce;
   const revenueData =
-    metrics.topProductsByRevenue?.slice(0, 10).map((p) => ({
+    commerce?.topProductsByRevenue?.slice(0, 10).map((p) => ({
       name: (p.productName || `#${p.productId}`).slice(0, 20),
       value: parseDecimal(p.value),
       count: p.count ?? 0,
@@ -38,7 +39,7 @@ export const ProductCharts: FC<ProductChartsProps> = ({ metrics }) => {
     })) ?? [];
 
   const quantityData =
-    metrics.topProductsByQuantity?.slice(0, 10).map((p) => ({
+    commerce?.topProductsByQuantity?.slice(0, 10).map((p) => ({
       name: (p.productName || `#${p.productId}`).slice(0, 20),
       value: p.count ?? 0,
       revenue: parseDecimal(p.value),
@@ -47,7 +48,7 @@ export const ProductCharts: FC<ProductChartsProps> = ({ metrics }) => {
 
   // Revenue rank with margin, so a top seller that's actually low-margin is visible.
   const revenueMarginRows =
-    metrics.topProductsByRevenue?.slice(0, 10).map((p) => ({
+    commerce?.topProductsByRevenue?.slice(0, 10).map((p) => ({
       productId: p.productId,
       productName: p.productName,
       revenue: parseDecimal(p.value),
@@ -65,7 +66,7 @@ export const ProductCharts: FC<ProductChartsProps> = ({ metrics }) => {
   };
 
   const categoryData =
-    metrics.revenueByCategory?.map((c) => ({
+    commerce?.revenueByCategory?.map((c) => ({
       name: (c.categoryName || `#${c.categoryId}`).slice(0, 20),
       value: parseDecimal(c.value),
       count: c.count ?? 0,

--- a/src/components/managers/page/components/PromoTable.tsx
+++ b/src/components/managers/page/components/PromoTable.tsx
@@ -8,7 +8,7 @@ interface PromoTableProps {
 }
 
 export const PromoTable: FC<PromoTableProps> = ({ metrics }) => {
-  const promos = metrics?.revenueByPromo ?? [];
+  const promos = metrics?.commerce?.revenueByPromo ?? [];
   if (promos.length === 0) return null;
 
   return (

--- a/src/components/managers/page/components/SizeRunEfficiencyTable.tsx
+++ b/src/components/managers/page/components/SizeRunEfficiencyTable.tsx
@@ -15,9 +15,18 @@ const MIN_SIZES = 3;
 export const SizeRunEfficiencyTable: FC<SizeRunEfficiencyTableProps> = ({ sizeRunEfficiency }) => {
   if (!sizeRunEfficiency || sizeRunEfficiency.length === 0) return null;
 
+  // Backend now ships unit buy/sell quantities → real sell-through (units sold ÷ units bought),
+  // not just the coarse "how many distinct sizes sold at least once" coverage proxy.
+  const hasUnitData = sizeRunEfficiency.some((r) => (r.unitsBought ?? 0) > 0);
+
   const sorted = [...sizeRunEfficiency]
     .filter((r) => (r.totalSizes || 0) >= MIN_SIZES)
-    .sort((a, b) => (a.efficiencyPct || 0) - (b.efficiencyPct || 0))
+    // Worst sell-through first — those are the overbought runs to act on.
+    .sort((a, b) =>
+      hasUnitData
+        ? (a.sellThroughPct || 0) - (b.sellThroughPct || 0)
+        : (a.efficiencyPct || 0) - (b.efficiencyPct || 0),
+    )
     .slice(0, 20);
 
   if (sorted.length === 0) return null;
@@ -38,24 +47,33 @@ export const SizeRunEfficiencyTable: FC<SizeRunEfficiencyTableProps> = ({ sizeRu
               </th>
               <th className='text-right p-2'>
                 <Text variant='uppercase' className='text-[10px]'>
-                  Total sizes
+                  Sizes sold
                 </Text>
               </th>
+              {hasUnitData && (
+                <th className='text-right p-2'>
+                  <Text variant='uppercase' className='text-[10px]'>
+                    Units sold / bought
+                  </Text>
+                </th>
+              )}
               <th className='text-right p-2'>
                 <Text variant='uppercase' className='text-[10px]'>
-                  Sold through
-                </Text>
-              </th>
-              <th className='text-right p-2'>
-                <Text variant='uppercase' className='text-[10px]'>
-                  Sell-through %
+                  {hasUnitData ? 'Sell-through %' : 'Size coverage %'}
                 </Text>
               </th>
             </tr>
           </thead>
           <tbody>
             {sorted.map((row, idx) => {
-              const pct = row.efficiencyPct || 0;
+              const totalSizes = row.totalSizes || 0;
+              const bought = row.unitsBought ?? 0;
+              // Prefer true unit sell-through; fall back to the size-coverage proxy when a row
+              // has no buy quantity (e.g. stock predates cost/receiving data).
+              const showTrue = hasUnitData && bought > 0;
+              const pct = showTrue ? row.sellThroughPct || 0 : row.efficiencyPct || 0;
+              // Low sell-through on a wide run = real overbuy; single-digit runs are too small to judge.
+              const isPoor = pct < 50 && totalSizes >= 4;
               return (
                 <tr key={idx} className='border-b border-textInactiveColor hover:bg-bgSecondary'>
                   <td className='p-2'>
@@ -66,20 +84,24 @@ export const SizeRunEfficiencyTable: FC<SizeRunEfficiencyTableProps> = ({ sizeRu
                     />
                   </td>
                   <td className='p-2 text-right'>
-                    <Text>{formatNumber(row.totalSizes || 0)}</Text>
+                    <Text>
+                      {formatNumber(row.soldThroughSizes || 0)}/{formatNumber(totalSizes)}
+                    </Text>
                   </td>
+                  {hasUnitData && (
+                    <td className='p-2 text-right'>
+                      {bought > 0 ? (
+                        <Text>
+                          {formatNumber(row.unitsSold ?? 0)}/{formatNumber(bought)}
+                        </Text>
+                      ) : (
+                        <Text variant='inactive'>—</Text>
+                      )}
+                    </td>
+                  )}
                   <td className='p-2 text-right'>
-                    <Text>{formatNumber(row.soldThroughSizes || 0)}</Text>
-                  </td>
-                  <td className='p-2 text-right'>
-                    <Text
-                      className={
-                        pct < 50 && (row.totalSizes || 0) >= 4
-                          ? 'text-error font-bold'
-                          : 'font-bold'
-                      }
-                    >
-                      {pct.toFixed(1)}%
+                    <Text className={isPoor ? 'text-error font-bold' : 'font-bold'}>
+                      {pct.toFixed(1)}%{!showTrue && hasUnitData ? '*' : ''}
                     </Text>
                   </td>
                 </tr>
@@ -89,13 +111,22 @@ export const SizeRunEfficiencyTable: FC<SizeRunEfficiencyTableProps> = ({ sizeRu
         </table>
       </div>
       <div className='mt-3 text-xs text-textInactiveColor space-y-1'>
-        <Text>
-          Share of distinct sizes that sold at least once (of {MIN_SIZES}+ sizes offered) — a coarse
-          proxy for whether the size run was bought right. Low = likely overbought some sizes.
-        </Text>
-        <Text>
-          True sell-through (units sold ÷ units bought) needs cost/buy data from the backend.
-        </Text>
+        {hasUnitData ? (
+          <>
+            <Text>
+              True sell-through = units sold ÷ units bought. Low on a wide size run = likely
+              overbought — the sizes to cut next buy.
+            </Text>
+            {sorted.some((r) => (r.unitsBought ?? 0) === 0) && (
+              <Text>* Size-coverage proxy shown where unit buy quantities aren&apos;t recorded.</Text>
+            )}
+          </>
+        ) : (
+          <Text>
+            Share of distinct sizes that sold at least once (of {MIN_SIZES}+ sizes offered) — a
+            coarse proxy while unit buy quantities aren&apos;t recorded yet.
+          </Text>
+        )}
       </div>
     </div>
   );

--- a/src/components/managers/page/components/SizeRunEfficiencyTable.tsx
+++ b/src/components/managers/page/components/SizeRunEfficiencyTable.tsx
@@ -118,7 +118,9 @@ export const SizeRunEfficiencyTable: FC<SizeRunEfficiencyTableProps> = ({ sizeRu
               overbought — the sizes to cut next buy.
             </Text>
             {sorted.some((r) => (r.unitsBought ?? 0) === 0) && (
-              <Text>* Size-coverage proxy shown where unit buy quantities aren&apos;t recorded.</Text>
+              <Text>
+                * Size-coverage proxy shown where unit buy quantities aren&apos;t recorded.
+              </Text>
             )}
           </>
         ) : (

--- a/src/components/managers/page/components/SlowMoversTable.tsx
+++ b/src/components/managers/page/components/SlowMoversTable.tsx
@@ -27,6 +27,8 @@ export const SlowMoversTable: FC<SlowMoversTableProps> = ({ slowMovers }) => {
   }, [slowMovers, showNoSalesProducts]);
 
   const hiddenGhostCount = useMemo(() => slowMovers.filter(isNeverSoldGhost).length, [slowMovers]);
+  // Margin tells you how much room there is to mark a slow mover down before it stops paying.
+  const anyCosted = useMemo(() => topSlowMovers.some((r) => r.hasCost), [topSlowMovers]);
 
   return (
     <div className='border border-textInactiveColor p-4'>
@@ -68,6 +70,11 @@ export const SlowMoversTable: FC<SlowMoversTableProps> = ({ slowMovers }) => {
                 </th>
                 <th className='text-right p-2'>
                   <Text variant='uppercase' className='text-[10px]'>
+                    Margin
+                  </Text>
+                </th>
+                <th className='text-right p-2'>
+                  <Text variant='uppercase' className='text-[10px]'>
                     Units Sold
                   </Text>
                 </th>
@@ -101,6 +108,20 @@ export const SlowMoversTable: FC<SlowMoversTableProps> = ({ slowMovers }) => {
                     <td className='p-2 text-right'>
                       <Text>{formatCurrency(parseDecimal(row.revenue))}</Text>
                     </td>
+                    <td
+                      className='p-2 text-right'
+                      title={
+                        row.hasCost
+                          ? `Gross margin ${formatCurrency(parseDecimal(row.grossMargin))}`
+                          : 'No product cost set'
+                      }
+                    >
+                      {row.hasCost && row.grossMarginPct != null ? (
+                        <Text>{row.grossMarginPct.toFixed(0)}%</Text>
+                      ) : (
+                        <Text variant='inactive'>N/A</Text>
+                      )}
+                    </td>
                     <td className='p-2 text-right'>
                       <Text>{formatNumber(row.unitsSold || 0)}</Text>
                     </td>
@@ -120,7 +141,11 @@ export const SlowMoversTable: FC<SlowMoversTableProps> = ({ slowMovers }) => {
         </div>
       )}
       <div className='mt-3 text-xs text-textInactiveColor space-y-1'>
-        <Text>Products with low sales velocity — consider promotions or markdown.</Text>
+        <Text>
+          Products with low sales velocity — consider promotions or markdown. Margin is the room to
+          discount before a unit stops paying for itself.
+        </Text>
+        {!anyCosted && <Text>Set product costs to see margin (markdown headroom) here.</Text>}
         {!showNoSalesProducts && hiddenGhostCount > 0 && (
           <Text>Default view excludes products with no sales (e.g. test or seed SKUs).</Text>
         )}

--- a/src/components/managers/page/components/TrafficCharts.tsx
+++ b/src/components/managers/page/components/TrafficCharts.tsx
@@ -32,7 +32,7 @@ function trafficBySourceToData(items: TrafficSourceMetric[] | undefined) {
  */
 export const TrafficCharts: FC<TrafficChartsProps> = ({ metrics }) => {
   if (!metrics) return null;
-  const data = trafficBySourceToData(metrics.trafficBySource).slice(0, 10);
+  const data = trafficBySourceToData(metrics.traffic?.trafficBySource).slice(0, 10);
   if (data.length === 0) return null;
 
   const tooltipFormatter = (raw: TooltipComponentFormatterCallbackParams) => {

--- a/src/components/managers/page/components/index.ts
+++ b/src/components/managers/page/components/index.ts
@@ -3,6 +3,7 @@ export { ChannelSpendForm } from './ChannelSpendForm';
 export { CrossSellTable } from './CrossSellTable';
 export { DateRangePicker } from './DateRangePicker';
 export { DeadStockTable } from './DeadStockTable';
+export { DropVerdictTable } from './DropVerdictTable';
 export { ExecutiveHealthStrip } from './ExecutiveHealthStrip';
 export { FunnelChart } from './FunnelChart';
 export { GeographyCharts } from './GeographyCharts';

--- a/src/components/managers/page/executiveAlerts.ts
+++ b/src/components/managers/page/executiveAlerts.ts
@@ -45,7 +45,7 @@ export function currentMetricValue(m: unknown): number {
 
 /** Whether there are enough current-period orders for order-derived rates to be trusted. */
 export function hasEnoughOrdersForAlert(metrics: BusinessMetrics | undefined): boolean {
-  return currentMetricValue(metrics?.ordersCount) >= MIN_ORDERS_FOR_ALERT;
+  return currentMetricValue(metrics?.commerce?.ordersCount) >= MIN_ORDERS_FOR_ALERT;
 }
 
 function effectiveChangePct(m: unknown): number | null {
@@ -60,7 +60,8 @@ function effectiveChangePct(m: unknown): number | null {
 }
 
 export function orderCancellationSharePercent(metrics: BusinessMetrics | undefined): number | null {
-  const rows = metrics?.ordersByStatus;
+  const commerce = metrics?.commerce;
+  const rows = commerce?.ordersByStatus;
   if (!rows?.length) return null;
   let statusSum = 0;
   let cancelled = 0;
@@ -72,7 +73,7 @@ export function orderCancellationSharePercent(metrics: BusinessMetrics | undefin
   }
   // `ordersByStatus` counts status transitions (its sum exceeds the order count), so the share of
   // cancelled orders must be divided by the real order total, not by the sum of all status rows.
-  const totalOrders = getMetricComparison(asMetricRecord(metrics?.ordersCount)).value;
+  const totalOrders = getMetricComparison(asMetricRecord(commerce?.ordersCount)).value;
   const denom = totalOrders > 0 ? totalOrders : statusSum;
   if (denom <= 0) return null;
   return Math.min(100, (cancelled / denom) * 100);
@@ -86,10 +87,13 @@ export function computeExecutiveAlerts(
   const alerts: ExecutiveAlert[] = [];
   if (!metrics) return alerts;
 
+  const commerce = metrics.commerce;
+  const traffic = metrics.traffic;
+
   // Gate order- and session-derived alerts behind current-period volume floors so single-order
   // or low-traffic weeks don't trigger red/amber on pure noise.
-  const enoughOrders = currentMetricValue(metrics.ordersCount) >= MIN_ORDERS_FOR_ALERT;
-  const enoughSessions = currentMetricValue(metrics.sessions) >= MIN_SESSIONS_FOR_ALERT;
+  const enoughOrders = currentMetricValue(commerce?.ordersCount) >= MIN_ORDERS_FOR_ALERT;
+  const enoughSessions = currentMetricValue(traffic?.sessions) >= MIN_SESSIONS_FOR_ALERT;
 
   const cancelPct = orderCancellationSharePercent(metrics);
   if (enoughOrders && cancelPct != null && cancelPct >= CANCELLATION_SHARE_ALERT) {
@@ -101,7 +105,7 @@ export function computeExecutiveAlerts(
     });
   }
 
-  const refundRec = asMetricRecord(metrics.refundRate);
+  const refundRec = asMetricRecord(commerce?.refundRate);
   const refund = getMetricComparison(refundRec);
   if (enoughOrders && refund.value >= REFUND_RATE_LEVEL_WARNING) {
     alerts.push({
@@ -111,28 +115,28 @@ export function computeExecutiveAlerts(
   }
 
   if (compareEnabled) {
-    const revPct = effectiveChangePct(metrics.revenue);
+    const revPct = effectiveChangePct(commerce?.revenue);
     if (enoughOrders && revPct != null && revPct <= REVENUE_DROP_ALERT_PCT) {
       alerts.push({
         severity: 'warning',
         title: `Revenue ${formatPercent(revPct)} vs comparison period`,
       });
     }
-    const ordPct = effectiveChangePct(metrics.ordersCount);
+    const ordPct = effectiveChangePct(commerce?.ordersCount);
     if (enoughOrders && ordPct != null && ordPct <= ORDERS_DROP_ALERT_PCT) {
       alerts.push({
         severity: 'warning',
         title: `Orders ${formatPercent(ordPct)} vs comparison period`,
       });
     }
-    const sessPct = effectiveChangePct(metrics.sessions);
+    const sessPct = effectiveChangePct(traffic?.sessions);
     if (enoughSessions && sessPct != null && sessPct <= SESSIONS_DROP_ALERT_PCT) {
       alerts.push({
         severity: 'warning',
         title: `Sessions ${formatPercent(sessPct)} vs comparison period`,
       });
     }
-    const convPct = effectiveChangePct(metrics.conversionRate);
+    const convPct = effectiveChangePct(traffic?.conversionRate);
     if (enoughSessions && convPct != null && convPct <= CONVERSION_DROP_ALERT_PCT) {
       alerts.push({
         severity: 'warning',
@@ -171,10 +175,10 @@ export function deriveHealthStatus(
   if (
     compareEnabled &&
     metrics &&
-    currentMetricValue(metrics.ordersCount) >= MIN_ORDERS_FOR_ALERT
+    currentMetricValue(metrics.commerce?.ordersCount) >= MIN_ORDERS_FOR_ALERT
   ) {
-    const revPct = effectiveChangePct(metrics.revenue);
-    const ordPct = effectiveChangePct(metrics.ordersCount);
+    const revPct = effectiveChangePct(metrics.commerce?.revenue);
+    const ordPct = effectiveChangePct(metrics.commerce?.ordersCount);
     if (revPct != null && revPct <= -15 && ordPct != null && ordPct <= -15) {
       return 'needs_attention';
     }

--- a/src/components/managers/page/tabs/GrowthTab.tsx
+++ b/src/components/managers/page/tabs/GrowthTab.tsx
@@ -20,11 +20,12 @@ interface GrowthTabProps {
  */
 export function GrowthTab({ metricsResponse }: GrowthTabProps) {
   const metrics = metricsResponse.business;
-  const sampleSize = metrics?.clvDistribution?.sampleSize ?? 0;
+  const commerce = metrics?.commerce;
+  const sampleSize = commerce?.clvDistribution?.sampleSize ?? 0;
 
-  const repeatRate = getMetricComparison(metrics?.repeatCustomersRate as any);
-  const ordersPerCustomer = getMetricComparison(metrics?.avgOrdersPerCustomer as any);
-  const daysBetweenOrders = getMetricComparison(metrics?.avgDaysBetweenOrders as any);
+  const repeatRate = getMetricComparison(commerce?.repeatCustomersRate as any);
+  const ordersPerCustomer = getMetricComparison(commerce?.avgOrdersPerCustomer as any);
+  const daysBetweenOrders = getMetricComparison(commerce?.avgDaysBetweenOrders as any);
 
   return (
     <div className='space-y-10'>

--- a/src/components/managers/page/tabs/ProductsTab.tsx
+++ b/src/components/managers/page/tabs/ProductsTab.tsx
@@ -40,10 +40,11 @@ export function ProductsTab({ metricsResponse }: ProductsTabProps) {
   }, [hash, metricsResponse]);
 
   const metrics = metricsResponse.business;
+  const commerce = metrics?.commerce;
   const hasProductCharts =
-    (metrics?.topProductsByRevenue?.length ?? 0) > 0 ||
-    (metrics?.topProductsByQuantity?.length ?? 0) > 0 ||
-    (metrics?.revenueByCategory?.length ?? 0) > 0;
+    (commerce?.topProductsByRevenue?.length ?? 0) > 0 ||
+    (commerce?.topProductsByQuantity?.length ?? 0) > 0 ||
+    (commerce?.revenueByCategory?.length ?? 0) > 0;
   const hasAnyProductData =
     hasProductCharts ||
     (metricsResponse.slowMovers?.length ?? 0) > 0 ||

--- a/src/components/managers/page/tabs/ProductsTab.tsx
+++ b/src/components/managers/page/tabs/ProductsTab.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import {
   DeadStockTable,
+  DropVerdictTable,
   InventoryHealthTable,
   InventoryTargetForm,
   NotifyMeIntentTable,
@@ -47,6 +48,7 @@ export function ProductsTab({ metricsResponse }: ProductsTabProps) {
     (commerce?.revenueByCategory?.length ?? 0) > 0;
   const hasAnyProductData =
     hasProductCharts ||
+    (metricsResponse.sellThroughByDrop?.length ?? 0) > 0 ||
     (metricsResponse.slowMovers?.length ?? 0) > 0 ||
     (metricsResponse.deadStock?.length ?? 0) > 0 ||
     (metricsResponse.sizeAnalytics?.length ?? 0) > 0 ||
@@ -66,6 +68,17 @@ export function ProductsTab({ metricsResponse }: ProductsTabProps) {
         </div>
       ) : (
         <>
+          {(metricsResponse.sellThroughByDrop?.length ?? 0) > 0 && (
+            <details className='border border-textInactiveColor' open>
+              <summary className='cursor-pointer select-none bg-bgSecondary/30 px-4 py-3 text-sm font-bold uppercase hover:bg-bgSecondary/50'>
+                Drops
+              </summary>
+              <div className='space-y-6 p-4'>
+                <DropVerdictTable sellThroughByDrop={metricsResponse.sellThroughByDrop} />
+              </div>
+            </details>
+          )}
+
           <details className='border border-textInactiveColor' open>
             <summary className='cursor-pointer select-none bg-bgSecondary/30 px-4 py-3 text-sm font-bold uppercase hover:bg-bgSecondary/50'>
               What's Selling

--- a/src/components/managers/page/tabs/RevenueTab.tsx
+++ b/src/components/managers/page/tabs/RevenueTab.tsx
@@ -9,6 +9,7 @@ import {
   formatCurrencyDelta,
   formatNumber,
   formatNumberDelta,
+  formatPercentWithBand,
   getMetricComparison,
 } from '../utils';
 
@@ -224,7 +225,7 @@ export function RevenueTab({ metricsResponse, compareEnabled = false }: RevenueT
             </Text>
             {showRates && (
               <Text variant='uppercase' className='text-textInactiveColor text-[10px]'>
-                {refundRate.value.toFixed(1)}%
+                {formatPercentWithBand(refundRate.value, refundRate.marginOfError)}
               </Text>
             )}
           </div>

--- a/src/components/managers/page/tabs/RevenueTab.tsx
+++ b/src/components/managers/page/tabs/RevenueTab.tsx
@@ -54,12 +54,14 @@ const Delta: FC<{
 
 export function RevenueTab({ metricsResponse, compareEnabled = false }: RevenueTabProps) {
   const metrics = metricsResponse.business;
+  const commerce = metrics?.commerce;
+  const margin = metrics?.margin;
 
-  const revenue = getMetricComparison(metrics?.revenue as any);
-  const grossRevenue = getMetricComparison(metrics?.grossRevenue as any);
-  const orders = getMetricComparison(metrics?.ordersCount as any);
-  const aov = getMetricComparison(metrics?.avgOrderValue as any);
-  const refundRate = getMetricComparison(metrics?.refundRate as any);
+  const revenue = getMetricComparison(commerce?.revenue as any);
+  const grossRevenue = getMetricComparison(commerce?.grossRevenue as any);
+  const orders = getMetricComparison(commerce?.ordersCount as any);
+  const aov = getMetricComparison(commerce?.avgOrderValue as any);
+  const refundRate = getMetricComparison(commerce?.refundRate as any);
   const cancellationPct = orderCancellationSharePercent(metrics);
 
   const ordersN = orders.value;
@@ -68,11 +70,11 @@ export function RevenueTab({ metricsResponse, compareEnabled = false }: RevenueT
   const showRates = ordersN >= MIN_ORDERS_FOR_RATE;
 
   // Margin — computed only over the costed subset of revenue (products with a cost set).
-  const revenueCost = getMetricComparison(metrics?.revenueCost as any);
-  const grossMargin = getMetricComparison(metrics?.grossMargin as any);
-  const grossMarginPct = getMetricComparison(metrics?.grossMarginPct as any);
-  const contributionMargin = getMetricComparison(metrics?.contributionMargin as any);
-  const costCoverage = metrics?.costCoveragePct ?? 0;
+  const revenueCost = getMetricComparison(margin?.revenueCost as any);
+  const grossMargin = getMetricComparison(margin?.grossMargin as any);
+  const grossMarginPct = getMetricComparison(margin?.grossMarginPct as any);
+  const contributionMargin = getMetricComparison(margin?.contributionMargin as any);
+  const costCoverage = margin?.costCoveragePct ?? 0;
   const marginPctTrusted = costCoverage >= COVERAGE_FLOOR_FOR_PCT;
 
   return (
@@ -224,10 +226,10 @@ export function RevenueTab({ metricsResponse, compareEnabled = false }: RevenueT
         </div>
 
         <div className='grid gap-4 md:grid-cols-2'>
-          <TimeSeriesChart title='Revenue' data={coarsenTimeSeries(metrics?.revenueByDay)} />
+          <TimeSeriesChart title='Revenue' data={coarsenTimeSeries(commerce?.revenueByDay)} />
           <TimeSeriesChart
             title='Gross revenue'
-            data={coarsenTimeSeries(metrics?.grossRevenueByDay)}
+            data={coarsenTimeSeries(commerce?.grossRevenueByDay)}
           />
         </div>
       </div>
@@ -252,20 +254,20 @@ export function RevenueTab({ metricsResponse, compareEnabled = false }: RevenueT
           <div className='grid gap-4 md:grid-cols-2'>
             <TimeSeriesChart
               title='Units sold'
-              data={coarsenTimeSeries(metrics?.unitsSoldByDay)}
+              data={coarsenTimeSeries(commerce?.unitsSoldByDay)}
               valueFormat='number'
             />
             <TimeSeriesChart
               title='Shipped'
-              data={coarsenTimeSeries(metrics?.shippedByDay)}
+              data={coarsenTimeSeries(commerce?.shippedByDay)}
               valueFormat='number'
             />
             <TimeSeriesChart
               title='Delivered'
-              data={coarsenTimeSeries(metrics?.deliveredByDay)}
+              data={coarsenTimeSeries(commerce?.deliveredByDay)}
               valueFormat='number'
             />
-            <TimeSeriesChart title='Refunds' data={coarsenTimeSeries(metrics?.refundsByDay)} />
+            <TimeSeriesChart title='Refunds' data={coarsenTimeSeries(commerce?.refundsByDay)} />
           </div>
         </div>
       </details>

--- a/src/components/managers/page/tabs/RevenueTab.tsx
+++ b/src/components/managers/page/tabs/RevenueTab.tsx
@@ -93,7 +93,8 @@ export function RevenueTab({ metricsResponse, compareEnabled = false }: RevenueT
             {costCoverage > 0
               ? `over the ${costCoverage.toFixed(0)}% of revenue with a product cost set`
               : 'set product costs to unlock'}
-            {uncostedCount > 0 && ` · ${uncostedCount} product${uncostedCount === 1 ? '' : 's'} missing cost`}
+            {uncostedCount > 0 &&
+              ` · ${uncostedCount} product${uncostedCount === 1 ? '' : 's'} missing cost`}
           </Text>
         </div>
         {costCoverage > 0 ? (

--- a/src/components/managers/page/tabs/RevenueTab.tsx
+++ b/src/components/managers/page/tabs/RevenueTab.tsx
@@ -73,9 +73,14 @@ export function RevenueTab({ metricsResponse, compareEnabled = false }: RevenueT
   const revenueCost = getMetricComparison(margin?.revenueCost as any);
   const grossMargin = getMetricComparison(margin?.grossMargin as any);
   const grossMarginPct = getMetricComparison(margin?.grossMarginPct as any);
+  const paymentFees = getMetricComparison(margin?.paymentFees as any);
   const contributionMargin = getMetricComparison(margin?.contributionMargin as any);
   const costCoverage = margin?.costCoveragePct ?? 0;
   const marginPctTrusted = costCoverage >= COVERAGE_FLOOR_FOR_PCT;
+  // Processor fees bridge gross profit → contribution; only show the line once they're captured.
+  const showFees = paymentFees.value > 0;
+  // Products with no cost entered are why margin is partial/dark — name the gap to close it.
+  const uncostedCount = margin?.uncostedProductIds?.length ?? 0;
 
   return (
     <div className='space-y-6'>
@@ -87,10 +92,13 @@ export function RevenueTab({ metricsResponse, compareEnabled = false }: RevenueT
             {costCoverage > 0
               ? `over the ${costCoverage.toFixed(0)}% of revenue with a product cost set`
               : 'set product costs to unlock'}
+            {uncostedCount > 0 && ` · ${uncostedCount} product${uncostedCount === 1 ? '' : 's'} missing cost`}
           </Text>
         </div>
         {costCoverage > 0 ? (
-          <div className='grid grid-cols-2 md:grid-cols-4 gap-3 border-2 border-textColor/20 p-4 bg-bgSecondary/30'>
+          <div
+            className={`grid grid-cols-2 ${showFees ? 'md:grid-cols-5' : 'md:grid-cols-4'} gap-3 border-2 border-textColor/20 p-4 bg-bgSecondary/30`}
+          >
             <div className='space-y-1'>
               <Text variant='uppercase' className='text-textInactiveColor text-[10px]'>
                 COGS
@@ -129,6 +137,17 @@ export function RevenueTab({ metricsResponse, compareEnabled = false }: RevenueT
                 </Text>
               )}
             </div>
+            {showFees && (
+              <div className='space-y-1'>
+                <Text variant='uppercase' className='text-textInactiveColor text-[10px]'>
+                  Payment fees
+                </Text>
+                <Text className='font-bold text-lg'>−{formatCurrency(paymentFees.value)}</Text>
+                <Text variant='uppercase' className='text-textInactiveColor text-[10px]'>
+                  processor cut
+                </Text>
+              </div>
+            )}
             <div className='space-y-1'>
               <Text variant='uppercase' className='text-textInactiveColor text-[10px]'>
                 Contribution
@@ -141,7 +160,7 @@ export function RevenueTab({ metricsResponse, compareEnabled = false }: RevenueT
                 enabled={compareEnabled}
               />
               <Text variant='uppercase' className='text-textInactiveColor text-[10px]'>
-                after shipping
+                {showFees ? 'after shipping & fees' : 'after shipping'}
               </Text>
             </div>
           </div>

--- a/src/components/managers/page/tabs/ThisWeekTab.tsx
+++ b/src/components/managers/page/tabs/ThisWeekTab.tsx
@@ -33,7 +33,10 @@ export function ThisWeekTab({
   customTo,
 }: ThisWeekTabProps) {
   const metrics = metricsResponse.business;
-  const metricsRecord = metrics as Record<string, unknown> | undefined;
+  const commerce = metrics?.commerce;
+  const traffic = metrics?.traffic;
+  // ordersByDay moved into the commerce sub-message; feed getTimeSeries that record.
+  const metricsRecord = commerce as Record<string, unknown> | undefined;
   const { pathname } = useLocation();
   const revenueHref = `${pathname}?tab=revenue`;
   const productsHref = `${pathname}?tab=products`;
@@ -62,8 +65,8 @@ export function ThisWeekTab({
   );
 
   const top3Products = useMemo(() => {
-    const byRevenue = metrics?.topProductsByRevenue || [];
-    const byQuantity = metrics?.topProductsByQuantity || [];
+    const byRevenue = commerce?.topProductsByRevenue || [];
+    const byQuantity = commerce?.topProductsByQuantity || [];
 
     // Units live in `count` on some breakdowns and in `value` on others — take whichever is
     // populated so the join doesn't silently render 0 units for every product.
@@ -78,10 +81,10 @@ export function ThisWeekTab({
       units: quantityMap.get(p.productId) ?? unitsOf(p),
       grossMarginPct: p.hasCost ? p.grossMarginPct : null,
     }));
-  }, [metrics?.topProductsByRevenue, metrics?.topProductsByQuantity]);
+  }, [commerce?.topProductsByRevenue, commerce?.topProductsByQuantity]);
 
   const topTrafficSource = useMemo(() => {
-    const sources = metrics?.trafficBySource || [];
+    const sources = traffic?.trafficBySource || [];
     const filtered = sources.filter((s) => {
       const name = [s.source, s.medium].filter(Boolean).join(' / ').toLowerCase();
       return !name.includes('direct') && !name.includes('none');
@@ -94,7 +97,7 @@ export function ThisWeekTab({
       name: [top.source, top.medium].filter(Boolean).join(' / ') || 'Unknown',
       sessions: top.sessions ?? 0,
     };
-  }, [metrics?.trafficBySource]);
+  }, [traffic?.trafficBySource]);
 
   // Payment failures = money that didn't get captured — the one ops-relevant signal kept
   // from the retired Technical tab.
@@ -143,12 +146,12 @@ export function ThisWeekTab({
         <div className='grid gap-4 md:grid-cols-2'>
           <TimeSeriesChart
             title='New customers'
-            data={coarsenTimeSeries(metrics?.newCustomersByDay)}
+            data={coarsenTimeSeries(commerce?.newCustomersByDay)}
             valueFormat='number'
           />
           <TimeSeriesChart
             title='Returning customers'
-            data={coarsenTimeSeries(metrics?.returningCustomersByDay)}
+            data={coarsenTimeSeries(commerce?.returningCustomersByDay)}
             valueFormat='number'
           />
         </div>

--- a/src/components/managers/page/utils.ts
+++ b/src/components/managers/page/utils.ts
@@ -47,7 +47,25 @@ export function getMetricComparison(m: Record<string, unknown> | undefined) {
   // n the metric is computed over (e.g. orders behind a refund rate). Lets the UI suppress
   // or widen a figure at low volume instead of guessing from arbitrary hardcoded floors.
   const sampleSize = (m.sampleSize ?? m.sample_size) as number | undefined;
-  return { value, compareValue, changePct, lowerIsBetter, changeAbsolute, caveat, sampleSize };
+  // 95% CI half-width in the metric's own units; populated only for true count-proportions
+  // (conversion, promo usage). Lets the UI render "12.0% ± 2.4" instead of a bare rate.
+  const marginOfError = (m.marginOfError ?? m.margin_of_error) as number | undefined;
+  return {
+    value,
+    compareValue,
+    changePct,
+    lowerIsBetter,
+    changeAbsolute,
+    caveat,
+    sampleSize,
+    marginOfError,
+  };
+}
+
+/** Render a percentage with its 95% CI band when the backend computed one: "12.0% ± 2.4". */
+export function formatPercentWithBand(value: number, marginOfError: number | undefined): string {
+  const base = `${value.toFixed(1)}%`;
+  return marginOfError && marginOfError > 0 ? `${base} ± ${marginOfError.toFixed(1)}` : base;
 }
 
 /**


### PR DESCRIPTION
Promotes the analytics backend follow-ups from beta to master/prod. All changes verified on beta (#333).

Consumes `grbpwr-proto @26a19e8`:
- **Proto client regen** + submodule bump `59e11d3 → 26a19e8` (resyncs a drifted pointer).
- **Breaking migration**: `BusinessMetrics` god-object → `commerce / margin / traffic / email` sub-messages; all reads repointed.
- **New signals**: Drop verdict section (per-release sell-through), cross-sell lift + attach rate, slow-mover margin (markdown headroom), true size sell-through, payment fees + uncosted-product count in the P&L, sampleSize/marginOfError plumbing.
- Available-but-unwired by choice: `GetDashboard` RPC, `AlertSettings` CRUD.

Ledger: `docs/analytics-backend-asks.md`.

Verification: `tsc` clean w.r.t. this change (5 pre-existing hero/sidebar errors, untouched); `yarn build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En4pgGj4hfK2DKKeqKYyLN