### PR TITLE
Backend audit: clearer media-upload errors + paginated stock-changes export

### DIFF
--- a/src/components/managers/media/utils/useUploadMedia.ts
+++ b/src/components/managers/media/utils/useUploadMedia.ts
@@ -36,6 +36,25 @@ function getContentTypeFromDataUrl(dataUrl: string): string {
   return match ? match[1] : 'image/jpeg';
 }
 
+// Maps an upload failure to a clear, media-specific message. The grpc-gateway surfaces the
+// gRPC code as an HTTP status on the thrown error: INVALID_ARGUMENT → 400 (bad file — the
+// backend rejects images over 40 megapixels / 28 MB and videos that aren't a real MP4/WebM),
+// UNAUTHENTICATED/PERMISSION_DENIED → 401/403, INTERNAL → 5xx (retry). Auth error texts are
+// intentionally generic on the backend, so we branch on the status code, not the message.
+function mediaUploadErrorMessage(error: unknown, isVideo: boolean): string {
+  const status = (error as { status?: number })?.status;
+  const raw = error instanceof Error ? error.message : '';
+  if (status === 400) {
+    return isVideo
+      ? 'Video rejected — it must be a valid MP4 or WebM file no larger than 50 MB.'
+      : 'Image rejected — it must be a valid image no larger than 40 megapixels (≈28 MB).';
+  }
+  if (status === 401) return 'Session expired — please sign in again.';
+  if (status === 403) return 'You do not have permission to upload media.';
+  if (status && status >= 500) return 'Upload failed on the server — please try again.';
+  return raw || 'Failed to upload media.';
+}
+
 export type UploadMediaInput = File | string;
 
 export function useUploadMedia() {
@@ -78,9 +97,14 @@ export function useUploadMedia() {
       }
 
       if (!isVideo) {
-        const response = await adminService.UploadContentImage({
-          rawB64Image: base64,
-        });
+        let response;
+        try {
+          response = await adminService.UploadContentImage({
+            rawB64Image: base64,
+          });
+        } catch (e) {
+          throw new Error(mediaUploadErrorMessage(e, false));
+        }
 
         if (!response.media) {
           throw new Error('Upload image failed: empty response');
@@ -90,10 +114,15 @@ export function useUploadMedia() {
       }
 
       const raw = trimBeforeBase64(base64);
-      const response = await adminService.UploadContentVideo({
-        raw,
-        contentType,
-      });
+      let response;
+      try {
+        response = await adminService.UploadContentVideo({
+          raw,
+          contentType,
+        });
+      } catch (e) {
+        throw new Error(mediaUploadErrorMessage(e, true));
+      }
 
       if (!response.media) {
         throw new Error('Upload video failed: empty response');

--- a/src/components/managers/orders-catalog/components/StockChangesReport.tsx
+++ b/src/components/managers/orders-catalog/components/StockChangesReport.tsx
@@ -1,6 +1,7 @@
 import { subDays } from 'date-fns';
 import { useState } from 'react';
 import { adminService } from 'api/api';
+import { StockChangeRow } from 'api/proto-http/admin';
 import {
   downloadCsv,
   stockChangeRowsToCsv,
@@ -40,14 +41,27 @@ export function StockChangesReport() {
     }
     setIsExporting(true);
     try {
-      const response = await adminService.ListStockChanges({
-        from: toRfc3339DateOnly(dateFrom, false),
-        to: toRfc3339DateOnly(dateTo, true),
-        source: undefined,
-        limit: -1,
-        offset: undefined,
-      });
-      const rows = response.changes ?? [];
+      // The backend clamps list limits (>1000 → 1000, ≤0 → default 50), so a single
+      // "give me everything" request can silently truncate. Page through explicitly using
+      // the response `total` so the export always covers the full date range.
+      const PAGE = 1000;
+      const MAX_PAGES = 100; // safety cap: 100k rows
+      const rows: StockChangeRow[] = [];
+      let offset = 0;
+      for (let page = 0; page < MAX_PAGES; page++) {
+        const response = await adminService.ListStockChanges({
+          from: toRfc3339DateOnly(dateFrom, false),
+          to: toRfc3339DateOnly(dateTo, true),
+          source: undefined,
+          limit: PAGE,
+          offset,
+        });
+        const batch = response.changes ?? [];
+        rows.push(...batch);
+        const total = response.total ?? 0;
+        if (batch.length < PAGE || rows.length >= total) break;
+        offset += batch.length;
+      }
       const csv = stockChangeRowsToCsv(rows);
       const filename = `stock-changes-${dateFrom}-to-${dateTo}.csv`;
       downloadCsv(csv, filename);


### PR DESCRIPTION
Frontend response to the `fix/backend-audit` backend changes (proto contracts unchanged — no client regen).

## Changes
- **Media upload errors** (`useUploadMedia`): the backend now rejects images >40 MP and videos with invalid magic bytes with `InvalidArgument`/400. Map upload failures to clear, media-specific messages **by HTTP status** (400 = image too large / invalid video; 401/403 = auth/permission; 5xx = retry) rather than echoing the now-generic backend text.
- **`StockChangesReport` CSV export**: replaced `limit: -1` ("give me everything") with real pagination over `response.total`. The backend now clamps list limits (`>1000 → 1000`, `≤0 → 50`), so the old single-shot request would silently truncate as the table grows.

## Audit result (mandatory checklist)
Checked all 7 clamped list RPCs (`GetProductsPaged`, `ListPromos`, `ListObjectsPaged`, `ListOrders`, `GetOrderReviewsPaged`, `GetProductReviewsPaged`, `GetSupportTicketsPaged`) — **all already paginate with sane limits**; none passes `limit > 1000` or `limit ≤ 0`. No refactor needed there. `ListStockChanges` (not in the list, but same anti-pattern) was the only offender, hardened above.

Verified: `tsc` clean for both files; `prettier` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En4pgGj4hfK2DKKeqKYyLN