### PR TITLE
Nav: impeccable polish on the grouped dropdowns

### DIFF
--- a/src/ui/components/nav-dropdown-menu.tsx
+++ b/src/ui/components/nav-dropdown-menu.tsx
@@ -45,7 +45,9 @@ export function NavDropdownMenu({
               <NavigationMenu.Trigger
                 className={cn(
                   'group flex items-center gap-1 px-2 py-1 text-textBaseSize whitespace-nowrap cursor-pointer',
-                  'underline-offset-4 transition-colors hover:underline',
+                  // Hover matches the bar's logo/logout language (opacity), so the
+                  // underline is reserved to mean "this section is open or active".
+                  'underline-offset-4 transition-opacity hover:opacity-70',
                   'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-textColor',
                   'data-[state=open]:underline',
                   groupActive && 'underline',
@@ -54,7 +56,7 @@ export function NavDropdownMenu({
                 {group.label}
                 <ChevronDownIcon
                   aria-hidden
-                  className='size-3 opacity-50 transition-transform duration-150 group-data-[state=open]:rotate-180'
+                  className='size-3 opacity-50 transition-transform duration-150 motion-reduce:transition-none group-data-[state=open]:rotate-180'
                 />
               </NavigationMenu.Trigger>
 
@@ -76,10 +78,14 @@ export function NavDropdownMenu({
                           <NavigationMenu.Link asChild active={itemActive}>
                             <Link
                               to={item.route}
+                              aria-current={itemActive ? 'page' : undefined}
                               className={cn(
                                 'block whitespace-nowrap px-3 py-2 text-textBaseSize transition-colors',
                                 'hover:bg-textColor hover:text-bgColor',
-                                'focus-visible:bg-textColor focus-visible:text-bgColor focus-visible:outline-none',
+                                // Keyboard focus inverts like hover, plus an inset ring so it
+                                // stays visible on the already-inverted active row.
+                                'focus-visible:bg-textColor focus-visible:text-bgColor',
+                                'focus-visible:outline focus-visible:outline-2 focus-visible:outline-bgColor focus-visible:[outline-offset:-2px]',
                                 itemActive && 'bg-textColor text-bgColor',
                               )}
                             >

--- a/src/ui/layout.tsx
+++ b/src/ui/layout.tsx
@@ -49,7 +49,7 @@ export const Layout: FC<LayoutProps> = ({ children }) => {
 
         <div className='flex grow basis-0 items-center justify-end gap-1'>
           <div className='hidden lg:block'>
-            <NavDropdownMenu groups={[ADMIN_GROUP]} align='end' />
+            <NavDropdownMenu groups={[ADMIN_GROUP]} align='end' onOpenChange={setIsNavOpen} />
           </div>
           <Button
             className='px-2 underline-offset-2 hover:underline transition-colors hover:opacity-70 cursor-pointer'


### PR DESCRIPTION
Follow-up polish on the grouped desktop nav (#335).

- Trigger hover matches the bar's logo/logout language (`opacity-70`); underline now means only "section open or active", removing the hover/active collision.
- Dropdown items get a distinct inset keyboard-focus ring (visible on the inverted active row) instead of dropping the outline; `aria-current="page"` on the active item.
- `prefers-reduced-motion` guard on the caret rotation.
- The right-aligned admin dropdown also frames the bar on open, matching the left nav.

`yarn build` ✓, `tsc` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BpScUQLCXZK7jZKeyfNBL