### PR TITLE
Proto 6f4121a: task fitting-link + start dates, fitting callouts, tech-card media split + costing redo

### DIFF
--- a/src/api/proto-http/admin/index.ts
+++ b/src/api/proto-http/admin/index.ts
@@ -2475,6 +2475,10 @@ export type common_FittingInsert = {
   // uploaded via Admin.UploadPattern; the url is stored as a snapshot (immune to later
   // tech-card edits).
   patterns: common_FittingPattern[] | undefined;
+  // Callouts pinned onto the fitting's photos — a marker + note flagging what is
+  // wrong with the fit at a point on a specific photo (media_ids). Full-replace on
+  // update, like sizes/media/patterns.
+  callouts: common_FittingCallout[] | undefined;
 };
 
 // FittingStatus is the lifecycle state of a fitting session.
@@ -2503,6 +2507,18 @@ export type common_FittingPattern = {
   url: string | undefined;
   filename: string | undefined;
   sizeBytes: number | undefined;
+};
+
+// FittingCallout is a numbered marker pinned to a fitting photo, noting a fit
+// problem at a point on the image ("here the shoulder is too tight"). It is the
+// fitting analogue of TechCardCallout but deliberately simpler: a pin + a note,
+// with no part/dimensions (a fitting flags posadka, not spec geometry).
+export type common_FittingCallout = {
+  number: number | undefined;
+  note: string | undefined;
+  mediaId: number | undefined;
+  posX: googletype_Decimal | undefined;
+  posY: googletype_Decimal | undefined;
 };
 
 export type AddFittingResponse = {
@@ -2583,6 +2599,11 @@ export type common_TaskInsert = {
   productId: number | undefined;
   orderUuid: string | undefined;
   archiveId: number | undefined;
+  fittingId: number | undefined;
+  // Planned start (when work SHOULD begin), the manual counterpart of due_date.
+  // The ACTUAL start (when the card first entered IN_PROGRESS) is the
+  // server-stamped Task.started_at, not this field. Unset = no planned start.
+  startDate: wellKnownTimestamp | undefined;
 };
 
 export type common_TaskPriority =
@@ -2640,6 +2661,10 @@ export type common_Task = {
   // Orthogonal to placement — archiving does not change board/status/position.
   archivedAt: wellKnownTimestamp | undefined;
   checklist: common_TaskChecklistItem[] | undefined;
+  // Actual start: server-stamped the FIRST time the card enters IN_PROGRESS
+  // (never client-supplied, never cleared on later moves). Unset = the card has
+  // not been started yet. This is distinct from the planned TaskInsert.start_date.
+  startedAt: wellKnownTimestamp | undefined;
 };
 
 // TaskChecklistItem is one row of a task's checklist — a lightweight subtask with
@@ -2774,8 +2799,9 @@ export type GetFulfillmentBoardResponse = {
   columns: common_FulfillmentColumnCards[] | undefined;
 };
 
-// FulfillmentColumnCards groups one column's cards, in fulfillment order
-// (oldest order first, so the longest-waiting order is picked first).
+// FulfillmentColumnCards groups one column's cards. The active columns
+// (TO_FULFILL, SHIPPED) are oldest order first (longest-waiting picked first);
+// the historical DELIVERED column is newest first and bounded.
 export type common_FulfillmentColumnCards = {
   column: common_FulfillmentColumn | undefined;
   cards: common_FulfillmentCard[] | undefined;
@@ -3365,7 +3391,13 @@ export type common_TechCardInsert = {
   // children (full-replace on update)
   sizeIds: number[] | undefined;
   productIds: number[] | undefined;
-  media: common_TechCardMediaItem[] | undefined;
+  // Sketch media split into two INDEPENDENT lists (replaces the single `media = 32`):
+  // moodboard_media — mood / inspiration / reference / fabric-swatch photos (design intent)
+  // technical_media — flat sketches used in construction (front / back / detail / lining / preview)
+  // Construction consumes ONLY technical_media. Each item's `kind` sub-classifies within its
+  // list. Both are full-replace on update; callouts pin onto technical_media by media_id.
+  moodboardMedia: common_TechCardMediaItem[] | undefined;
+  technicalMedia: common_TechCardMediaItem[] | undefined;
   callouts: common_TechCardCallout[] | undefined;
   revisions: common_TechCardRevision[] | undefined;
   // materials (Phase 2): bill of materials (article catalog) and colourways (recipes).
@@ -3651,31 +3683,32 @@ export type common_TechCardPackaging = {
   notes: string | undefined;
 };
 
-// TechCardCosting holds the manually-entered cost articles (Sheet «Калькуляция»).
-// The materials rollup and total are COMPUTED on read from the BOM; they are
-// output-only (ignored on write) and never converted across currencies.
+// TechCardCosting holds the manually-entered per-unit cost articles (Sheet «Калькуляция»).
+// Everything is in a SINGLE currency. The materials line and the unit/order totals are
+// COMPUTED on read (output-only, ignored on write). Model: cost is built per GARMENT, then
+// scaled to the whole order by order_qty. There is NO pricing here — markup/wholesale/retail
+// were removed; pricing lives on the published product.
 export type common_TechCardCosting = {
+  // manual per-unit cost articles (per ONE garment), all in `currency`.
   cmtCost: googletype_Decimal | undefined;
   hardwareCost: googletype_Decimal | undefined;
   packagingCost: googletype_Decimal | undefined;
   logisticsCost: googletype_Decimal | undefined;
   overheadCost: googletype_Decimal | undefined;
   defectPercent: googletype_Decimal | undefined;
-  // Pricing is single (brand policy): markup_multiplier, wholesale_price, retail_price
-  // and currency are the SAME across colourways. Per-SKU pricing, if ever needed, lives
-  // on the published product, not here.
-  markupMultiplier: googletype_Decimal | undefined;
-  wholesalePrice: googletype_Decimal | undefined;
-  retailPrice: googletype_Decimal | undefined;
   currency: string | undefined;
   notes: string | undefined;
-  // OUTPUT-ONLY computed rollup (ignored on write; no currency conversion). The root
-  // rollup is the PRIMARY colourway (colorways index 0); per-colourway figures are in
-  // colorway_costs. A usage with per-size consumption contributes its whole-run
-  // size_run_total (order-scale); a usage without contributes its per-garment line_total.
+  // OUTPUT-ONLY computed rollup (ignored on write). Root figures are the PRIMARY colourway
+  // (colorways index 0); per-colourway figures are in colorway_costs. Materials come from the
+  // BOM via each colourway's usages, normalised to a PER-GARMENT figure (a usage graded only
+  // per size is divided by order_qty), then taken in the single `currency` — a BOM line in
+  // another currency is flagged in has_unconverted_currencies and left out of materials_per_unit
+  // (it still appears in materials_total under its own currency, never silently dropped).
   materialsTotal: common_TechCardCostLine[] | undefined;
-  materialsCost: googletype_Decimal | undefined;
-  totalCost: googletype_Decimal | undefined;
+  materialsPerUnit: googletype_Decimal | undefined;
+  unitCost: googletype_Decimal | undefined;
+  orderQty: number | undefined;
+  orderCost: googletype_Decimal | undefined;
   hasUnconvertedCurrencies: boolean | undefined;
   totalSam: googletype_Decimal | undefined;
   colorwayCosts: common_TechCardColorwayCost[] | undefined;
@@ -3687,13 +3720,17 @@ export type common_TechCardCostLine = {
   amount: googletype_Decimal | undefined;
 };
 
-// TechCardColorwayCost is the computed material cost of ONE colourway (Sheet «Калькуляция»).
-// OUTPUT-ONLY (ignored on write). Per-currency buckets; no FX conversion.
+// TechCardColorwayCost is the computed cost of ONE colourway (Sheet «Калькуляция»),
+// OUTPUT-ONLY (ignored on write). Materials come from that colourway's usages; the manual
+// articles (CMT/hardware/…) are shared across colourways, so unit_cost folds them in. All
+// figures are per GARMENT except order_cost (whole run). No FX conversion.
 export type common_TechCardColorwayCost = {
   colorwayIndex: number | undefined;
   materialsTotal: common_TechCardCostLine[] | undefined;
-  materialsCost: googletype_Decimal | undefined;
-  sizeRunTotal: googletype_Decimal | undefined;
+  materialsPerUnit: googletype_Decimal | undefined;
+  unitCost: googletype_Decimal | undefined;
+  orderQty: number | undefined;
+  orderCost: googletype_Decimal | undefined;
   hasUnconvertedCurrencies: boolean | undefined;
 };
 
@@ -3793,14 +3830,17 @@ export type common_TechCard = {
   techCard: common_TechCardInsert | undefined;
   createdAt: wellKnownTimestamp | undefined;
   updatedAt: wellKnownTimestamp | undefined;
-  resolvedMedia: common_TechCardMediaFull[] | undefined;
   lockVersion: number | undefined;
+  // Resolved sketch media (MediaFull), split to mirror the writable lists.
+  resolvedMoodboardMedia: common_TechCardMediaFull[] | undefined;
+  resolvedTechnicalMedia: common_TechCardMediaFull[] | undefined;
 };
 
 // TechCardMediaFull is a resolved sketch-media reference for display.
 export type common_TechCardMediaFull = {
   media: common_MediaFull | undefined;
   kind: common_TechCardMediaKind | undefined;
+  caption: string | undefined;
 };
 
 export type UpdateTechCardRequest = {

--- a/src/api/proto-http/common/index.ts
+++ b/src/api/proto-http/common/index.ts
@@ -954,6 +954,10 @@ export type FittingInsert = {
   // uploaded via Admin.UploadPattern; the url is stored as a snapshot (immune to later
   // tech-card edits).
   patterns: FittingPattern[] | undefined;
+  // Callouts pinned onto the fitting's photos — a marker + note flagging what is
+  // wrong with the fit at a point on a specific photo (media_ids). Full-replace on
+  // update, like sizes/media/patterns.
+  callouts: FittingCallout[] | undefined;
 };
 
 // FittingPattern is one PDF выкройка iteration tried in a fitting (snapshot of the
@@ -963,6 +967,18 @@ export type FittingPattern = {
   url: string | undefined;
   filename: string | undefined;
   sizeBytes: number | undefined;
+};
+
+// FittingCallout is a numbered marker pinned to a fitting photo, noting a fit
+// problem at a point on the image ("here the shoulder is too tight"). It is the
+// fitting analogue of TechCardCallout but deliberately simpler: a pin + a note,
+// with no part/dimensions (a fitting flags posadka, not spec geometry).
+export type FittingCallout = {
+  number: number | undefined;
+  note: string | undefined;
+  mediaId: number | undefined;
+  posX: googletype_Decimal | undefined;
+  posY: googletype_Decimal | undefined;
 };
 
 // Fitting is a stored try-on session with resolved media for display.
@@ -1013,8 +1029,9 @@ export type FulfillmentCard = {
   hasNotes: boolean | undefined;
 };
 
-// FulfillmentColumnCards groups one column's cards, in fulfillment order
-// (oldest order first, so the longest-waiting order is picked first).
+// FulfillmentColumnCards groups one column's cards. The active columns
+// (TO_FULFILL, SHIPPED) are oldest order first (longest-waiting picked first);
+// the historical DELIVERED column is newest first and bounded.
 export type FulfillmentColumnCards = {
   column: FulfillmentColumn | undefined;
   cards: FulfillmentCard[] | undefined;
@@ -1544,6 +1561,11 @@ export type TaskInsert = {
   productId: number | undefined;
   orderUuid: string | undefined;
   archiveId: number | undefined;
+  fittingId: number | undefined;
+  // Planned start (when work SHOULD begin), the manual counterpart of due_date.
+  // The ACTUAL start (when the card first entered IN_PROGRESS) is the
+  // server-stamped Task.started_at, not this field. Unset = no planned start.
+  startDate: wellKnownTimestamp | undefined;
 };
 
 // TaskChecklistItem is one row of a task's checklist — a lightweight subtask with
@@ -1577,6 +1599,10 @@ export type Task = {
   // Orthogonal to placement — archiving does not change board/status/position.
   archivedAt: wellKnownTimestamp | undefined;
   checklist: TaskChecklistItem[] | undefined;
+  // Actual start: server-stamped the FIRST time the card enters IN_PROGRESS
+  // (never client-supplied, never cleared on later moves). Unset = the card has
+  // not been started yet. This is distinct from the planned TaskInsert.start_date.
+  startedAt: wellKnownTimestamp | undefined;
 };
 
 // TaskCommentInsert is the writable payload for a comment. author is set
@@ -1734,6 +1760,7 @@ export type TechCardMediaItem = {
 export type TechCardMediaFull = {
   media: MediaFull | undefined;
   kind: TechCardMediaKind | undefined;
+  caption: string | undefined;
 };
 
 // TechCardCallout is a numbered detail note pointing at the technical sketch.
@@ -1937,41 +1964,46 @@ export type TechCardCostLine = {
   amount: googletype_Decimal | undefined;
 };
 
-// TechCardColorwayCost is the computed material cost of ONE colourway (Sheet «Калькуляция»).
-// OUTPUT-ONLY (ignored on write). Per-currency buckets; no FX conversion.
+// TechCardColorwayCost is the computed cost of ONE colourway (Sheet «Калькуляция»),
+// OUTPUT-ONLY (ignored on write). Materials come from that colourway's usages; the manual
+// articles (CMT/hardware/…) are shared across colourways, so unit_cost folds them in. All
+// figures are per GARMENT except order_cost (whole run). No FX conversion.
 export type TechCardColorwayCost = {
   colorwayIndex: number | undefined;
   materialsTotal: TechCardCostLine[] | undefined;
-  materialsCost: googletype_Decimal | undefined;
-  sizeRunTotal: googletype_Decimal | undefined;
+  materialsPerUnit: googletype_Decimal | undefined;
+  unitCost: googletype_Decimal | undefined;
+  orderQty: number | undefined;
+  orderCost: googletype_Decimal | undefined;
   hasUnconvertedCurrencies: boolean | undefined;
 };
 
-// TechCardCosting holds the manually-entered cost articles (Sheet «Калькуляция»).
-// The materials rollup and total are COMPUTED on read from the BOM; they are
-// output-only (ignored on write) and never converted across currencies.
+// TechCardCosting holds the manually-entered per-unit cost articles (Sheet «Калькуляция»).
+// Everything is in a SINGLE currency. The materials line and the unit/order totals are
+// COMPUTED on read (output-only, ignored on write). Model: cost is built per GARMENT, then
+// scaled to the whole order by order_qty. There is NO pricing here — markup/wholesale/retail
+// were removed; pricing lives on the published product.
 export type TechCardCosting = {
+  // manual per-unit cost articles (per ONE garment), all in `currency`.
   cmtCost: googletype_Decimal | undefined;
   hardwareCost: googletype_Decimal | undefined;
   packagingCost: googletype_Decimal | undefined;
   logisticsCost: googletype_Decimal | undefined;
   overheadCost: googletype_Decimal | undefined;
   defectPercent: googletype_Decimal | undefined;
-  // Pricing is single (brand policy): markup_multiplier, wholesale_price, retail_price
-  // and currency are the SAME across colourways. Per-SKU pricing, if ever needed, lives
-  // on the published product, not here.
-  markupMultiplier: googletype_Decimal | undefined;
-  wholesalePrice: googletype_Decimal | undefined;
-  retailPrice: googletype_Decimal | undefined;
   currency: string | undefined;
   notes: string | undefined;
-  // OUTPUT-ONLY computed rollup (ignored on write; no currency conversion). The root
-  // rollup is the PRIMARY colourway (colorways index 0); per-colourway figures are in
-  // colorway_costs. A usage with per-size consumption contributes its whole-run
-  // size_run_total (order-scale); a usage without contributes its per-garment line_total.
+  // OUTPUT-ONLY computed rollup (ignored on write). Root figures are the PRIMARY colourway
+  // (colorways index 0); per-colourway figures are in colorway_costs. Materials come from the
+  // BOM via each colourway's usages, normalised to a PER-GARMENT figure (a usage graded only
+  // per size is divided by order_qty), then taken in the single `currency` — a BOM line in
+  // another currency is flagged in has_unconverted_currencies and left out of materials_per_unit
+  // (it still appears in materials_total under its own currency, never silently dropped).
   materialsTotal: TechCardCostLine[] | undefined;
-  materialsCost: googletype_Decimal | undefined;
-  totalCost: googletype_Decimal | undefined;
+  materialsPerUnit: googletype_Decimal | undefined;
+  unitCost: googletype_Decimal | undefined;
+  orderQty: number | undefined;
+  orderCost: googletype_Decimal | undefined;
   hasUnconvertedCurrencies: boolean | undefined;
   totalSam: googletype_Decimal | undefined;
   colorwayCosts: TechCardColorwayCost[] | undefined;
@@ -2015,7 +2047,13 @@ export type TechCardInsert = {
   // children (full-replace on update)
   sizeIds: number[] | undefined;
   productIds: number[] | undefined;
-  media: TechCardMediaItem[] | undefined;
+  // Sketch media split into two INDEPENDENT lists (replaces the single `media = 32`):
+  // moodboard_media — mood / inspiration / reference / fabric-swatch photos (design intent)
+  // technical_media — flat sketches used in construction (front / back / detail / lining / preview)
+  // Construction consumes ONLY technical_media. Each item's `kind` sub-classifies within its
+  // list. Both are full-replace on update; callouts pin onto technical_media by media_id.
+  moodboardMedia: TechCardMediaItem[] | undefined;
+  technicalMedia: TechCardMediaItem[] | undefined;
   callouts: TechCardCallout[] | undefined;
   revisions: TechCardRevision[] | undefined;
   // materials (Phase 2): bill of materials (article catalog) and colourways (recipes).
@@ -2044,8 +2082,10 @@ export type TechCard = {
   techCard: TechCardInsert | undefined;
   createdAt: wellKnownTimestamp | undefined;
   updatedAt: wellKnownTimestamp | undefined;
-  resolvedMedia: TechCardMediaFull[] | undefined;
   lockVersion: number | undefined;
+  // Resolved sketch media (MediaFull), split to mirror the writable lists.
+  resolvedMoodboardMedia: TechCardMediaFull[] | undefined;
+  resolvedTechnicalMedia: TechCardMediaFull[] | undefined;
 };
 
 // TechCardListItem is a lightweight tech-card header for list views.

--- a/src/components/managers/fitting/components/fitting-callouts.tsx
+++ b/src/components/managers/fitting/components/fitting-callouts.tsx
@@ -1,0 +1,275 @@
+import { common_MediaFull } from 'api/proto-http/admin';
+import { cn } from 'lib/utility';
+import { useEffect, useRef, useState } from 'react';
+import { Controller, useFieldArray, useFormContext, useWatch } from 'react-hook-form';
+import { Button } from 'ui/components/button';
+import Select from 'ui/components/select';
+import Text from 'ui/components/text';
+import InputField from 'ui/form/fields/input-field';
+import TextareaField from 'ui/form/fields/textarea-field';
+import { FittingFormData } from './schema';
+
+const clamp01 = (n: number) => Math.min(1, Math.max(0, n));
+
+type FormCallout = {
+  number?: number;
+  note?: string;
+  mediaId?: number;
+  posX?: string;
+  posY?: string;
+};
+
+// Pin numbered markers onto the fitting's photos: click a photo to drop a callout,
+// drag a marker to move it (stores normalised pos_x/pos_y 0..1), and write what is
+// wrong with the fit at that point. Mirrors the tech-card sketch callouts, minus
+// the part/dimensions (a fitting flags posadka, not spec geometry). One field array
+// owns both the canvas markers and the text rows so positions stay in sync.
+export function FittingCallouts({ mediaById }: { mediaById: Map<number, common_MediaFull> }) {
+  const { control, setValue } = useFormContext<FittingFormData>();
+  const { fields, append, remove } = useFieldArray({ control, name: 'callouts' });
+  const callouts = (useWatch({ control, name: 'callouts' }) ?? []) as FormCallout[];
+  const mediaIds = (useWatch({ control, name: 'mediaIds' }) ?? []) as number[];
+
+  const imageUrl = (id: number) => {
+    const f = mediaById.get(id);
+    return f?.media?.fullSize?.mediaUrl || f?.media?.thumbnail?.mediaUrl || '';
+  };
+  const views = mediaIds.filter((id) => !!imageUrl(id));
+
+  const [viewId, setViewId] = useState<number | null>(null);
+  const activeViewId = viewId != null && views.includes(viewId) ? viewId : views[0] ?? null;
+  const url = activeViewId != null ? imageUrl(activeViewId) : '';
+  const viewIndex = (id: number) => views.indexOf(id) + 1;
+
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const dragIdxRef = useRef<number | null>(null);
+  const dragPosRef = useRef<{ x: number; y: number } | null>(null);
+  const [dragPos, setDragPos] = useState<{ idx: number; x: number; y: number } | null>(null);
+
+  function coords(clientX: number, clientY: number) {
+    const rect = wrapRef.current?.getBoundingClientRect();
+    if (!rect || rect.width === 0) return { x: 0, y: 0 };
+    return {
+      x: clamp01((clientX - rect.left) / rect.width),
+      y: clamp01((clientY - rect.top) / rect.height),
+    };
+  }
+
+  useEffect(() => {
+    function move(e: PointerEvent) {
+      if (dragIdxRef.current == null) return;
+      const p = coords(e.clientX, e.clientY);
+      dragPosRef.current = p;
+      setDragPos({ idx: dragIdxRef.current, ...p });
+    }
+    function up() {
+      const idx = dragIdxRef.current;
+      const p = dragPosRef.current;
+      if (idx != null && p) {
+        setValue(`callouts.${idx}.posX`, p.x.toFixed(3), { shouldDirty: true });
+        setValue(`callouts.${idx}.posY`, p.y.toFixed(3), { shouldDirty: true });
+      }
+      dragIdxRef.current = null;
+      dragPosRef.current = null;
+      setDragPos(null);
+    }
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+    return () => {
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+  }, [setValue]);
+
+  // When a photo is removed from the fitting, un-pin any fit note that was on it —
+  // keep the note text but drop the now-dead pin + coords so it isn't saved pointing
+  // at a media no longer attached (which could never be shown/repositioned again).
+  // Reacts only to actual removals (diff vs the previous ids), not to mount/additions.
+  const prevMediaIdsRef = useRef<number[]>(mediaIds);
+  useEffect(() => {
+    const prev = prevMediaIdsRef.current;
+    prevMediaIdsRef.current = mediaIds;
+    const removed = prev.filter((id) => !mediaIds.includes(id));
+    if (!removed.length) return;
+    callouts.forEach((c, i) => {
+      if (c.mediaId && removed.includes(c.mediaId)) {
+        setValue(`callouts.${i}.mediaId`, 0, { shouldDirty: true });
+        setValue(`callouts.${i}.posX`, '', { shouldDirty: true });
+        setValue(`callouts.${i}.posY`, '', { shouldDirty: true });
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mediaIds]);
+
+  function addAt(e: React.MouseEvent) {
+    if (dragIdxRef.current != null || activeViewId == null) return;
+    const { x, y } = coords(e.clientX, e.clientY);
+    append({
+      number: fields.length + 1,
+      note: '',
+      mediaId: activeViewId,
+      posX: x.toFixed(3),
+      posY: y.toFixed(3),
+    });
+  }
+
+  const pinOptions = [
+    { value: 0, label: '— unanchored —' },
+    ...views.map((id, i) => ({ value: id, label: `photo #${i + 1}` })),
+  ];
+
+  return (
+    <div className='space-y-4'>
+      {views.length === 0 ? (
+        <Text variant='inactive' size='small'>
+          add a photo above to pin fit notes on it
+        </Text>
+      ) : (
+        <div className='space-y-2'>
+          <div className='flex flex-wrap gap-2'>
+            {views.map((id, i) => (
+              <button
+                key={id}
+                type='button'
+                onClick={() => setViewId(id)}
+                className={cn(
+                  'border px-2 py-1 text-textBaseSize uppercase transition-colors',
+                  id === activeViewId
+                    ? 'border-textColor bg-textColor text-bgColor'
+                    : 'border-textInactiveColor text-textColor hover:border-textInactiveColor',
+                )}
+              >
+                photo #{i + 1}
+              </button>
+            ))}
+          </div>
+
+          <div ref={wrapRef} className='relative w-fit touch-none'>
+            <img
+              src={url}
+              alt='fitting photo'
+              onClick={addAt}
+              className='block max-h-[460px] w-auto cursor-crosshair select-none border border-textInactiveColor'
+              draggable={false}
+            />
+            {callouts.map((c, idx) => {
+              if (c.mediaId !== activeViewId) return null;
+              const dragging = dragPos?.idx === idx;
+              const x = dragging ? dragPos.x : parseFloat(c.posX ?? '');
+              const y = dragging ? dragPos.y : parseFloat(c.posY ?? '');
+              if (Number.isNaN(x) || Number.isNaN(y)) return null;
+              return (
+                <button
+                  key={idx}
+                  type='button'
+                  onPointerDown={(e) => {
+                    e.stopPropagation();
+                    dragIdxRef.current = idx;
+                    const p = coords(e.clientX, e.clientY);
+                    dragPosRef.current = p;
+                    setDragPos({ idx, ...p });
+                  }}
+                  onClick={(e) => e.stopPropagation()}
+                  className='absolute flex size-6 -translate-x-1/2 -translate-y-1/2 cursor-move items-center justify-center rounded-full border-2 border-bgColor bg-textColor text-textBaseSize text-bgColor'
+                  style={{ left: `${x * 100}%`, top: `${y * 100}%` }}
+                  aria-label={`callout ${c.number || idx + 1}`}
+                >
+                  {c.number || idx + 1}
+                </button>
+              );
+            })}
+          </div>
+          <Text variant='inactive' size='small'>
+            click the photo to add a fit note · drag a marker to move it
+          </Text>
+        </div>
+      )}
+
+      <div className='space-y-3 border-t border-textInactiveColor pt-3'>
+        {fields.length === 0 ? (
+          <Text variant='inactive' size='small'>
+            no fit notes
+          </Text>
+        ) : (
+          fields.map((f, index) => {
+            const pinnedTo = callouts[index]?.mediaId ?? 0;
+            return (
+              <div key={f.id} className='space-y-2 border border-textInactiveColor p-3'>
+                <div className='flex items-center justify-between'>
+                  <Text variant='uppercase' size='small'>
+                    fit note {index + 1}
+                    {pinnedTo > 0 ? ` · photo #${viewIndex(pinnedTo)}` : ''}
+                  </Text>
+                  <Button
+                    type='button'
+                    variant='secondary'
+                    aria-label='remove fit note'
+                    onClick={() => remove(index)}
+                  >
+                    ✕
+                  </Button>
+                </div>
+                <div className='grid grid-cols-1 gap-2 lg:grid-cols-2'>
+                  <InputField
+                    name={`callouts.${index}.number`}
+                    type='number'
+                    valueAsNumber
+                    label='number'
+                  />
+                  <Controller
+                    control={control}
+                    name={`callouts.${index}.mediaId`}
+                    render={({ field }) => (
+                      <label className='flex flex-col gap-1'>
+                        <Text variant='label' size='small' component='span'>
+                          pinned to
+                        </Text>
+                        <Select
+                          name={`callouts.${index}.mediaId`}
+                          items={pinOptions}
+                          value={field.value != null ? String(field.value) : field.value}
+                          onValueChange={(val: string | undefined) => {
+                            const next = Number(val ?? 0);
+                            // re-pinning to another photo: recenter the marker on the new
+                            // view — keeping the old coords would point it at an unrelated
+                            // spot; unanchoring (0) clears the pin entirely.
+                            if (next !== (field.value ?? 0)) {
+                              setValue(`callouts.${index}.posX`, next ? '0.500' : '', {
+                                shouldDirty: true,
+                              });
+                              setValue(`callouts.${index}.posY`, next ? '0.500' : '', {
+                                shouldDirty: true,
+                              });
+                            }
+                            field.onChange(next);
+                          }}
+                          fullWidth
+                        />
+                      </label>
+                    )}
+                  />
+                </div>
+                <TextareaField
+                  name={`callouts.${index}.note`}
+                  label='note (что не так с посадкой)'
+                  rows={2}
+                  maxLength={2000}
+                />
+              </div>
+            );
+          })
+        )}
+        <Button
+          type='button'
+          variant='main'
+          className='uppercase'
+          onClick={() =>
+            append({ number: fields.length + 1, note: '', mediaId: 0, posX: '', posY: '' })
+          }
+        >
+          add fit note
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/managers/fitting/components/fitting-media.tsx
+++ b/src/components/managers/fitting/components/fitting-media.tsx
@@ -1,20 +1,21 @@
-import { common_Fitting, common_MediaFull } from 'api/proto-http/admin';
+import { common_MediaFull } from 'api/proto-http/admin';
 import { MediaGallerySelector } from 'components/managers/media/components/media-gallery-selector';
-import { useState } from 'react';
 import { useController, useFormContext } from 'react-hook-form';
 import { FittingFormData } from './schema';
 
-export function FittingMedia({ fitting }: { fitting?: common_Fitting }) {
+// The resolved-media map (saved fitting.media + freshly-picked) is owned by the
+// parent FittingForm and shared with the callouts editor, so a just-picked photo
+// can be annotated without a save/reload.
+export function FittingMedia({
+  mediaById,
+  onPicked,
+}: {
+  mediaById: Map<number, common_MediaFull>;
+  onPicked: (items: common_MediaFull[]) => void;
+}) {
   const { control } = useFormContext<FittingFormData>();
   const { field } = useController({ control, name: 'mediaIds' });
-  const [media, setMedia] = useState<common_MediaFull[]>([]);
 
-  const fittingMedia = fitting?.media || [];
-  const mediaById = new Map<number, common_MediaFull>(
-    [...fittingMedia, ...media]
-      .filter((m): m is common_MediaFull & { id: number } => m.id != null)
-      .map((m) => [m.id, m]),
-  );
   const mediaLinks = (field.value ?? [])
     .map((id) => mediaById.get(id))
     .filter((m): m is common_MediaFull => m != null);
@@ -23,13 +24,12 @@ export function FittingMedia({ fitting }: { fitting?: common_Fitting }) {
     if (!picked.length) return;
     const unique = picked.filter((m) => !(field.value ?? []).includes(m.id || 0));
     if (!unique.length) return;
-    setMedia((prev) => [...prev, ...unique]);
+    onPicked(unique);
     const ids = unique.map((m) => m.id).filter((id): id is number => id != null);
     field.onChange([...(field.value ?? []), ...ids]);
   }
 
   function handleDelete(id: number) {
-    setMedia((prev) => prev.filter((m) => m.id !== id));
     field.onChange((field.value ?? []).filter((v) => v !== id));
   }
 

--- a/src/components/managers/fitting/components/index.tsx
+++ b/src/components/managers/fitting/components/index.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { common_Fitting } from 'api/proto-http/admin';
+import { common_Fitting, common_MediaFull } from 'api/proto-http/admin';
 import { usePermissions } from 'components/managers/accounts/utils/permissions';
 import {
   useCreateFitting,
@@ -10,7 +10,7 @@ import { useAllModels } from 'components/managers/models/components/useModelQuer
 import { fittingStatusOptions, fittingVerdictOptions } from 'constants/filter';
 import { ROUTES, SECTION } from 'constants/routes';
 import { useSnackBarStore } from 'lib/stores/store';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { Button } from 'ui/components/button';
@@ -19,6 +19,7 @@ import { Form } from 'ui/form';
 import InputField from 'ui/form/fields/input-field';
 import SelectField from 'ui/form/fields/select-field';
 import TextareaField from 'ui/form/fields/textarea-field';
+import { FittingCallouts } from './fitting-callouts';
 import { FittingMedia } from './fitting-media';
 import { PatternsFields } from './patterns-fields';
 import { ProductField } from './product-field';
@@ -92,6 +93,17 @@ export function FittingForm({
 
   const selectedModelId = form.watch('modelId');
   const selectedModel = (models ?? []).find((m) => m.id === selectedModelId);
+
+  // Resolved-media map shared by the photo picker and the callouts editor, so a
+  // freshly-picked photo can be annotated before the fitting is saved (saved
+  // fitting.media + media picked this session).
+  const [picked, setPicked] = useState<common_MediaFull[]>([]);
+  const mediaById = useMemo(() => {
+    const m = new Map<number, common_MediaFull>();
+    for (const item of fitting?.media ?? []) if (item.id != null) m.set(item.id, item);
+    for (const p of picked) if (p.id != null) m.set(p.id, p);
+    return m;
+  }, [fitting?.media, picked]);
 
   async function handleSubmit(data: FittingFormData) {
     const fittingInsert = mapFormToFittingInsert(data);
@@ -171,7 +183,13 @@ export function FittingForm({
               <PatternsFields />
             </Section>
             <Section title='photos'>
-              <FittingMedia fitting={fitting} />
+              <FittingMedia
+                mediaById={mediaById}
+                onPicked={(items) => setPicked((prev) => [...prev, ...items])}
+              />
+            </Section>
+            <Section title='callouts (замечания по посадке)'>
+              <FittingCallouts mediaById={mediaById} />
             </Section>
           </div>
         </div>

--- a/src/components/managers/fitting/components/schema.ts
+++ b/src/components/managers/fitting/components/schema.ts
@@ -5,6 +5,7 @@ import {
   common_FittingVerdict,
 } from 'api/proto-http/admin';
 import { ZERO_TIMESTAMP } from 'components/managers/fittings/components/utils';
+import { decimalToInput, inputToDecimal } from 'utils/decimal';
 import { z } from 'zod';
 
 const fittingSizeSchema = z.object({
@@ -19,6 +20,17 @@ const fittingPatternSchema = z.object({
   url: z.string().optional().default(''),
   filename: z.string().optional().default(''),
   sizeBytes: z.number().optional().default(0),
+});
+
+// A numbered marker pinned onto a fitting photo, flagging what is wrong with the
+// fit at a point on the image. posX/posY are normalised (0..1) strings while in
+// the form (like the tech-card callouts) — converted to Decimal at the boundary.
+const fittingCalloutSchema = z.object({
+  number: z.number().int().optional().default(0),
+  note: z.string().optional().default(''),
+  mediaId: z.number().int().optional().default(0), // FK media(id); 0 = unanchored
+  posX: z.string().optional().default(''),
+  posY: z.string().optional().default(''),
 });
 
 export const fittingSchema = z
@@ -37,6 +49,7 @@ export const fittingSchema = z
     sizes: z.array(fittingSizeSchema).default([]),
     patterns: z.array(fittingPatternSchema).default([]),
     mediaIds: z.array(z.number()).default([]),
+    callouts: z.array(fittingCalloutSchema).default([]),
   })
   .refine((data) => !!data.productId || !!data.techCardId, {
     message: 'Укажите продукт или тех карту',
@@ -57,6 +70,7 @@ export const fittingDefaultData: FittingFormData = {
   sizes: [],
   patterns: [],
   mediaIds: [],
+  callouts: [],
 };
 
 export function todayDateInput(): string {
@@ -109,6 +123,13 @@ export function mapFittingToForm(fitting: common_Fitting): FittingFormData {
       fitting.media?.map((m) => m.id).filter((id): id is number => id != null) ??
       insert?.mediaIds ??
       [],
+    callouts: (insert?.callouts ?? []).map((c) => ({
+      number: c.number || 0,
+      note: c.note || '',
+      mediaId: c.mediaId || 0,
+      posX: decimalToInput(c.posX),
+      posY: decimalToInput(c.posY),
+    })),
   };
 }
 
@@ -135,5 +156,15 @@ export function mapFormToFittingInsert(data: FittingFormData): common_FittingIns
         sizeBytes: p.sizeBytes || 0,
       })),
     mediaIds: data.mediaIds ?? [],
+    // note is required by the contract — drop markers left un-annotated on save.
+    callouts: (data.callouts ?? [])
+      .filter((c) => c.note?.trim())
+      .map((c, i) => ({
+        number: c.number || i + 1,
+        note: c.note?.trim() || '',
+        mediaId: c.mediaId || 0,
+        posX: inputToDecimal(c.posX),
+        posY: inputToDecimal(c.posY),
+      })),
   };
 }

--- a/src/components/managers/hero/components/map-schema-to-hero-data.ts
+++ b/src/components/managers/hero/components/map-schema-to-hero-data.ts
@@ -455,14 +455,15 @@ export function mapHeroFullToFormData(
                     e.newsletter?.media?.landscape?.media?.thumbnail?.mediaUrl || '',
                   mediaPortraitUrl: e.newsletter?.media?.portrait?.media?.thumbnail?.mediaUrl || '',
                   ...readMediaModifiers(e.newsletter?.media),
+                  // placeholder / ctaText / successText are NOT carried by the newsletter
+                  // contract (HeroNewsletterTranslation is headline+body only — the email
+                  // placeholder, button and success text are handled client-side on the
+                  // storefront). The form fields stay optional and simply load empty.
                   translations:
                     e.newsletter?.translations?.map((t) => ({
                       languageId: t.languageId || 0,
                       headline: t.headline,
                       body: t.body,
-                      placeholder: t.placeholder,
-                      ctaText: t.ctaText,
-                      successText: t.successText,
                     })) || [],
                 },
               };

--- a/src/components/managers/media/utils/useMediaQuery.ts
+++ b/src/components/managers/media/utils/useMediaQuery.ts
@@ -48,7 +48,7 @@ export function useInfiniteMedia(limit: number = ITEMS_PER_PAGE) {
 
 // id → MediaFull map over the most-recent `limit` library items. Used to resolve media
 // referenced only by id (colourway swatches, construction-description reference images) that
-// the tech card's resolvedMedia (sketch media only) doesn't carry. Best-effort: media older
+// the tech card's resolved sketch media (moodboard/technical only) doesn't carry. Best-effort: media older
 // than `limit` items back won't resolve — the proper fix is the backend resolving all
 // referenced media. One cached request (5 min).
 export function useMediaMap(limit = 500) {

--- a/src/components/managers/tasks/api/tasksService.ts
+++ b/src/components/managers/tasks/api/tasksService.ts
@@ -70,12 +70,14 @@ function mapInsert(i: common_Task['task']): TaskInsert {
     assignee: i?.assignee ?? '',
     priority: i?.priority ?? 'TASK_PRIORITY_UNKNOWN',
     dueDate: i?.dueDate || undefined,
+    startDate: i?.startDate || undefined,
     labels: i?.labels ?? [],
     mediaIds: i?.mediaIds ?? [],
     techCardId: i?.techCardId ?? 0,
     productId: i?.productId ?? 0,
     orderUuid: i?.orderUuid ?? '',
     archiveId: i?.archiveId ?? 0,
+    fittingId: i?.fittingId ?? 0,
   };
 }
 
@@ -102,6 +104,7 @@ function mapTask(t: common_Task): Task {
     createdBy: t.createdBy ?? '',
     createdAt: t.createdAt ?? '',
     updatedAt: t.updatedAt ?? '',
+    startedAt: t.startedAt ?? '',
     archivedAt: t.archivedAt ?? '',
   };
 }

--- a/src/components/managers/tasks/api/types.ts
+++ b/src/components/managers/tasks/api/types.ts
@@ -58,6 +58,9 @@ export interface TaskInsert {
   assignee: string; // AdminAccount.username; '' = unassigned
   priority: TaskPriority;
   dueDate: string | undefined; // RFC3339; undefined = no deadline (key always present, mirrors common_TaskInsert)
+  // Planned start (когда работа ДОЛЖНА начаться) — the manual counterpart of
+  // dueDate. Distinct from the server-stamped actual start (Task.startedAt).
+  startDate: string | undefined; // RFC3339; undefined = no planned start
   labels: string[];
   mediaIds: number[];
   // Optional typed links (0 / '' = none) — mirrors common.TaskInsert.
@@ -65,6 +68,7 @@ export interface TaskInsert {
   productId: number;
   orderUuid: string;
   archiveId: number;
+  fittingId: number; // примерка / try-on session (GetFitting)
 }
 
 // Stored card (common.Task): id + content + placement + resolved media + identity.
@@ -79,6 +83,10 @@ export interface Task {
   createdBy: string; // AdminAccount.username
   createdAt: string;
   updatedAt: string;
+  // Actual start: server-stamped the FIRST time the card enters IN_PROGRESS
+  // (never client-supplied). '' = not started yet. Distinct from the planned
+  // TaskInsert.startDate.
+  startedAt: string;
   // Soft-archive stamp. '' = active; set (RFC3339) = archived (hidden from the
   // board's default view, restorable via UnarchiveTask). Orthogonal to placement.
   archivedAt: string;
@@ -115,12 +123,14 @@ export function emptyTaskInsert(): TaskInsert {
     assignee: '',
     priority: 'TASK_PRIORITY_UNKNOWN',
     dueDate: undefined,
+    startDate: undefined,
     labels: [],
     mediaIds: [],
     techCardId: 0,
     productId: 0,
     orderUuid: '',
     archiveId: 0,
+    fittingId: 0,
   };
 }
 

--- a/src/components/managers/tasks/components/link-chip.tsx
+++ b/src/components/managers/tasks/components/link-chip.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { adminService } from 'api/api';
+import { formatFittingDate, statusLabel } from 'components/managers/fittings/components/utils';
 import { Link } from 'react-router-dom';
 import { TaskLink } from '../utils/links';
 
@@ -30,6 +31,14 @@ function useLinkName(link: TaskLink) {
           const r: any = await adminService.GetArchiveByID({ id: link.id });
           return r?.archive?.archiveList?.slug || null;
         }
+        if (link.kind === 'fitting') {
+          // No name field — compose date · status like the fitting card list.
+          const r = await adminService.GetFitting({ id: link.id });
+          const f = r?.fitting?.fitting;
+          if (!f) return null;
+          const date = formatFittingDate(f.fittingDate);
+          return [date, statusLabel(f.status)].filter(Boolean).join(' · ') || null;
+        }
         return null;
       } catch {
         return null;
@@ -43,6 +52,7 @@ const KIND_PREFIX: Record<TaskLink['kind'], string> = {
   product: 'product',
   order: 'order',
   archive: 'drop',
+  fitting: 'примерка',
 };
 
 export function LinkChip({ link, onNavigate }: { link: TaskLink; onNavigate?: () => void }) {

--- a/src/components/managers/tasks/components/task-card.tsx
+++ b/src/components/managers/tasks/components/task-card.tsx
@@ -23,7 +23,8 @@ export function TaskCardBody({ task, dragging }: { task: Task; dragging?: boolea
   const t = task.task;
   const due = dueMeta(t.dueDate);
   const linkCount =
-    [t.techCardId, t.productId, t.archiveId].filter((v) => v > 0).length + (t.orderUuid ? 1 : 0);
+    [t.techCardId, t.productId, t.archiveId, t.fittingId].filter((v) => v > 0).length +
+    (t.orderUuid ? 1 : 0);
   const checkTotal = task.checklist.length;
   const checkDone = task.checklist.filter((c) => c.isDone).length;
   const isArchived = !!task.archivedAt;

--- a/src/components/managers/tasks/components/task-form-modal.tsx
+++ b/src/components/managers/tasks/components/task-form-modal.tsx
@@ -17,7 +17,13 @@ import {
   STATUSES,
   toOptions,
 } from '../utils/meta';
-import { archiveConfig, orderConfig, productConfig, techCardConfig } from '../utils/entity-configs';
+import {
+  archiveConfig,
+  fittingConfig,
+  orderConfig,
+  productConfig,
+  techCardConfig,
+} from '../utils/entity-configs';
 import { AssigneeSelect } from './assignee-select';
 import { EntityPicker } from './entity-picker';
 import { MediaAttachments } from './media-attachments';
@@ -181,6 +187,18 @@ export function TaskFormModal({ open, onOpenChange, mode, initial, saving, onSub
                   )}
                 />
               </Field>
+              <Field label='start date'>
+                <Controller
+                  control={control}
+                  name='startDate'
+                  render={({ field }) => (
+                    <DatePicker
+                      value={field.value ? new Date(field.value) : undefined}
+                      onChange={(d) => field.onChange(d ? d.toISOString() : undefined)}
+                    />
+                  )}
+                />
+              </Field>
               <Field label='due date'>
                 <Controller
                   control={control}
@@ -264,6 +282,19 @@ export function TaskFormModal({ open, onOpenChange, mode, initial, saving, onSub
                         value={field.value}
                         onChange={field.onChange}
                         config={productConfig}
+                      />
+                    )}
+                  />
+                </Field>
+                <Field label='примерка'>
+                  <Controller
+                    control={control}
+                    name='fittingId'
+                    render={({ field }) => (
+                      <EntityPicker
+                        value={field.value}
+                        onChange={field.onChange}
+                        config={fittingConfig}
                       />
                     )}
                   />

--- a/src/components/managers/tasks/task-detail/page.tsx
+++ b/src/components/managers/tasks/task-detail/page.tsx
@@ -299,9 +299,19 @@ export function TaskDetail() {
                 <span className='text-labelColor'>unassigned</span>
               )}
             </Row>
+            <Row label='planned start'>
+              <span className={cn(!t.startDate && 'text-labelColor')}>
+                {t.startDate ? format(new Date(t.startDate), 'PPP') : '—'}
+              </span>
+            </Row>
             <Row label='due'>
               <span className={cn(due.state === 'overdue' && 'text-error')}>
                 {t.dueDate ? format(new Date(t.dueDate), 'PPP') : '—'}
+              </span>
+            </Row>
+            <Row label='started'>
+              <span className='text-labelColor'>
+                {task.startedAt ? format(new Date(task.startedAt), 'PP') : 'not started'}
               </span>
             </Row>
             <Row label='created'>

--- a/src/components/managers/tasks/utils/entity-configs.ts
+++ b/src/components/managers/tasks/utils/entity-configs.ts
@@ -1,6 +1,12 @@
 import { adminService, frontendService } from 'api/api';
-import type { common_Order, common_Product, common_TechCardListItem } from 'api/proto-http/admin';
+import type {
+  common_Fitting,
+  common_Order,
+  common_Product,
+  common_TechCardListItem,
+} from 'api/proto-http/admin';
 import type { common_ArchiveList } from 'api/proto-http/frontend';
+import { formatFittingDate, statusLabel } from 'components/managers/fittings/components/utils';
 import { EntityConfig, EntityOption } from '../components/entity-picker';
 
 // Maps the four typed task links to their real admin/frontend list + single-get
@@ -143,6 +149,41 @@ function archiveOption(a: common_ArchiveList): EntityOption {
     thumbnail: a.thumbnail?.media?.thumbnail?.mediaUrl,
   };
 }
+
+// ---- fitting / примерка (ListFittings has no text search → client filter) ---
+// A fitting has no name field, so compose a label from its date + status; the
+// client-side filter matches on that text (and the id sublabel).
+function fittingOption(f: common_Fitting): EntityOption {
+  const date = formatFittingDate(f.fitting?.fittingDate);
+  return {
+    value: f.id ?? 0,
+    label: date ? `примерка · ${date}` : `примерка #${f.id}`,
+    sublabel: `#${f.id} · ${statusLabel(f.fitting?.status)}`,
+  };
+}
+
+export const fittingConfig: EntityConfig = {
+  kind: 'fitting',
+  empty: 0,
+  mode: 'client',
+  searchPlaceholder: 'search примерки by date / status…',
+  emptyResult: 'no fittings',
+  load: async () => {
+    const r = await adminService.ListFittings({
+      limit: 100,
+      offset: undefined,
+      orderFactor: 'ORDER_FACTOR_DESC',
+      productId: undefined,
+      modelId: undefined,
+      techCardId: undefined,
+    });
+    return (r.fittings ?? []).map(fittingOption);
+  },
+  resolve: async (value) => {
+    const r = await adminService.GetFitting({ id: value as number });
+    return r?.fitting ? fittingOption(r.fitting) : null;
+  },
+};
 
 export const archiveConfig: EntityConfig = {
   kind: 'archive',

--- a/src/components/managers/tasks/utils/links.ts
+++ b/src/components/managers/tasks/utils/links.ts
@@ -1,6 +1,6 @@
 import { TaskInsert } from '../api/types';
 
-export type LinkKind = 'techcard' | 'product' | 'order' | 'archive';
+export type LinkKind = 'techcard' | 'product' | 'order' | 'archive' | 'fitting';
 
 export interface TaskLink {
   kind: LinkKind;
@@ -46,6 +46,13 @@ export function taskLinks(t: TaskInsert): TaskLink[] {
       label: `drop #${t.archiveId}`,
       to: `/archives`,
     });
+  if (t.fittingId > 0)
+    links.push({
+      kind: 'fitting',
+      id: t.fittingId,
+      label: `примерка #${t.fittingId}`,
+      to: `/fittings/${t.fittingId}`,
+    });
   return links;
 }
 
@@ -54,6 +61,7 @@ export function taskLinkCount(t: TaskInsert): number {
     (t.techCardId > 0 ? 1 : 0) +
     (t.productId > 0 ? 1 : 0) +
     (t.orderUuid ? 1 : 0) +
-    (t.archiveId > 0 ? 1 : 0)
+    (t.archiveId > 0 ? 1 : 0) +
+    (t.fittingId > 0 ? 1 : 0)
   );
 }

--- a/src/components/managers/tech-card/components/colorways-field.tsx
+++ b/src/components/managers/tech-card/components/colorways-field.tsx
@@ -435,8 +435,8 @@ function ColorwayCard({
 
   const hexValid = /^#?[0-9a-fA-F]{3,8}$/.test(hex.trim());
   const hexCss = hex.trim().startsWith('#') ? hex.trim() : `#${hex.trim()}`;
-  // resolve the saved swatch from the media library so it survives a reload (resolvedMedia
-  // carries only sketch media)
+  // resolve the saved swatch from the media library so it survives a reload (the resolved
+  // sketch media carries only moodboard/technical sketches)
   const libraryMap = useMediaMap();
   const swatchFromLib = swatchMediaId ? libraryMap.get(swatchMediaId) : undefined;
   const swatchUrl =

--- a/src/components/managers/tech-card/components/construction-tab.tsx
+++ b/src/components/managers/tech-card/components/construction-tab.tsx
@@ -63,7 +63,8 @@ function ConstructionSketch({
   onActivePinChange: (n: number | null) => void;
 }) {
   const { control } = useFormContext<TechCardFormData>();
-  const media = (useWatch({ control, name: 'media' }) ?? []) as Array<{
+  // Assembly map draws on the technical sketches (front/back/detail), not the moodboard.
+  const media = (useWatch({ control, name: 'technicalMedia' }) ?? []) as Array<{
     mediaId: number;
     kind?: string;
   }>;
@@ -317,13 +318,14 @@ export function ConstructionTab({ techCard }: { techCard?: common_TechCard }) {
     [operations],
   );
 
+  // The assembly map pins onto the technical sketches (callouts live there).
   const mediaById = useMemo(() => {
     const m = new Map<number, common_MediaFull>();
-    for (const rm of techCard?.resolvedMedia ?? []) {
+    for (const rm of techCard?.resolvedTechnicalMedia ?? []) {
       if (rm.media?.id != null) m.set(rm.media.id, rm.media);
     }
     return m;
-  }, [techCard?.resolvedMedia]);
+  }, [techCard?.resolvedTechnicalMedia]);
 
   const cwIdx = colorwayIdx < colorways.length ? colorwayIdx : 0;
   const selectedUsages = colorways[cwIdx]?.usages ?? [];

--- a/src/components/managers/tech-card/components/costing-field.tsx
+++ b/src/components/managers/tech-card/components/costing-field.tsx
@@ -39,8 +39,9 @@ export function CostingField({ techCard }: { techCard?: common_TechCard }) {
   const materialsTotal = rollup?.materialsTotal ?? [];
   const hasRollup =
     materialsTotal.length > 0 ||
-    !!rollup?.materialsCost?.value ||
-    !!rollup?.totalCost?.value ||
+    !!rollup?.materialsPerUnit?.value ||
+    !!rollup?.unitCost?.value ||
+    !!rollup?.orderCost?.value ||
     !!rollup?.totalSam?.value ||
     colorwayCosts.length > 0;
 
@@ -56,19 +57,18 @@ export function CostingField({ techCard }: { techCard?: common_TechCard }) {
         </div>
       )}
       <div className='grid grid-cols-2 gap-3 lg:grid-cols-3'>
-        <DecimalField name='costing.cmtCost' label='CMT cost' />
-        <DecimalField name='costing.hardwareCost' label='hardware cost' />
-        <DecimalField name='costing.packagingCost' label='packaging cost' />
-        <DecimalField name='costing.logisticsCost' label='logistics cost' />
-        <DecimalField name='costing.overheadCost' label='overhead cost' />
+        <DecimalField name='costing.cmtCost' label='CMT cost / изделие' />
+        <DecimalField name='costing.hardwareCost' label='hardware / изделие' />
+        <DecimalField name='costing.packagingCost' label='packaging / изделие' />
+        <DecimalField name='costing.logisticsCost' label='logistics / изделие' />
+        <DecimalField name='costing.overheadCost' label='overhead / изделие' />
         <DecimalField name='costing.defectPercent' label='defect %' />
-        <DecimalField name='costing.markupMultiplier' label='markup ×' />
-        <DecimalField name='costing.wholesalePrice' label='wholesale price' />
-        <DecimalField name='costing.retailPrice' label='retail price' />
         <CurrencySelect name='costing.currency' label='currency' />
       </div>
       <Text variant='inactive' size='small'>
-        Цены оптовая/розничная и валюта едины для всех колорвеев (политика бренда).
+        Все статьи — на 1 изделие, в одной валюте. Себестоимость считается на изделие, затем
+        масштабируется на тираж (order qty). Ценообразование (наценка/опт/розница) живёт на
+        опубликованном продукте, не здесь.
       </Text>
       <TextareaField name='costing.notes' label='notes' rows={2} maxLength={2000} />
 
@@ -94,8 +94,11 @@ export function CostingField({ techCard }: { techCard?: common_TechCard }) {
                       </Text>
                     ))}
                     <Text variant='inactive' size='small'>
-                      на изделие: {decimalToInput(cc.materialsCost) || '—'} · на тираж:{' '}
-                      {decimalToInput(cc.sizeRunTotal) || '—'}
+                      материалы/изделие: {decimalToInput(cc.materialsPerUnit) || '—'} ·
+                      себестоимость/изделие: {decimalToInput(cc.unitCost) || '—'}
+                    </Text>
+                    <Text variant='inactive' size='small'>
+                      тираж {cc.orderQty || 0} · на тираж: {decimalToInput(cc.orderCost) || '—'}
                     </Text>
                     {cc.hasUnconvertedCurrencies && (
                       <Text variant='inactive' size='small'>
@@ -116,13 +119,17 @@ export function CostingField({ techCard }: { techCard?: common_TechCard }) {
                 </Text>
               ))}
               <Text variant='inactive' size='small'>
-                materials cost: {decimalToInput(rollup?.materialsCost) || '—'}
+                материалы / изделие: {decimalToInput(rollup?.materialsPerUnit) || '—'}
+              </Text>
+              <Text variant='inactive' size='small'>
+                себестоимость / изделие: {decimalToInput(rollup?.unitCost) || '—'}
+              </Text>
+              <Text variant='inactive' size='small'>
+                тираж {rollup?.orderQty || 0} · себестоимость тиража:{' '}
+                {decimalToInput(rollup?.orderCost) || '—'}
               </Text>
               <Text variant='inactive' size='small'>
                 Σ SAM (информативно): {decimalToInput(rollup?.totalSam) || '—'} min
-              </Text>
-              <Text variant='inactive' size='small'>
-                total cost: {decimalToInput(rollup?.totalCost) || '—'}
               </Text>
               {rollup?.hasUnconvertedCurrencies && (
                 <Text variant='inactive' size='small'>

--- a/src/components/managers/tech-card/components/details-editor.tsx
+++ b/src/components/managers/tech-card/components/details-editor.tsx
@@ -31,13 +31,16 @@ export function DetailsEditor({ techCard }: { techCard?: common_TechCard }) {
 
   const mediaById = useMemo(() => {
     const m = new Map<number, common_MediaFull>();
-    for (const rm of techCard?.resolvedMedia ?? [])
+    for (const rm of [
+      ...(techCard?.resolvedTechnicalMedia ?? []),
+      ...(techCard?.resolvedMoodboardMedia ?? []),
+    ])
       if (rm.media?.id != null) m.set(rm.media.id, rm.media);
     return m;
-  }, [techCard?.resolvedMedia]);
-  // resolvedMedia carries only the sketch media; detail reference images are plain library
-  // media ids, so resolve them from the media library too (otherwise they show as "#id" after
-  // a reload).
+  }, [techCard?.resolvedTechnicalMedia, techCard?.resolvedMoodboardMedia]);
+  // The resolved sketch maps carry only the sketch media; detail reference images are plain
+  // library media ids, so resolve them from the media library too (otherwise they show as
+  // "#id" after a reload).
   const libraryMap = useMediaMap();
 
   const detailByKey = (key: string) => details.find((d) => d.key === key);

--- a/src/components/managers/tech-card/components/index.tsx
+++ b/src/components/managers/tech-card/components/index.tsx
@@ -69,7 +69,8 @@ type TabId = (typeof TABS)[number]['id'];
 
 // Maps a form-error root key to the tab that owns it; unmapped keys are header fields.
 const ERROR_TAB: Record<string, TabId> = {
-  media: 'sketch',
+  moodboardMedia: 'sketch',
+  technicalMedia: 'sketch',
   callouts: 'sketch',
   patterns: 'patterns',
   sizeIds: 'patterns',

--- a/src/components/managers/tech-card/components/media-field.tsx
+++ b/src/components/managers/tech-card/components/media-field.tsx
@@ -1,4 +1,4 @@
-import { common_MediaFull } from 'api/proto-http/admin';
+import { common_MediaFull, common_TechCardMediaKind } from 'api/proto-http/admin';
 import { MediaSelector } from 'components/managers/media/components/media-selector';
 import { techCardMediaKindOptions } from 'constants/filter';
 import { isVideo } from 'lib/features/filterContentType';
@@ -11,18 +11,44 @@ import InputField from 'ui/form/fields/input-field';
 import SelectField from 'ui/form/fields/select-field';
 import { TechCardFormData } from './schema';
 
-// Technical sketch media. Each item carries a `kind` + `caption`; the form only stores
-// { mediaId, kind, caption }. The resolved MediaFull map (for thumbnails) is owned by
-// the parent SketchTab and shared with the callout canvas.
+// Kinds that make sense for each list (both draw from the same enum; the split just
+// filters which options are offered).
+const TECHNICAL_KINDS: common_TechCardMediaKind[] = [
+  'TECH_CARD_MEDIA_KIND_FRONT',
+  'TECH_CARD_MEDIA_KIND_BACK',
+  'TECH_CARD_MEDIA_KIND_DETAIL',
+  'TECH_CARD_MEDIA_KIND_LINING',
+  'TECH_CARD_MEDIA_KIND_PREVIEW',
+];
+const MOODBOARD_KINDS: common_TechCardMediaKind[] = [
+  'TECH_CARD_MEDIA_KIND_MOODBOARD',
+  'TECH_CARD_MEDIA_KIND_REFERENCE',
+  'TECH_CARD_MEDIA_KIND_SWATCH',
+];
+
+type MediaListName = 'moodboardMedia' | 'technicalMedia';
+
+// One sketch-media list (moodboard or technical). Each item carries a `kind` + `caption`;
+// the form only stores { mediaId, kind, caption }. The resolved MediaFull map (for
+// thumbnails) is owned by the parent SketchTab and shared with the callout canvas.
 export function MediaField({
+  name,
   mediaById,
   onPickedMedia,
 }: {
+  name: MediaListName;
   mediaById: Map<number, common_MediaFull>;
   onPickedMedia: (items: common_MediaFull[]) => void;
 }) {
   const { control } = useFormContext<TechCardFormData>();
-  const { fields, append, remove } = useFieldArray({ control, name: 'media' });
+  const { fields, append, remove } = useFieldArray({ control, name });
+  const isMoodboard = name === 'moodboardMedia';
+  const kinds = isMoodboard ? MOODBOARD_KINDS : TECHNICAL_KINDS;
+  const kindOptions = techCardMediaKindOptions.filter((o) => kinds.includes(o.value));
+  const defaultKind: common_TechCardMediaKind = kinds[0];
+  const emptyLabel = isMoodboard ? 'no moodboard images' : 'no sketches';
+  const addLabel = isMoodboard ? 'add moodboard image' : 'add sketch';
+  const purpose = isMoodboard ? 'moodboard reference' : 'tech sketch';
   const selectedIds = fields.map((f) => f.mediaId);
   const viewer = useMediaViewer();
   const viewerItems = fields.map((f) => {
@@ -35,7 +61,7 @@ export function MediaField({
     if (!fresh.length) return;
     onPickedMedia(fresh);
     for (const it of fresh) {
-      append({ mediaId: it.id as number, kind: 'TECH_CARD_MEDIA_KIND_FRONT' });
+      append({ mediaId: it.id as number, kind: defaultKind });
     }
   }
 
@@ -43,7 +69,7 @@ export function MediaField({
     <div className='space-y-3'>
       {fields.length === 0 ? (
         <Text variant='inactive' size='small'>
-          no sketches
+          {emptyLabel}
         </Text>
       ) : (
         <div className='grid grid-cols-2 gap-3 md:grid-cols-3'>
@@ -87,12 +113,8 @@ export function MediaField({
                     [x]
                   </Button>
                 </div>
-                <SelectField
-                  name={`media.${index}.kind`}
-                  label='kind'
-                  items={techCardMediaKindOptions}
-                />
-                <InputField name={`media.${index}.caption`} label='caption' />
+                <SelectField name={`${name}.${index}.kind`} label='kind' items={kindOptions} />
+                <InputField name={`${name}.${index}.caption`} label='caption' />
               </div>
             );
           })}
@@ -100,8 +122,8 @@ export function MediaField({
       )}
 
       <MediaSelector
-        label='add sketch'
-        purpose='tech sketch'
+        label={addLabel}
+        purpose={purpose}
         aspectRatio={['Custom']}
         allowMultiple
         showVideos

--- a/src/components/managers/tech-card/components/schema.ts
+++ b/src/components/managers/tech-card/components/schema.ts
@@ -13,6 +13,7 @@ import {
   common_TechCardLabDipStatus,
   common_TechCardLabelType,
   common_TechCardMeasurementUnit,
+  common_TechCardMediaItem,
   common_TechCardMediaKind,
   common_TechCardOperationType,
   common_TechCardPackaging,
@@ -24,13 +25,13 @@ import { ZERO_TIMESTAMP } from 'components/managers/tech-cards/components/utils'
 import { decimalToInput, inputToDecimal } from 'utils/decimal';
 import { z } from 'zod';
 
-// Tech-card form. Covers the full TechCardInsert: header ("Титул"), sketch media +
-// callouts, size range + patterns, linked products, colourways (recipe = usages), BOM
-// (article catalog), construction, operations, labels, packaging, costing, details,
-// and the revision log. The backend does a full replace on update, so
+// Tech-card form. Covers the full TechCardInsert: header ("Титул"), sketch media
+// (moodboard + technical) + callouts, size range + patterns, linked products, colourways
+// (recipe = usages), BOM (article catalog), construction, operations, labels, packaging,
+// costing, details, and the revision log. The backend does a full replace on update, so
 // mapFormToTechCardInsert sends every section. Computed fields — costing rollups
-// (materials_total/materials_cost/total_cost/colorway_costs) and usage line/run totals —
-// are output-only: shown read-only, never sent.
+// (materials_total/materials_per_unit/unit_cost/order_cost/colorway_costs) and usage
+// line/run totals — are output-only: shown read-only, never sent.
 
 const DEFAULT_STAGE: common_TechCardStage = 'TECH_CARD_STAGE_PROTO';
 const DEFAULT_APPROVAL_STATE: common_TechCardApprovalState = 'TECH_CARD_APPROVAL_STATE_DRAFT';
@@ -256,6 +257,8 @@ const packagingSchema = z.object({
   notes: z.string().optional().default(''),
 });
 
+// Manual per-unit cost articles (per ONE garment), all in a single `currency`. Pricing
+// (markup/wholesale/retail) was removed from the tech card — it lives on the published product.
 const costingSchema = z.object({
   cmtCost: z.string().optional().default(''),
   hardwareCost: z.string().optional().default(''),
@@ -263,9 +266,6 @@ const costingSchema = z.object({
   logisticsCost: z.string().optional().default(''),
   overheadCost: z.string().optional().default(''),
   defectPercent: z.string().optional().default(''),
-  markupMultiplier: z.string().optional().default(''),
-  wholesalePrice: z.string().optional().default(''),
-  retailPrice: z.string().optional().default(''),
   currency: z.string().optional().default(''),
   notes: z.string().optional().default(''),
 });
@@ -301,9 +301,6 @@ export const emptyCosting: z.input<typeof costingSchema> = {
   logisticsCost: '',
   overheadCost: '',
   defectPercent: '',
-  markupMultiplier: '',
-  wholesalePrice: '',
-  retailPrice: '',
   currency: '',
   notes: '',
 };
@@ -339,7 +336,10 @@ export const techCardSchema = z.object({
   sizeQuantities: z.array(sizeQuantitySchema).default([]),
   patterns: z.array(patternSchema).default([]), // per-size PDF выкройки
   productIds: z.array(z.number()).default([]),
-  media: z.array(mediaItemSchema).default([]),
+  // Sketch media split into two independent lists (construction consumes ONLY technicalMedia;
+  // callouts pin onto technicalMedia). Each item's `kind` sub-classifies within its list.
+  moodboardMedia: z.array(mediaItemSchema).default([]),
+  technicalMedia: z.array(mediaItemSchema).default([]),
   callouts: z.array(calloutSchema).default([]),
   colorways: z.array(colorwaySchema).default([]),
   bomItems: z.array(bomItemSchema).default([]),
@@ -380,7 +380,8 @@ export const techCardDefaultData: TechCardFormData = {
   sizeQuantities: [],
   patterns: [],
   productIds: [],
-  media: [],
+  moodboardMedia: [],
+  technicalMedia: [],
   callouts: [],
   colorways: [],
   bomItems: [],
@@ -403,6 +404,51 @@ function approvalStateOrDefault(state?: string): string {
 }
 function measurementUnitOrDefault(unit?: string): string {
   return unit && unit !== 'TECH_CARD_MEASUREMENT_UNIT_UNKNOWN' ? unit : DEFAULT_MEASUREMENT_UNIT;
+}
+
+// Both sketch-media lists (moodboard / technical) share the { mediaId, kind, caption } shape.
+type FormMediaItem = z.input<typeof mediaItemSchema>;
+function mapMediaItemToForm(m: common_TechCardMediaItem): FormMediaItem {
+  return {
+    mediaId: m.mediaId || 0,
+    kind: m.kind && m.kind !== 'TECH_CARD_MEDIA_KIND_UNKNOWN' ? m.kind : DEFAULT_MEDIA_KIND,
+    caption: m.caption || '',
+  };
+}
+function mapMediaItemOut(m: FormMediaItem): common_TechCardMediaItem {
+  return {
+    mediaId: m.mediaId,
+    kind: (m.kind || 'TECH_CARD_MEDIA_KIND_UNKNOWN') as common_TechCardMediaKind,
+    caption: m.caption?.trim() || '',
+  };
+}
+
+const MOODBOARD_KIND_SET = new Set([
+  'TECH_CARD_MEDIA_KIND_MOODBOARD',
+  'TECH_CARD_MEDIA_KIND_REFERENCE',
+  'TECH_CARD_MEDIA_KIND_SWATCH',
+]);
+
+// Sketch media read into the two split lists. Backward-compat: a tech card saved before the
+// proto media-split still holds its sketches under the removed single `media` field. If BOTH
+// new lists are empty but a legacy `media` list is present, route legacy items into
+// moodboard/technical by kind — so an un-migrated card doesn't open with empty grids and get
+// its sketches wiped on the next full-replace save.
+function splitSketchMedia(insert?: common_TechCardInsert): {
+  moodboardMedia: FormMediaItem[];
+  technicalMedia: FormMediaItem[];
+} {
+  const moodboardMedia = (insert?.moodboardMedia ?? []).map(mapMediaItemToForm);
+  const technicalMedia = (insert?.technicalMedia ?? []).map(mapMediaItemToForm);
+  if (moodboardMedia.length || technicalMedia.length) return { moodboardMedia, technicalMedia };
+  const legacy = (insert as { media?: common_TechCardMediaItem[] } | undefined)?.media ?? [];
+  const mood: FormMediaItem[] = [];
+  const tech: FormMediaItem[] = [];
+  for (const m of legacy) {
+    const item = mapMediaItemToForm(m);
+    (MOODBOARD_KIND_SET.has(item.kind ?? '') ? mood : tech).push(item);
+  }
+  return { moodboardMedia: mood, technicalMedia: tech };
 }
 
 export function mapTechCardToForm(techCard: common_TechCard): TechCardFormData {
@@ -441,11 +487,7 @@ export function mapTechCardToForm(techCard: common_TechCard): TechCardFormData {
       sizeBytes: Number(p.sizeBytes) || 0,
     })),
     productIds: insert?.productIds ?? [],
-    media: (insert?.media ?? []).map((m) => ({
-      mediaId: m.mediaId || 0,
-      kind: m.kind && m.kind !== 'TECH_CARD_MEDIA_KIND_UNKNOWN' ? m.kind : DEFAULT_MEDIA_KIND,
-      caption: m.caption || '',
-    })),
+    ...splitSketchMedia(insert),
     callouts: (insert?.callouts ?? []).map((c) => ({
       number: c.number || 0,
       part: c.part || '',
@@ -581,9 +623,6 @@ export function mapTechCardToForm(techCard: common_TechCard): TechCardFormData {
           logisticsCost: decimalToInput(insert.costing.logisticsCost),
           overheadCost: decimalToInput(insert.costing.overheadCost),
           defectPercent: decimalToInput(insert.costing.defectPercent),
-          markupMultiplier: decimalToInput(insert.costing.markupMultiplier),
-          wholesalePrice: decimalToInput(insert.costing.wholesalePrice),
-          retailPrice: decimalToInput(insert.costing.retailPrice),
           currency: insert.costing.currency || '',
           notes: insert.costing.notes || '',
         }
@@ -680,8 +719,9 @@ function mapPackagingOut(p?: TechCardFormData['packaging']): common_TechCardPack
   };
 }
 
-// costing rollup fields (materials_total/materials_cost/total_cost/colorway_costs/total_sam)
-// are output-only — never sent on write.
+// The materials line and the unit/order totals (materials_total / materials_per_unit /
+// unit_cost / order_qty / order_cost / colorway_costs / total_sam) are computed server-side
+// from the BOM + colourway usages — output-only, never sent on write.
 function mapCostingOut(c?: TechCardFormData['costing']): common_TechCardCosting | undefined {
   if (
     !hasContent([
@@ -691,9 +731,6 @@ function mapCostingOut(c?: TechCardFormData['costing']): common_TechCardCosting 
       c?.logisticsCost,
       c?.overheadCost,
       c?.defectPercent,
-      c?.markupMultiplier,
-      c?.wholesalePrice,
-      c?.retailPrice,
       c?.currency,
       c?.notes,
     ])
@@ -707,14 +744,13 @@ function mapCostingOut(c?: TechCardFormData['costing']): common_TechCardCosting 
     logisticsCost: inputToDecimal(c?.logisticsCost),
     overheadCost: inputToDecimal(c?.overheadCost),
     defectPercent: inputToDecimal(c?.defectPercent),
-    markupMultiplier: inputToDecimal(c?.markupMultiplier),
-    wholesalePrice: inputToDecimal(c?.wholesalePrice),
-    retailPrice: inputToDecimal(c?.retailPrice),
     currency: c?.currency?.trim() || '',
     notes: c?.notes?.trim() || '',
     materialsTotal: undefined,
-    materialsCost: undefined,
-    totalCost: undefined,
+    materialsPerUnit: undefined,
+    unitCost: undefined,
+    orderQty: undefined,
+    orderCost: undefined,
     hasUnconvertedCurrencies: undefined,
     totalSam: undefined,
     colorwayCosts: undefined,
@@ -765,11 +801,8 @@ export function mapFormToTechCardInsert(
         sizeBytes: p.sizeBytes || 0,
       })),
     productIds: data.productIds ?? [],
-    media: (data.media ?? []).map((m) => ({
-      mediaId: m.mediaId,
-      kind: (m.kind || 'TECH_CARD_MEDIA_KIND_UNKNOWN') as common_TechCardMediaKind,
-      caption: m.caption?.trim() || '',
-    })),
+    moodboardMedia: (data.moodboardMedia ?? []).map(mapMediaItemOut),
+    technicalMedia: (data.technicalMedia ?? []).map(mapMediaItemOut),
     callouts: (data.callouts ?? []).map((c) => ({
       number: c.number || 0,
       part: c.part?.trim() || '',

--- a/src/components/managers/tech-card/components/sketch-tab.tsx
+++ b/src/components/managers/tech-card/components/sketch-tab.tsx
@@ -53,7 +53,8 @@ function CalloutsEditor({ mediaById }: { mediaById: Map<number, common_MediaFull
   const { control, setValue } = useFormContext<TechCardFormData>();
   const { fields, append, remove } = useFieldArray({ control, name: 'callouts' });
   const callouts = (useWatch({ control, name: 'callouts' }) ?? []) as FormCallout[];
-  const media = (useWatch({ control, name: 'media' }) ?? []) as Array<{
+  // Callouts pin onto the TECHNICAL sketches (construction media), not the moodboard.
+  const media = (useWatch({ control, name: 'technicalMedia' }) ?? []) as Array<{
     mediaId: number;
     kind?: string;
   }>;
@@ -269,30 +270,38 @@ function CalloutsEditor({ mediaById }: { mediaById: Map<number, common_MediaFull
   );
 }
 
-// Sketch sheet — owns the resolved-media map shared by the sketch grid and the callout
-// canvas (so a freshly-picked sketch can be annotated without a save/reload).
+// Sketch sheet — owns the resolved-media map shared by both sketch grids (moodboard +
+// technical) and the callout canvas (so a freshly-picked sketch can be annotated without a
+// save/reload). Media ids are unique across the two lists, so one shared map serves both.
 export function SketchTab({ techCard }: { techCard?: common_TechCard }) {
   const [picked, setPicked] = useState<common_MediaFull[]>([]);
 
   const mediaById = useMemo(() => {
     const m = new Map<number, common_MediaFull>();
-    for (const rm of techCard?.resolvedMedia ?? []) {
+    for (const rm of [
+      ...(techCard?.resolvedTechnicalMedia ?? []),
+      ...(techCard?.resolvedMoodboardMedia ?? []),
+    ]) {
       if (rm.media?.id != null) m.set(rm.media.id, rm.media);
     }
     for (const p of picked) if (p.id != null) m.set(p.id, p);
     return m;
-  }, [techCard?.resolvedMedia, picked]);
+  }, [techCard?.resolvedTechnicalMedia, techCard?.resolvedMoodboardMedia, picked]);
+
+  const onPicked = (items: common_MediaFull[]) => setPicked((prev) => [...prev, ...items]);
 
   return (
-    <div className='flex flex-col gap-6 lg:flex-row lg:items-start'>
-      <Section title='technical sketch' className='w-full lg:w-1/2'>
-        <MediaField
-          mediaById={mediaById}
-          onPickedMedia={(items) => setPicked((prev) => [...prev, ...items])}
-        />
-      </Section>
-      <Section title='callouts' className='w-full lg:w-1/2'>
-        <CalloutsEditor mediaById={mediaById} />
+    <div className='flex flex-col gap-6'>
+      <div className='flex flex-col gap-6 lg:flex-row lg:items-start'>
+        <Section title='technical sketch' className='w-full lg:w-1/2'>
+          <MediaField name='technicalMedia' mediaById={mediaById} onPickedMedia={onPicked} />
+        </Section>
+        <Section title='callouts' className='w-full lg:w-1/2'>
+          <CalloutsEditor mediaById={mediaById} />
+        </Section>
+      </div>
+      <Section title='moodboard (mood / reference / swatches)'>
+        <MediaField name='moodboardMedia' mediaById={mediaById} onPickedMedia={onPicked} />
       </Section>
     </div>
   );

--- a/src/components/managers/tech-card/components/tech-pack-document.tsx
+++ b/src/components/managers/tech-card/components/tech-pack-document.tsx
@@ -101,12 +101,15 @@ export function TechPackDocument({ techCard }: { techCard: common_TechCard }) {
 
   const mediaById = useMemo(() => {
     const m = new Map<number, common_MediaFull>();
-    for (const rm of techCard.resolvedMedia ?? [])
+    for (const rm of [
+      ...(techCard.resolvedTechnicalMedia ?? []),
+      ...(techCard.resolvedMoodboardMedia ?? []),
+    ])
       if (rm.media?.id != null) m.set(rm.media.id, rm.media);
     return m;
-  }, [techCard.resolvedMedia]);
-  // detail reference images (and swatches) are library media ids not carried in resolvedMedia
-  // (sketch only) — resolve them from the library so they print.
+  }, [techCard.resolvedTechnicalMedia, techCard.resolvedMoodboardMedia]);
+  // detail reference images (and swatches) are library media ids not carried in the resolved
+  // sketch maps — resolve them from the library so they print.
   const libraryMap = useMediaMap();
   const resolveMedia = (id: number) => mediaById.get(id) ?? libraryMap.get(id);
 
@@ -120,7 +123,7 @@ export function TechPackDocument({ techCard }: { techCard: common_TechCard }) {
   const sizeIds = tc.sizeIds ?? [];
   const colorways = tc.colorways ?? [];
   const captionById = new Map<number, { caption?: string; kind?: string }>();
-  for (const m of tc.media ?? [])
+  for (const m of [...(tc.technicalMedia ?? []), ...(tc.moodboardMedia ?? [])])
     if (m.mediaId != null) captionById.set(m.mediaId, { caption: m.caption, kind: m.kind });
 
   return (
@@ -205,10 +208,10 @@ export function TechPackDocument({ techCard }: { techCard: common_TechCard }) {
       )}
 
       {/* SKETCHES + CALLOUTS */}
-      {has(tc.media) && (
+      {has(tc.technicalMedia) && (
         <Sheet title='technical sketch'>
           <div className='flex flex-wrap gap-4'>
-            {(tc.media ?? []).map((m, i) => {
+            {(tc.technicalMedia ?? []).map((m, i) => {
               const full = m.mediaId != null ? mediaById.get(m.mediaId) : undefined;
               const url = full?.media?.fullSize?.mediaUrl || full?.media?.thumbnail?.mediaUrl || '';
               const meta = captionById.get(m.mediaId ?? -1);
@@ -264,6 +267,33 @@ export function TechPackDocument({ techCard }: { techCard: common_TechCard }) {
               </tbody>
             </table>
           )}
+        </Sheet>
+      )}
+
+      {/* MOODBOARD */}
+      {has(tc.moodboardMedia) && (
+        <Sheet title='moodboard'>
+          <div className='flex flex-wrap gap-4'>
+            {(tc.moodboardMedia ?? []).map((m, i) => {
+              const full = m.mediaId != null ? mediaById.get(m.mediaId) : undefined;
+              const url = full?.media?.fullSize?.mediaUrl || full?.media?.thumbnail?.mediaUrl || '';
+              const meta = captionById.get(m.mediaId ?? -1);
+              if (!url) return null;
+              return (
+                <figure key={i} className='break-inside-avoid'>
+                  <img
+                    src={url}
+                    alt=''
+                    className='block max-h-[240px] w-auto border border-black'
+                  />
+                  <figcaption className='mt-1 text-[10px] uppercase text-labelColor'>
+                    {mediaKindL[meta?.kind ?? ''] ?? 'reference'}
+                    {meta?.caption ? ` · ${meta.caption}` : ''}
+                  </figcaption>
+                </figure>
+              );
+            })}
+          </div>
         </Sheet>
       )}
 
@@ -600,11 +630,10 @@ export function TechPackDocument({ techCard }: { techCard: common_TechCard }) {
               <KV k='defect %' v={dec(tc.costing.defectPercent)} />
             </div>
             <div>
-              <KV k='materials (primary cw)' v={dec(tc.costing.materialsCost)} />
+              <KV k='materials / unit (primary cw)' v={dec(tc.costing.materialsPerUnit)} />
+              <KV k='unit cost' v={dec(tc.costing.unitCost)} />
+              <KV k='order qty' v={tc.costing.orderQty ? String(tc.costing.orderQty) : ''} />
               <KV k='total SAM (min)' v={dec(tc.costing.totalSam)} />
-              <KV k='markup ×' v={dec(tc.costing.markupMultiplier)} />
-              <KV k='wholesale' v={dec(tc.costing.wholesalePrice)} />
-              <KV k='retail' v={dec(tc.costing.retailPrice)} />
             </div>
           </div>
 
@@ -614,8 +643,9 @@ export function TechPackDocument({ techCard }: { techCard: common_TechCard }) {
               <thead>
                 <tr>
                   <th className={TH}>colourway</th>
-                  <th className={`${TH} text-right`}>materials / garment</th>
-                  <th className={`${TH} text-right`}>materials / run</th>
+                  <th className={`${TH} text-right`}>materials / unit</th>
+                  <th className={`${TH} text-right`}>unit cost</th>
+                  <th className={`${TH} text-right`}>order cost</th>
                 </tr>
               </thead>
               <tbody>
@@ -628,11 +658,14 @@ export function TechPackDocument({ techCard }: { techCard: common_TechCard }) {
                         {cc.colorwayIndex === 0 ? ' (primary)' : ''}
                       </td>
                       <td className={`${TD} whitespace-nowrap text-right`}>
-                        {dec(cc.materialsCost) || '—'}
+                        {dec(cc.materialsPerUnit) || '—'}
                         {cc.hasUnconvertedCurrencies ? ' ⚠' : ''}
                       </td>
                       <td className={`${TD} whitespace-nowrap text-right`}>
-                        {dec(cc.sizeRunTotal) || '—'}
+                        {dec(cc.unitCost) || '—'}
+                      </td>
+                      <td className={`${TD} whitespace-nowrap text-right`}>
+                        {dec(cc.orderCost) || '—'}
                       </td>
                     </tr>
                   );
@@ -641,10 +674,16 @@ export function TechPackDocument({ techCard }: { techCard: common_TechCard }) {
             </table>
           )}
 
-          <div className='mt-2 flex items-center justify-between border-t-2 border-black pt-1 text-sm'>
-            <span className='font-bold uppercase'>total cost</span>
+          <div className='mt-2 flex items-center justify-between border-t border-black pt-1 text-sm'>
+            <span className='font-bold uppercase'>unit cost</span>
             <span className='font-bold'>
-              {dec(tc.costing.totalCost) || '—'} {tc.costing.currency ?? ''}
+              {dec(tc.costing.unitCost) || '—'} {tc.costing.currency ?? ''}
+            </span>
+          </div>
+          <div className='mt-1 flex items-center justify-between border-t-2 border-black pt-1 text-sm'>
+            <span className='font-bold uppercase'>order cost</span>
+            <span className='font-bold'>
+              {dec(tc.costing.orderCost) || '—'} {tc.costing.currency ?? ''}
             </span>
           </div>
           {tc.costing.hasUnconvertedCurrencies && (


### PR DESCRIPTION
Pulls `grbpwr-proto` `5391a3a`→`6f4121a` and implements every new field. Zero tsc errors, `vite build` green.

## Tasks
- `TaskInsert.fittingId` — 5th typed link (примерка) + fitting entity picker
- `TaskInsert.startDate` (planned start) + read-only `Task.startedAt` (actual, server-stamped)

## Fitting
- `FittingInsert.callouts` — pin numbered fit-note markers on photos (click-to-place, drag, normalized pos). Un-pins notes when their photo is removed; recenters the marker on re-pin.

## Tech card
- Sketch media split: `media` → `moodboardMedia` + `technicalMedia` (`resolvedMedia` → `resolved{Moodboard,Technical}Media`); legacy-media read fallback so an un-migrated card isn't wiped on save.
- `TechCardMediaFull.caption`.
- Costing redo: drop pricing (markup/wholesale/retail → product); per-unit / per-order model (`materialsPerUnit`/`unitCost`/`orderQty`/`orderCost`).

## Also
- Fix 3 pre-existing hero tsc errors (newsletter mapper read client-side-only fields). Project now 0 tsc errors.
- Reviewed via multi-agent code-review (high); fixed callout orphan-on-delete, re-pin coord reset, legacy-media wipe guard.

> ⚠️ **Deploy ordering:** needs the backend on proto `6f4121a` (which migrates `media`→`technical_media` and understands the split + costing fields). Ship backend together-with/before this, else existing tech-card sketches read empty on an old backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BpScUQLCXZK7jZKeyfNBL