### PR TITLE
New-flow: consume backend that closed all open asks (B-2/B-3/#8/#9/#10/B-10 + gap-07 v2 regen)

### DIFF
--- a/src/api/proto-http/admin/index.ts
+++ b/src/api/proto-http/admin/index.ts
@@ -3542,6 +3542,7 @@ export type OpexRecurringInsert = {
   activeFrom: string | undefined;
   activeTo: string | undefined;
   note: string | undefined;
+  employeeId: number | undefined;
 };
 
 // OpexRecurring is a stored recurring OPEX template.
@@ -3573,6 +3574,51 @@ export type ListOpexRecurringRequest = {
 
 export type ListOpexRecurringResponse = {
   recurring: OpexRecurring[] | undefined;
+};
+
+// EmployeeInsert is a person in the salary registry (gap-07 v2 A): identity + employment window + an
+// informational default monthly cost. The booked cost stays in the OPEX journal (an OpexRecurring
+// template with employee_id set); default_monthly_cost only pre-fills that template, it is never a
+// cost figure in any report.
+export type EmployeeInsert = {
+  fullName: string | undefined;
+  role: string | undefined;
+  employmentStart: string | undefined;
+  employmentEnd: string | undefined;
+  defaultCurrency: string | undefined;
+  defaultMonthlyCost: googletype_Decimal | undefined;
+  note: string | undefined;
+};
+
+// Employee is a stored registry row.
+export type Employee = {
+  id: number | undefined;
+  employee: EmployeeInsert | undefined;
+  archived: boolean | undefined;
+};
+
+export type UpsertEmployeeRequest = {
+  employee: EmployeeInsert | undefined;
+  id: number | undefined;
+};
+
+export type UpsertEmployeeResponse = {
+  id: number | undefined;
+};
+
+export type ArchiveEmployeeRequest = {
+  id: number | undefined;
+};
+
+export type ArchiveEmployeeResponse = {
+};
+
+export type ListEmployeesRequest = {
+  includeArchived: boolean | undefined;
+};
+
+export type ListEmployeesResponse = {
+  employees: Employee[] | undefined;
 };
 
 export type GetOrderReviewsPagedRequest = {
@@ -3825,6 +3871,9 @@ export type CreateTechCardRequest = {
 
 export type common_TechCardInsert = {
   // identification (Sheet «Титул»)
+  // Артикул. Required from the PROTO stage onward; OPTIONAL (empty) while stage == IDEA — an idea
+  // is by definition pre-article (NF-03/B-2). Moving a card out of IDEA without a real style
+  // number is rejected with InvalidArgument.
   styleNumber: string | undefined;
   name: string | undefined;
   brand: string | undefined;
@@ -4029,6 +4078,11 @@ export type common_TechCardColorway = {
   // the colour's material recipe: which catalog article (bom_item_index) goes on which
   // garment part, in what colour, at what consumption. Per-colourway divergence lives here.
   usages: common_TechCardColorwayUsage[] | undefined;
+  // OUTPUT-ONLY stable row id (B-10): set on Get/List so a sample can be linked to a colourway
+  // (Sample.colorway_id). Ignored on write — a card save full-replaces colourways with fresh ids
+  // (the server re-points existing sample links by colourway identity, case-folded code+name), so
+  // re-read the card and use a fresh id right before linking a sample.
+  id: number | undefined;
 };
 
 // TechCardLabDipStatus is the lab-dip approval lifecycle of a colourway.
@@ -4410,6 +4464,9 @@ export type common_TechCardListItem = {
   // moodboard image; otherwise the PREVIEW-kind sketch (falling back to the first technical, then any
   // media). Empty when the card has no media. Resolved server-side to avoid an N+1 GetTechCard.
   previewUrl: string | undefined;
+  // Card purpose: "sellable" (default) or "auxiliary" (NF-07). Lets a board/list badge auxiliary
+  // cards (dust bags, shoppers…) without an N+1 GetTechCard, mirroring TechCard.purpose.
+  purpose: string | undefined;
 };
 
 // GetStylePipeline is the development board: one column per lifecycle stage
@@ -4675,6 +4732,7 @@ export type common_ProductionRunInsert = {
   costs: common_ProductionRunCost[] | undefined;
   markerEfficiencyPct: googletype_Decimal | undefined;
   markerNotes: string | undefined;
+  markers: common_ProductionRunMarker[] | undefined;
 };
 
 // ProductionRunStatus is the lifecycle state of a production run (партия). A run is planned, then
@@ -4722,6 +4780,32 @@ export type common_ProductionRunCostKind =
   | "PRODUCTION_RUN_COST_KIND_LOGISTICS"
   | "PRODUCTION_RUN_COST_KIND_DUTY"
   | "PRODUCTION_RUN_COST_KIND_OTHER";
+// ProductionRunMarker is one imported nesting marker (раскладка / lay) of a run (gap-07 v2 E): the
+// CAD source, the fabric width and lay length it was nested on, the units it yields, its
+// fabric-utilisation %, an optional fabric/size, and a reference URL to the exported marker file.
+// It is planning / traceability data — nothing here feeds the run's actual cost or cost_price.
+export type common_ProductionRunMarker = {
+  source: common_ProductionMarkerSource | undefined;
+  markerName: string | undefined;
+  sizeId: number | undefined;
+  materialId: number | undefined;
+  markerWidth: googletype_Decimal | undefined;
+  layLength: googletype_Decimal | undefined;
+  unitsPerMarker: number | undefined;
+  efficiencyPct: googletype_Decimal | undefined;
+  markerFileUrl: string | undefined;
+  notes: string | undefined;
+};
+
+// ProductionMarkerSource is the CAD/nesting software (or hand entry) a marker record came from.
+export type common_ProductionMarkerSource =
+  | "PRODUCTION_MARKER_SOURCE_UNKNOWN"
+  | "PRODUCTION_MARKER_SOURCE_GERBER"
+  | "PRODUCTION_MARKER_SOURCE_OPTITEX"
+  | "PRODUCTION_MARKER_SOURCE_LECTRA"
+  | "PRODUCTION_MARKER_SOURCE_AUDACES"
+  | "PRODUCTION_MARKER_SOURCE_MANUAL"
+  | "PRODUCTION_MARKER_SOURCE_OTHER";
 export type CreateProductionRunResponse = {
   id: number | undefined;
 };
@@ -4729,6 +4813,10 @@ export type CreateProductionRunResponse = {
 export type UpdateProductionRunRequest = {
   id: number | undefined;
   run: common_ProductionRunInsert | undefined;
+  // Optimistic-lock guard from GetProductionRun/list. >0 enforces the lock: a mismatch means the run
+  // changed under the editor -> Aborted (reload and retry). 0 keeps the legacy last-write-wins
+  // behaviour, so pre-existing clients are unaffected (#9).
+  expectedLockVersion: number | undefined;
 };
 
 export type UpdateProductionRunResponse = {
@@ -4759,6 +4847,10 @@ export type common_ProductionRun = {
   createdAt: wellKnownTimestamp | undefined;
   updatedAt: wellKnownTimestamp | undefined;
   actuals: common_ProductionRunActuals | undefined;
+  // Optimistic-lock token, bumped on every UpdateProductionRun. Echo into
+  // UpdateProductionRunRequest.expected_lock_version so a list→edit needs no extra GET (mirrors
+  // TechCard.lock_version).
+  lockVersion: number | undefined;
 };
 
 // ProductionRunActuals is the computed-on-read plan/fact summary of a run: actual totals from the
@@ -4782,6 +4874,11 @@ export type common_ProductionRunActuals = {
   materialsFromStockBase: googletype_Decimal | undefined;
   mixedMaterialsSources: boolean | undefined;
   hasUncostedIssues: boolean | undefined;
+  // Per-colourway material cost (gap-07 v2 C): stock issues grouped by the product_id they were cut
+  // for. Covers materials_from_stock only (manual cost articles stay run-level). Issues with no
+  // product_id fall into unattributed_materials_base, not any colourway.
+  byColorway: common_ProductionRunColorwayCost[] | undefined;
+  unattributedMaterialsBase: googletype_Decimal | undefined;
 };
 
 // ProductionRunCostByKind is the base-currency total of actual costs of one kind.
@@ -4790,11 +4887,26 @@ export type common_ProductionRunCostByKind = {
   amountBase: googletype_Decimal | undefined;
 };
 
+// ProductionRunColorwayCost is one colour-model's slice of a run's material-from-stock cost (gap-07
+// v2 C): the net material issued for that product and, if it received units, its per-unit material
+// cost. Manual (non-stock) cost articles are run-level and are NOT split here.
+export type common_ProductionRunColorwayCost = {
+  productId: number | undefined;
+  receivedQty: number | undefined;
+  materialsFromStockBase: googletype_Decimal | undefined;
+  materialsUnitCost: googletype_Decimal | undefined;
+  hasUncosted: boolean | undefined;
+};
+
 export type ListProductionRunsRequest = {
   techCardId: number | undefined;
   status: string | undefined;
   limit: number | undefined;
   offset: number | undefined;
+  // >0: return only "stale" runs — still open (planned/in_progress) and created more than N days ago
+  // (the same rule as the stale_open_production_run dashboard alert). Server-side so the attention
+  // filter/strip does not client-scan the two status pages (#10). 0 = no staleness filter.
+  staleDays: number | undefined;
 };
 
 export type ListProductionRunsResponse = {
@@ -4807,6 +4919,14 @@ export type ReceiveProductionRunRequest = {
   // NF-06: the run is multi-colourway, so receive no longer takes a product_id — every line's
   // received_qty is booked into that line's own product. Each product must be linked to the run's
   // tech card, and at least one line must carry a received quantity.
+  // AUXILIARY runs (NF-07/B-3): when the run's tech card has purpose=auxiliary this same RPC
+  // receives the output into the MATERIAL warehouse instead of product stock. Lines must NOT carry
+  // a product_id (rejected with InvalidArgument — not ignored); Σ received_qty is booked into the
+  // card's output_material_id as one receipt_production movement whose unit cost is the run's
+  // actual per-unit base cost (manual cost articles + materials-from-stock, net of returns) — it
+  // moves that material's moving average, or books uncosted when the actuals are incomplete. A
+  // card without output_material_id fails with FailedPrecondition. update_cost_price is a no-op
+  // for auxiliary runs (cost_price_updated is always false — there is no product).
   updateCostPrice: boolean | undefined;
 };
 
@@ -4872,6 +4992,8 @@ export type common_MaterialMovement = {
   adminUsername: string | undefined;
   occurredAt: wellKnownTimestamp | undefined;
   createdAt: wellKnownTimestamp | undefined;
+  productId: number | undefined;
+  lotId: number | undefined;
 };
 
 // MaterialMovementType is the kind of a material-stock movement (new-flow NF-01). quantity is
@@ -4895,6 +5017,8 @@ export type IssueMaterialStockRequest = {
   isReturn: boolean | undefined;
   occurredAt: string | undefined;
   comment: string | undefined;
+  productId: number | undefined;
+  lotId: number | undefined;
 };
 
 export type IssueMaterialStockResponse = {
@@ -4968,6 +5092,58 @@ export type ListMaterialMovementsRequest = {
 export type ListMaterialMovementsResponse = {
   movements: common_MaterialMovement[] | undefined;
   total: number | undefined;
+};
+
+// PackagingBomItem is one line of the global packaging recipe (gap-07 v2 B): a material consumed on
+// ship — qty_per_order once per shipment plus qty_per_item × the order's unit count. material_name /
+// material_unit are resolved server-side for display and ignored on write.
+export type PackagingBomItem = {
+  materialId: number | undefined;
+  materialName: string | undefined;
+  materialUnit: string | undefined;
+  qtyPerOrder: googletype_Decimal | undefined;
+  qtyPerItem: googletype_Decimal | undefined;
+  active: boolean | undefined;
+};
+
+export type UpsertPackagingBomRequest = {
+  items: PackagingBomItem[] | undefined;
+};
+
+export type UpsertPackagingBomResponse = {
+};
+
+export type ListPackagingBomRequest = {
+};
+
+export type ListPackagingBomResponse = {
+  items: PackagingBomItem[] | undefined;
+};
+
+export type ListMaterialLotsRequest = {
+  materialId: number | undefined;
+  includeArchived: boolean | undefined;
+};
+
+export type ListMaterialLotsResponse = {
+  lots: common_MaterialLot[] | undefined;
+};
+
+// MaterialLot is a received batch (roll / dye-lot) of a material (gap-07 v2 D): a supplier lot code
+// with a running remaining quantity, for traceability and colour matching. unit_cost is
+// informational only — valuation stays moving-average; a lot is NOT a FIFO costing basis.
+export type common_MaterialLot = {
+  id: number | undefined;
+  materialId: number | undefined;
+  lotCode: string | undefined;
+  supplierDoc: string | undefined;
+  receivedQty: googletype_Decimal | undefined;
+  remainingQty: googletype_Decimal | undefined;
+  unitCost: googletype_Decimal | undefined;
+  currency: string | undefined;
+  receivedAt: wellKnownTimestamp | undefined;
+  note: string | undefined;
+  archived: boolean | undefined;
 };
 
 // AdminPermission grants an account a level of access to one section.
@@ -5162,6 +5338,14 @@ export interface AdminService {
   // ListOpexRecurring returns recurring OPEX templates (active-only unless include_archived).
   // Requires costing:read (returns empty otherwise).
   ListOpexRecurring(request: ListOpexRecurringRequest): Promise<ListOpexRecurringResponse>;
+  // UpsertEmployee inserts (id==0) or updates an employee-registry row — the person behind a salary
+  // OpexRecurring template (gap-07 v2 A). Requires analytics:write.
+  UpsertEmployee(request: UpsertEmployeeRequest): Promise<UpsertEmployeeResponse>;
+  // ArchiveEmployee soft-archives an employee; linked recurring templates keep their employee_id.
+  // Requires analytics:write.
+  ArchiveEmployee(request: ArchiveEmployeeRequest): Promise<ArchiveEmployeeResponse>;
+  // ListEmployees returns registry rows (active-only unless include_archived). Requires analytics:read.
+  ListEmployees(request: ListEmployeesRequest): Promise<ListEmployeesResponse>;
   // Cancels an order
   CancelOrder(request: CancelOrderRequest): Promise<CancelOrderResponse>;
   // Adds a comment to an order
@@ -5322,6 +5506,12 @@ export interface AdminService {
   GetMaterialStock(request: GetMaterialStockRequest): Promise<GetMaterialStockResponse>;
   ListMaterialStock(request: ListMaterialStockRequest): Promise<ListMaterialStockResponse>;
   ListMaterialMovements(request: ListMaterialMovementsRequest): Promise<ListMaterialMovementsResponse>;
+  // UpsertPackagingBom full-replaces the global packaging recipe consumed on ship (gap-07 v2 B).
+  UpsertPackagingBom(request: UpsertPackagingBomRequest): Promise<UpsertPackagingBomResponse>;
+  // ListPackagingBom returns the packaging recipe (material name/unit + per-order/per-item quantities).
+  ListPackagingBom(request: ListPackagingBomRequest): Promise<ListPackagingBomResponse>;
+  // ListMaterialLots returns a material's structured lots / rolls (gap-07 v2 D).
+  ListMaterialLots(request: ListMaterialLotsRequest): Promise<ListMaterialLotsResponse>;
   // GetCostingFxRates returns the manual FX rates used to fold multi-currency tech-card
   // costing into the base currency.
   GetCostingFxRates(request: GetCostingFxRatesRequest): Promise<GetCostingFxRatesResponse>;
@@ -6283,6 +6473,57 @@ export function createAdminServiceClient(
         service: "AdminService",
         method: "ListOpexRecurring",
       }) as Promise<ListOpexRecurringResponse>;
+    },
+    UpsertEmployee(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/metrics/employees/upsert`; // eslint-disable-line quotes
+      const body = JSON.stringify(request);
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "POST",
+        body,
+      }, {
+        service: "AdminService",
+        method: "UpsertEmployee",
+      }) as Promise<UpsertEmployeeResponse>;
+    },
+    ArchiveEmployee(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/metrics/employees/archive`; // eslint-disable-line quotes
+      const body = JSON.stringify(request);
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "POST",
+        body,
+      }, {
+        service: "AdminService",
+        method: "ArchiveEmployee",
+      }) as Promise<ArchiveEmployeeResponse>;
+    },
+    ListEmployees(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/metrics/employees/list`; // eslint-disable-line quotes
+      const body = JSON.stringify(request);
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "POST",
+        body,
+      }, {
+        service: "AdminService",
+        method: "ListEmployees",
+      }) as Promise<ListEmployeesResponse>;
     },
     CancelOrder(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
       if (!request.orderUuid) {
@@ -7637,6 +7878,9 @@ export function createAdminServiceClient(
       if (request.offset) {
         queryParams.push(`offset=${encodeURIComponent(request.offset.toString())}`)
       }
+      if (request.staleDays) {
+        queryParams.push(`staleDays=${encodeURIComponent(request.staleDays.toString())}`)
+      }
       let uri = path;
       if (queryParams.length > 0) {
         uri += `?${queryParams.join("&")}`
@@ -7830,6 +8074,63 @@ export function createAdminServiceClient(
         service: "AdminService",
         method: "ListMaterialMovements",
       }) as Promise<ListMaterialMovementsResponse>;
+    },
+    UpsertPackagingBom(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/inventory/packaging-bom/upsert`; // eslint-disable-line quotes
+      const body = JSON.stringify(request);
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "POST",
+        body,
+      }, {
+        service: "AdminService",
+        method: "UpsertPackagingBom",
+      }) as Promise<UpsertPackagingBomResponse>;
+    },
+    ListPackagingBom(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/inventory/packaging-bom`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "GET",
+        body,
+      }, {
+        service: "AdminService",
+        method: "ListPackagingBom",
+      }) as Promise<ListPackagingBomResponse>;
+    },
+    ListMaterialLots(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      if (!request.materialId) {
+        throw new Error("missing required field request.material_id");
+      }
+      const path = `api/admin/inventory/${request.materialId}/lots`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      if (request.includeArchived) {
+        queryParams.push(`includeArchived=${encodeURIComponent(request.includeArchived.toString())}`)
+      }
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "GET",
+        body,
+      }, {
+        service: "AdminService",
+        method: "ListMaterialLots",
+      }) as Promise<ListMaterialLotsResponse>;
     },
     GetCostingFxRates(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
       const path = `api/admin/costing/fx-rates`; // eslint-disable-line quotes

--- a/src/api/proto-http/common/index.ts
+++ b/src/api/proto-http/common/index.ts
@@ -1621,6 +1621,11 @@ export type TechCardColorway = {
   // the colour's material recipe: which catalog article (bom_item_index) goes on which
   // garment part, in what colour, at what consumption. Per-colourway divergence lives here.
   usages: TechCardColorwayUsage[] | undefined;
+  // OUTPUT-ONLY stable row id (B-10): set on Get/List so a sample can be linked to a colourway
+  // (Sample.colorway_id). Ignored on write — a card save full-replaces colourways with fresh ids
+  // (the server re-points existing sample links by colourway identity, case-folded code+name), so
+  // re-read the card and use a fresh id right before linking a sample.
+  id: number | undefined;
 };
 
 // TechCardColorwayUsage is one material use inside a colourway: which catalog article
@@ -1971,6 +1976,9 @@ export type TechCardPiece = {
 
 export type TechCardInsert = {
   // identification (Sheet «Титул»)
+  // Артикул. Required from the PROTO stage onward; OPTIONAL (empty) while stage == IDEA — an idea
+  // is by definition pre-article (NF-03/B-2). Moving a card out of IDEA without a real style
+  // number is rejected with InvalidArgument.
   styleNumber: string | undefined;
   name: string | undefined;
   brand: string | undefined;
@@ -2073,6 +2081,9 @@ export type TechCardListItem = {
   // moodboard image; otherwise the PREVIEW-kind sketch (falling back to the first technical, then any
   // media). Empty when the card has no media. Resolved server-side to avoid an N+1 GetTechCard.
   previewUrl: string | undefined;
+  // Card purpose: "sellable" (default) or "auxiliary" (NF-07). Lets a board/list badge auxiliary
+  // cards (dust bags, shoppers…) without an N+1 GetTechCard, mirroring TechCard.purpose.
+  purpose: string | undefined;
 };
 
 // MaterialMovementType is the kind of a material-stock movement (new-flow NF-01). quantity is
@@ -2118,6 +2129,25 @@ export type MaterialMovement = {
   adminUsername: string | undefined;
   occurredAt: wellKnownTimestamp | undefined;
   createdAt: wellKnownTimestamp | undefined;
+  productId: number | undefined;
+  lotId: number | undefined;
+};
+
+// MaterialLot is a received batch (roll / dye-lot) of a material (gap-07 v2 D): a supplier lot code
+// with a running remaining quantity, for traceability and colour matching. unit_cost is
+// informational only — valuation stays moving-average; a lot is NOT a FIFO costing basis.
+export type MaterialLot = {
+  id: number | undefined;
+  materialId: number | undefined;
+  lotCode: string | undefined;
+  supplierDoc: string | undefined;
+  receivedQty: googletype_Decimal | undefined;
+  remainingQty: googletype_Decimal | undefined;
+  unitCost: googletype_Decimal | undefined;
+  currency: string | undefined;
+  receivedAt: wellKnownTimestamp | undefined;
+  note: string | undefined;
+  archived: boolean | undefined;
 };
 
 // MaterialStockRow is a catalog material joined with its stock balance, valuation and low-stock
@@ -2209,6 +2239,15 @@ export type ProductionRunCostKind =
   | "PRODUCTION_RUN_COST_KIND_LOGISTICS"
   | "PRODUCTION_RUN_COST_KIND_DUTY"
   | "PRODUCTION_RUN_COST_KIND_OTHER";
+// ProductionMarkerSource is the CAD/nesting software (or hand entry) a marker record came from.
+export type ProductionMarkerSource =
+  | "PRODUCTION_MARKER_SOURCE_UNKNOWN"
+  | "PRODUCTION_MARKER_SOURCE_GERBER"
+  | "PRODUCTION_MARKER_SOURCE_OPTITEX"
+  | "PRODUCTION_MARKER_SOURCE_LECTRA"
+  | "PRODUCTION_MARKER_SOURCE_AUDACES"
+  | "PRODUCTION_MARKER_SOURCE_MANUAL"
+  | "PRODUCTION_MARKER_SOURCE_OTHER";
 // ProductionRunLine is one colour-model × size line of a run: which product (colourway) at which
 // size, the planned quantity, and — once received — the received and defective counts (unset until
 // received) that drive plan/fact. product_id may be 0 while planning (the colourway may not be
@@ -2261,6 +2300,39 @@ export type ProductionRunActuals = {
   materialsFromStockBase: googletype_Decimal | undefined;
   mixedMaterialsSources: boolean | undefined;
   hasUncostedIssues: boolean | undefined;
+  // Per-colourway material cost (gap-07 v2 C): stock issues grouped by the product_id they were cut
+  // for. Covers materials_from_stock only (manual cost articles stay run-level). Issues with no
+  // product_id fall into unattributed_materials_base, not any colourway.
+  byColorway: ProductionRunColorwayCost[] | undefined;
+  unattributedMaterialsBase: googletype_Decimal | undefined;
+};
+
+// ProductionRunColorwayCost is one colour-model's slice of a run's material-from-stock cost (gap-07
+// v2 C): the net material issued for that product and, if it received units, its per-unit material
+// cost. Manual (non-stock) cost articles are run-level and are NOT split here.
+export type ProductionRunColorwayCost = {
+  productId: number | undefined;
+  receivedQty: number | undefined;
+  materialsFromStockBase: googletype_Decimal | undefined;
+  materialsUnitCost: googletype_Decimal | undefined;
+  hasUncosted: boolean | undefined;
+};
+
+// ProductionRunMarker is one imported nesting marker (раскладка / lay) of a run (gap-07 v2 E): the
+// CAD source, the fabric width and lay length it was nested on, the units it yields, its
+// fabric-utilisation %, an optional fabric/size, and a reference URL to the exported marker file.
+// It is planning / traceability data — nothing here feeds the run's actual cost or cost_price.
+export type ProductionRunMarker = {
+  source: ProductionMarkerSource | undefined;
+  markerName: string | undefined;
+  sizeId: number | undefined;
+  materialId: number | undefined;
+  markerWidth: googletype_Decimal | undefined;
+  layLength: googletype_Decimal | undefined;
+  unitsPerMarker: number | undefined;
+  efficiencyPct: googletype_Decimal | undefined;
+  markerFileUrl: string | undefined;
+  notes: string | undefined;
 };
 
 // ProductionRunInsert is the writable payload for a run (header + colour-model × size lines).
@@ -2277,6 +2349,7 @@ export type ProductionRunInsert = {
   costs: ProductionRunCost[] | undefined;
   markerEfficiencyPct: googletype_Decimal | undefined;
   markerNotes: string | undefined;
+  markers: ProductionRunMarker[] | undefined;
 };
 
 // ProductionRun is a stored run: the writable payload plus the server-owned identity, the frozen
@@ -2289,6 +2362,10 @@ export type ProductionRun = {
   createdAt: wellKnownTimestamp | undefined;
   updatedAt: wellKnownTimestamp | undefined;
   actuals: ProductionRunActuals | undefined;
+  // Optimistic-lock token, bumped on every UpdateProductionRun. Echo into
+  // UpdateProductionRunRequest.expected_lock_version so a list→edit needs no extra GET (mirrors
+  // TechCard.lock_version).
+  lockVersion: number | undefined;
 };
 
 // SampleInsert is the writable payload of a sample (сэмпл) — a sewn prototype of a style

--- a/src/components/managers/materials/components/movement-modals.tsx
+++ b/src/components/managers/materials/components/movement-modals.tsx
@@ -295,6 +295,10 @@ export function IssueStockModal({
         isReturn,
         occurredAt,
         comment: comment.trim(),
+        // gap-07 v2: optional per-colourway (product_id) and structured-lot attribution — not
+        // surfaced in this generic issue modal yet.
+        productId: 0,
+        lotId: 0,
       });
       showMessage(posted(res.movement), 'success');
       onOpenChange(false);

--- a/src/components/managers/materials/components/useMaterials.ts
+++ b/src/components/managers/materials/components/useMaterials.ts
@@ -16,11 +16,12 @@ const materialKeys = {
 export const bomSectionToDbFilter = (section: string): string | undefined =>
   section ? section.replace('TECH_CARD_BOM_SECTION_', '').toLowerCase() : undefined;
 
-export function useMaterials(section: string, includeArchived: boolean) {
+export function useMaterials(section: string, includeArchived: boolean, enabled = true) {
   return useQuery({
     queryKey: materialKeys.list(section, includeArchived),
     queryFn: () =>
       adminService.ListMaterials({ section: bomSectionToDbFilter(section), includeArchived }),
+    enabled,
   });
 }
 

--- a/src/components/managers/opex/components/recurring-tab.tsx
+++ b/src/components/managers/opex/components/recurring-tab.tsx
@@ -251,6 +251,8 @@ function RecurringFormModal({
           activeFrom: monthToApi(d.activeFrom),
           activeTo: d.activeTo ? monthToApi(d.activeTo) : '',
           note: d.note.trim(),
+          // gap-07 v2 A: salary link to the employee registry — registry UI not built yet.
+          employeeId: 0,
         },
       });
       showMessage(existing ? 'Template saved' : 'Template added', 'success');

--- a/src/components/managers/production-runs/components/aux-run-plan.tsx
+++ b/src/components/managers/production-runs/components/aux-run-plan.tsx
@@ -1,0 +1,141 @@
+import { common_Material, common_ProductionRun } from 'api/proto-http/admin';
+import { ROUTES } from 'constants/routes';
+import { useSnackBarStore } from 'lib/stores/store';
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Button } from 'ui/components/button';
+import Text from 'ui/components/text';
+import { useUpdateRunSection } from './useProductionRuns';
+
+const input = 'w-32 border border-textInactiveColor bg-bgColor px-2 py-1.5 text-textBaseSize';
+
+export function materialLabel(m?: common_Material, fallbackId = 0): string {
+  if (m) return `${m.code ? `${m.code} · ` : ''}${m.name ?? `#${m.id}`}`;
+  return fallbackId ? `#${fallbackId}` : '';
+}
+
+// Auxiliary run planning (NF-07 / B-3). An auxiliary tech card produces a MATERIAL, not sellable
+// products, so the colour-model × size grid doesn't apply — the run is just a quantity of the
+// card's output_material_id. On receive Σ received_qty is booked into that material's warehouse
+// stock, so the run's single line carries NO product_id and NO size (both 0); a line with a
+// product_id would be rejected by ReceiveProductionRun (InvalidArgument).
+export function AuxRunPlan({
+  run,
+  canEdit,
+  locked,
+  outputMaterialId,
+  outputMaterial,
+}: {
+  run: common_ProductionRun;
+  canEdit: boolean;
+  locked: boolean;
+  outputMaterialId: number;
+  outputMaterial?: common_Material;
+}) {
+  const { showMessage } = useSnackBarStore();
+  const update = useUpdateRunSection();
+  const editable = canEdit && !locked;
+
+  // The aux run's single product-less line holds the whole planned quantity.
+  const lines = run.run?.lines ?? [];
+  const line = lines.find((l) => !l.productId) ?? lines[0];
+
+  const [qty, setQty] = useState('');
+  // A sibling save (marker / costs) refetches the run — a dirty guard keeps a refetch from
+  // discarding a typed-but-unsaved quantity, matching the lines grid.
+  const [dirty, setDirty] = useState(false);
+  useEffect(() => {
+    if (dirty) return;
+    setQty(line?.plannedQty ? String(line.plannedQty) : '');
+  }, [line, dirty]);
+
+  const unit = outputMaterial?.unit?.trim();
+  const label = materialLabel(outputMaterial, outputMaterialId);
+
+  const save = async () => {
+    const planned = Number(qty);
+    if (!qty.trim() || !Number.isFinite(planned) || planned <= 0) {
+      showMessage('Enter a planned quantity greater than 0', 'error');
+      return;
+    }
+    // Replace the run's lines with the single aux line; keep any already-counted received/defect
+    // so re-planning before receive doesn't wipe a partial count.
+    try {
+      await update.mutateAsync({
+        id: run.id!,
+        patch: {
+          lines: [
+            {
+              productId: 0,
+              sizeId: 0,
+              plannedQty: planned,
+              receivedQty: line?.receivedQty,
+              defectQty: line?.defectQty,
+            },
+          ],
+        },
+      });
+      setDirty(false);
+      showMessage('Plan saved', 'success');
+    } catch (e) {
+      showMessage(e instanceof Error ? e.message : 'Failed to save plan', 'error');
+    }
+  };
+
+  return (
+    <div className='flex flex-col gap-2'>
+      <Text variant='uppercase' size='small'>
+        auxiliary output
+        {dirty ? <span className='ml-2 lowercase text-labelColor'>· unsaved</span> : null}
+      </Text>
+
+      {outputMaterialId ? (
+        <Text variant='inactive' size='small'>
+          produces → {label}
+          {unit ? ` · ${unit}` : ''} · booked into the material warehouse on receive
+        </Text>
+      ) : (
+        <Text size='small'>
+          ! no output material on the tech card — set one before planning or receiving ·{' '}
+          <Link to={`${ROUTES.techCards}/${run.run?.techCardId}`} className='underline'>
+            open tech card ↗
+          </Link>
+        </Text>
+      )}
+
+      <div className='flex flex-wrap items-end gap-3'>
+        <label className='flex flex-col gap-1'>
+          <Text size='small'>planned quantity{unit ? ` (${unit})` : ''}</Text>
+          <input
+            className={input}
+            inputMode='numeric'
+            value={qty}
+            disabled={!editable}
+            onChange={(e) => {
+              setDirty(true);
+              setQty(e.target.value.replace(/[^0-9]/g, ''));
+            }}
+          />
+        </label>
+        {line?.receivedQty != null ? (
+          <Text variant='inactive' size='small'>
+            received {line.receivedQty}
+            {line.defectQty ? ` · defect ${line.defectQty}` : ''}
+          </Text>
+        ) : null}
+        {editable ? (
+          <Button
+            type='button'
+            variant='main'
+            size='lg'
+            className='uppercase'
+            disabled={update.isPending}
+            onClick={save}
+          >
+            {update.isPending ? 'saving…' : 'save plan'}
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/managers/production-runs/components/aux-run-plan.tsx
+++ b/src/components/managers/production-runs/components/aux-run-plan.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Button } from 'ui/components/button';
 import Text from 'ui/components/text';
-import { useUpdateRunSection } from './useProductionRuns';
+import { updateRunErrorMessage, useUpdateRunSection } from './useProductionRuns';
 
 const input = 'w-32 border border-textInactiveColor bg-bgColor px-2 py-1.5 text-textBaseSize';
 
@@ -78,7 +78,7 @@ export function AuxRunPlan({
       setDirty(false);
       showMessage('Plan saved', 'success');
     } catch (e) {
-      showMessage(e instanceof Error ? e.message : 'Failed to save plan', 'error');
+      showMessage(updateRunErrorMessage(e), 'error');
     }
   };
 

--- a/src/components/managers/production-runs/components/lines-grid.tsx
+++ b/src/components/managers/production-runs/components/lines-grid.tsx
@@ -8,7 +8,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Button } from 'ui/components/button';
 import Text from 'ui/components/text';
-import { useUpdateRunSection } from './useProductionRuns';
+import { updateRunErrorMessage, useUpdateRunSection } from './useProductionRuns';
 
 const cell = 'border border-textInactiveColor bg-bgColor px-2 py-1 text-textBaseSize';
 const key = (productId: number, sizeId: number) => `${productId}:${sizeId}`;
@@ -168,7 +168,7 @@ export function LinesGrid({
       setDirty(false);
       showMessage('Lines saved', 'success');
     } catch (e) {
-      showMessage(e instanceof Error ? e.message : 'Failed to save lines', 'error');
+      showMessage(updateRunErrorMessage(e), 'error');
     }
   };
 

--- a/src/components/managers/production-runs/components/marker-block.tsx
+++ b/src/components/managers/production-runs/components/marker-block.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Button } from 'ui/components/button';
 import Text from 'ui/components/text';
 import { decimalToInput, inputToDecimal, sanitizeDecimal } from 'utils/decimal';
-import { useUpdateRunSection } from './useProductionRuns';
+import { updateRunErrorMessage, useUpdateRunSection } from './useProductionRuns';
 
 const cell = 'w-full border border-textInactiveColor bg-bgColor px-2 py-1.5 text-textBaseSize';
 
@@ -76,7 +76,7 @@ export function MarkerBlock({
       setDirty(false);
       showMessage('Marker saved', 'success');
     } catch (e) {
-      showMessage(e instanceof Error ? e.message : 'Failed to save marker', 'error');
+      showMessage(updateRunErrorMessage(e), 'error');
     }
   };
 

--- a/src/components/managers/production-runs/components/production-run-modal.tsx
+++ b/src/components/managers/production-runs/components/production-run-modal.tsx
@@ -9,7 +9,11 @@ import { Button } from 'ui/components/button';
 import Text from 'ui/components/text';
 import { decimalToInput } from 'utils/decimal';
 import { isRunLocked, runDetailPath, runStatusLabel, runStatusOptions } from './options';
-import { useSaveProductionRun, useUpdateRunSection } from './useProductionRuns';
+import {
+  updateRunErrorMessage,
+  useSaveProductionRun,
+  useUpdateRunSection,
+} from './useProductionRuns';
 
 const cell = 'w-full border border-textInactiveColor bg-bgColor px-2 py-1.5 text-textBaseSize';
 const isoToDate = (ts?: string) => (ts ? ts.slice(0, 10) : '');
@@ -129,8 +133,7 @@ export function ProductionRunModal({
             showMessage('Run updated', 'success');
             onOpenChange(false);
           },
-          onError: (e) =>
-            showMessage(e instanceof Error ? e.message : 'Failed to save run', 'error'),
+          onError: (e) => showMessage(updateRunErrorMessage(e), 'error'),
         },
       );
       return;

--- a/src/components/managers/production-runs/components/production-run-modal.tsx
+++ b/src/components/managers/production-runs/components/production-run-modal.tsx
@@ -150,6 +150,7 @@ export function ProductionRunModal({
           costs: [],
           markerEfficiencyPct: undefined,
           markerNotes: undefined,
+          markers: [],
         },
       },
       {

--- a/src/components/managers/production-runs/components/receive-modal.tsx
+++ b/src/components/managers/production-runs/components/receive-modal.tsx
@@ -1,5 +1,5 @@
 import * as DialogPrimitives from '@radix-ui/react-dialog';
-import { common_ProductionRun } from 'api/proto-http/admin';
+import { common_Material, common_ProductionRun } from 'api/proto-http/admin';
 import { usePermissions } from 'components/managers/accounts/utils/permissions';
 import { findInDictionary } from 'lib/features/findInDictionary';
 import { useDictionary } from 'lib/providers/dictionary-provider';
@@ -8,6 +8,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from 'ui/components/button';
 import Text from 'ui/components/text';
 import { decimalToInput } from 'utils/decimal';
+import { materialLabel } from './aux-run-plan';
 import { useReceiveProductionRun, useUpdateRunSection } from './useProductionRuns';
 
 const cell = 'w-full border border-textInactiveColor bg-bgColor px-2 py-1.5 text-textBaseSize';
@@ -23,14 +24,23 @@ type Row = {
 // Receiving is two steps against the contract: persist received/defect on each run LINE
 // (UpdateProductionRun), then post stock into each line's own product + optionally set its
 // cost_price (ReceiveProductionRun — NF-06, no run-level product).
+// Auxiliary runs (NF-07 / B-3) reuse the same two steps, but the single product-less line's
+// received qty is booked into the tech card's output_material_id in the MATERIAL warehouse: no
+// per-product grouping, no orphan guard, and cost_price is a no-op (there is no product).
 export function ReceiveModal({
   open,
   onOpenChange,
   run,
+  isAux = false,
+  outputMaterialId = 0,
+  outputMaterial,
 }: {
   open: boolean;
   onOpenChange: (v: boolean) => void;
   run?: common_ProductionRun;
+  isAux?: boolean;
+  outputMaterialId?: number;
+  outputMaterial?: common_Material;
 }) {
   const { showMessage } = useSnackBarStore();
   const { dictionary } = useDictionary();
@@ -53,6 +63,14 @@ export function ReceiveModal({
     });
     return out;
   }, [rows]);
+
+  // The aux run is a single product-less line; find its flat index for the received/defect inputs.
+  const auxIdx = useMemo(() => {
+    const i = rows.findIndex((r) => !r.productId);
+    return i >= 0 ? i : 0;
+  }, [rows]);
+  const auxDest = materialLabel(outputMaterial, outputMaterialId);
+  const auxUnit = outputMaterial?.unit?.trim();
 
   // Reset per-run state on the CLOSED → OPEN transition only. The naive [run, open] deps
   // re-ran mid-flow — step 1's own invalidation refetches `run` on the detail page and the
@@ -83,15 +101,24 @@ export function ReceiveModal({
 
   const submit = async () => {
     if (!run?.id || !run.run) return;
-    // NF-06: a line with received > 0 is booked into its own product — it must have one. Publish
-    // the colour-model as a product (or zero its received qty) before receiving.
-    const orphans = rows.filter((r) => (Number(r.received) || 0) > 0 && !r.productId);
-    if (orphans.length > 0) {
-      showMessage(
-        `${orphans.length} line(s) have no product — publish the product or set received to 0`,
-        'error',
-      );
-      return;
+    if (isAux) {
+      // NF-07: aux receive books into output_material_id — the card must name one, or the RPC
+      // fails with FailedPrecondition.
+      if (!outputMaterialId) {
+        showMessage('Set an output material on the tech card before receiving', 'error');
+        return;
+      }
+    } else {
+      // NF-06: a line with received > 0 is booked into its own product — it must have one. Publish
+      // the colour-model as a product (or zero its received qty) before receiving.
+      const orphans = rows.filter((r) => (Number(r.received) || 0) > 0 && !r.productId);
+      if (orphans.length > 0) {
+        showMessage(
+          `${orphans.length} line(s) have no product — publish the product or set received to 0`,
+          'error',
+        );
+        return;
+      }
     }
     // Guard the counts: no negatives, and defects can't exceed what was received.
     for (const r of rows) {
@@ -134,12 +161,18 @@ export function ReceiveModal({
       return;
     }
     try {
-      // Step 2 posts stock into each line's product + optionally sets cost_price.
-      const res = await receive.mutateAsync({ runId: run.id, updateCostPrice });
+      // Step 2 posts stock into each line's product (or the output material for aux) + optionally
+      // sets cost_price (no-op for aux).
+      const res = await receive.mutateAsync({
+        runId: run.id,
+        updateCostPrice: isAux ? false : updateCostPrice,
+      });
       showMessage(
-        res.costPriceUpdated
-          ? 'Run received · product cost updated'
-          : 'Run received · stock posted',
+        isAux
+          ? 'Run received · material stock posted'
+          : res.costPriceUpdated
+            ? 'Run received · product cost updated'
+            : 'Run received · stock posted',
         'success',
       );
       onOpenChange(false);
@@ -179,16 +212,16 @@ export function ReceiveModal({
                 no lines planned — plan quantities on the run page first
               </Text>
             ) : null}
-            {groups.map((g) => (
-              <div key={g.productId} className='flex flex-col gap-1'>
+
+            {isAux && rows.length > 0 ? (
+              <div className='flex flex-col gap-1'>
                 <Text size='small'>
-                  {g.productId
-                    ? `#${g.productId}`
-                    : '(unassigned — publish a product to book stock)'}
+                  → {auxDest || 'output material'}
+                  {auxUnit ? ` · ${auxUnit}` : ''} · booked into the material warehouse
                 </Text>
                 <div className='grid grid-cols-[1fr_auto_auto] items-center gap-2'>
                   <Text variant='uppercase' size='small'>
-                    size
+                    quantity
                   </Text>
                   <Text variant='uppercase' size='small'>
                     received
@@ -196,34 +229,76 @@ export function ReceiveModal({
                   <Text variant='uppercase' size='small'>
                     defect
                   </Text>
-                  {g.items.map(({ r, i }) => (
-                    <RowInputs
-                      key={`${r.productId}-${r.sizeId}`}
-                      label={String(findInDictionary(dictionary, r.sizeId, 'size') || r.sizeId)}
-                      planned={r.plannedQty}
-                      received={r.received}
-                      defect={r.defect}
-                      onReceived={(v) =>
-                        setRows((prev) => {
-                          const next = [...prev];
-                          next[i] = { ...next[i], received: v };
-                          return next;
-                        })
-                      }
-                      onDefect={(v) =>
-                        setRows((prev) => {
-                          const next = [...prev];
-                          next[i] = { ...next[i], defect: v };
-                          return next;
-                        })
-                      }
-                    />
-                  ))}
+                  <RowInputs
+                    label={auxUnit || 'units'}
+                    planned={rows[auxIdx]?.plannedQty ?? 0}
+                    received={rows[auxIdx]?.received ?? '0'}
+                    defect={rows[auxIdx]?.defect ?? '0'}
+                    onReceived={(v) =>
+                      setRows((prev) => {
+                        const next = [...prev];
+                        next[auxIdx] = { ...next[auxIdx], received: v };
+                        return next;
+                      })
+                    }
+                    onDefect={(v) =>
+                      setRows((prev) => {
+                        const next = [...prev];
+                        next[auxIdx] = { ...next[auxIdx], defect: v };
+                        return next;
+                      })
+                    }
+                  />
                 </div>
               </div>
-            ))}
+            ) : null}
 
-            {canWriteCosting && (
+            {!isAux &&
+              groups.map((g) => (
+                <div key={g.productId} className='flex flex-col gap-1'>
+                  <Text size='small'>
+                    {g.productId
+                      ? `#${g.productId}`
+                      : '(unassigned — publish a product to book stock)'}
+                  </Text>
+                  <div className='grid grid-cols-[1fr_auto_auto] items-center gap-2'>
+                    <Text variant='uppercase' size='small'>
+                      size
+                    </Text>
+                    <Text variant='uppercase' size='small'>
+                      received
+                    </Text>
+                    <Text variant='uppercase' size='small'>
+                      defect
+                    </Text>
+                    {g.items.map(({ r, i }) => (
+                      <RowInputs
+                        key={`${r.productId}-${r.sizeId}`}
+                        label={String(findInDictionary(dictionary, r.sizeId, 'size') || r.sizeId)}
+                        planned={r.plannedQty}
+                        received={r.received}
+                        defect={r.defect}
+                        onReceived={(v) =>
+                          setRows((prev) => {
+                            const next = [...prev];
+                            next[i] = { ...next[i], received: v };
+                            return next;
+                          })
+                        }
+                        onDefect={(v) =>
+                          setRows((prev) => {
+                            const next = [...prev];
+                            next[i] = { ...next[i], defect: v };
+                            return next;
+                          })
+                        }
+                      />
+                    ))}
+                  </div>
+                </div>
+              ))}
+
+            {!isAux && canWriteCosting && (
               <label className='flex items-center gap-2 border-t border-textInactiveColor pt-3'>
                 <input
                   type='checkbox'
@@ -240,8 +315,9 @@ export function ReceiveModal({
             )}
 
             <Text variant='inactive' size='small'>
-              Приёмка приходует сток по каждой строке в её продукт и переводит партию в received —
-              после этого её нельзя удалить.
+              {isAux
+                ? 'Приёмка приходует выпуск в склад материала (output material) и переводит партию в received — после этого её нельзя удалить.'
+                : 'Приёмка приходует сток по каждой строке в её продукт и переводит партию в received — после этого её нельзя удалить.'}
             </Text>
           </div>
 

--- a/src/components/managers/production-runs/components/receive-modal.tsx
+++ b/src/components/managers/production-runs/components/receive-modal.tsx
@@ -9,7 +9,11 @@ import { Button } from 'ui/components/button';
 import Text from 'ui/components/text';
 import { decimalToInput } from 'utils/decimal';
 import { materialLabel } from './aux-run-plan';
-import { useReceiveProductionRun, useUpdateRunSection } from './useProductionRuns';
+import {
+  updateRunErrorMessage,
+  useReceiveProductionRun,
+  useUpdateRunSection,
+} from './useProductionRuns';
 
 const cell = 'w-full border border-textInactiveColor bg-bgColor px-2 py-1.5 text-textBaseSize';
 
@@ -157,7 +161,7 @@ export function ReceiveModal({
           }),
       });
     } catch (e) {
-      showMessage(e instanceof Error ? e.message : 'Failed to save received counts', 'error');
+      showMessage(updateRunErrorMessage(e), 'error');
       return;
     }
     try {

--- a/src/components/managers/production-runs/components/run-costs.tsx
+++ b/src/components/managers/production-runs/components/run-costs.tsx
@@ -10,7 +10,7 @@ import { Button } from 'ui/components/button';
 import Text from 'ui/components/text';
 import { decimalToInput, inputToDecimal, sanitizeDecimal } from 'utils/decimal';
 import { runCostKindOptions } from './options';
-import { useUpdateRunSection } from './useProductionRuns';
+import { updateRunErrorMessage, useUpdateRunSection } from './useProductionRuns';
 
 const cell = 'w-full border border-textInactiveColor bg-bgColor px-2 py-1.5 text-textBaseSize';
 const isoToDate = (ts?: string) => (ts ? ts.slice(0, 10) : '');
@@ -113,7 +113,7 @@ export function RunCosts({
       setDirty(false);
       showMessage('Costs saved', 'success');
     } catch (e) {
-      showMessage(e instanceof Error ? e.message : 'Failed to save costs', 'error');
+      showMessage(updateRunErrorMessage(e), 'error');
     }
   };
 

--- a/src/components/managers/production-runs/components/useProductionRuns.ts
+++ b/src/components/managers/production-runs/components/useProductionRuns.ts
@@ -27,7 +27,7 @@ export function useUpdateRunSection() {
       const base = (fresh.run?.run ?? {}) as common_ProductionRunInsert;
       const run = { ...base, ...patch };
       if (mergeLines) run.lines = mergeLines(base.lines ?? []);
-      return adminService.UpdateProductionRun({ id, run });
+      return adminService.UpdateProductionRun({ id, run, expectedLockVersion: 0 });
     },
     onSuccess: (_d, v) => {
       qc.invalidateQueries({ queryKey: productionRunKeys.all });
@@ -53,6 +53,7 @@ export function useProductionRuns(techCardId: number, status: string) {
         status: runStatusToDbFilter(status),
         limit: 200,
         offset: 0,
+        staleDays: undefined,
       }),
   });
 }
@@ -82,7 +83,7 @@ export function useSaveProductionRun() {
   return useMutation({
     mutationFn: ({ id, run }: { id: number; run: common_ProductionRunInsert }) =>
       id
-        ? adminService.UpdateProductionRun({ id, run })
+        ? adminService.UpdateProductionRun({ id, run, expectedLockVersion: 0 })
         : adminService.CreateProductionRun({ run }),
     onSuccess: () => qc.invalidateQueries({ queryKey: productionRunKeys.all }),
   });

--- a/src/components/managers/production-runs/components/useProductionRuns.ts
+++ b/src/components/managers/production-runs/components/useProductionRuns.ts
@@ -4,11 +4,12 @@ import { common_ProductionRunInsert, common_ProductionRunLine } from 'api/proto-
 import { stockChangeHistoryKeys } from 'components/managers/product/components/stock/useStockChangeHistory';
 import { runStatusToDbFilter } from './options';
 
-// Read-modify-write a single section of a run's insert (R-17). UpdateProductionRun is a
-// full-replace with no lock_version, so each detail-page section (lines / marker / costs)
-// re-fetches the latest run immediately before saving and overrides ONLY its own keys — a
-// marker edit can't clobber concurrently-saved lines, and vice versa. The race window shrinks
-// to the fetch→save gap; a true lock_version on runs is a backend follow-up.
+// Read-modify-write a single section of a run's insert (R-17). Each detail-page section
+// (lines / marker / costs) re-fetches the latest run immediately before saving and overrides
+// ONLY its own keys — a marker edit can't clobber concurrently-saved lines, and vice versa.
+// #9: the fetched run's lock_version is now echoed back as expected_lock_version, so the server
+// rejects (Aborted → HTTP 409) if a concurrent writer bumped it in the fetch→save gap instead of
+// silently last-write-winning. A run predating the field reads lock_version 0 → legacy behaviour.
 // `mergeLines` derives the new lines FROM the fresh ones (receive uses it to stamp counted
 // quantities per (product, size) without replacing concurrently-edited lines wholesale).
 export function useUpdateRunSection() {
@@ -25,9 +26,10 @@ export function useUpdateRunSection() {
     }) => {
       const fresh = await adminService.GetProductionRun({ id });
       const base = (fresh.run?.run ?? {}) as common_ProductionRunInsert;
+      const expectedLockVersion = fresh.run?.lockVersion ?? 0;
       const run = { ...base, ...patch };
       if (mergeLines) run.lines = mergeLines(base.lines ?? []);
-      return adminService.UpdateProductionRun({ id, run, expectedLockVersion: 0 });
+      return adminService.UpdateProductionRun({ id, run, expectedLockVersion });
     },
     onSuccess: (_d, v) => {
       qc.invalidateQueries({ queryKey: productionRunKeys.all });
@@ -36,16 +38,28 @@ export function useUpdateRunSection() {
   });
 }
 
+// #9: an optimistic-lock conflict (Aborted → HTTP 409) means another writer saved the run between
+// this section's read and write. Surface a reload-and-retry hint rather than the raw gateway text;
+// silently retrying would re-introduce the last-write-wins the lock exists to prevent.
+export function updateRunErrorMessage(e: unknown): string {
+  const status = (e as { status?: number } | undefined)?.status;
+  if (status === 409) return 'Партия была изменена в другом окне — обновите страницу и повторите';
+  return e instanceof Error ? e.message : 'Не удалось сохранить изменения партии';
+}
+
 export const productionRunKeys = {
   all: ['productionRuns'] as const,
-  list: (techCardId: number, status: string) =>
-    [...productionRunKeys.all, 'list', techCardId, status] as const,
+  list: (techCardId: number, status: string, staleDays = 0) =>
+    [...productionRunKeys.all, 'list', techCardId, status, staleDays] as const,
   detail: (id: number) => [...productionRunKeys.all, 'detail', id] as const,
 };
 
-export function useProductionRuns(techCardId: number, status: string) {
+// #10: stale_days > 0 asks the backend for only the non-terminal runs that have sat at least that
+// long (the "stale" set the attention strip counts), replacing a client scan of two full status
+// pages. 0 = no staleness filter.
+export function useProductionRuns(techCardId: number, status: string, staleDays = 0) {
   return useQuery({
-    queryKey: productionRunKeys.list(techCardId, status),
+    queryKey: productionRunKeys.list(techCardId, status, staleDays),
     queryFn: () =>
       adminService.ListProductionRuns({
         techCardId: techCardId || undefined,
@@ -53,7 +67,7 @@ export function useProductionRuns(techCardId: number, status: string) {
         status: runStatusToDbFilter(status),
         limit: 200,
         offset: 0,
-        staleDays: undefined,
+        staleDays: staleDays || undefined,
       }),
   });
 }

--- a/src/components/managers/production-runs/detail-page.tsx
+++ b/src/components/managers/production-runs/detail-page.tsx
@@ -1,15 +1,17 @@
 import { common_ProductionRun, common_ProductionRunActuals } from 'api/proto-http/admin';
 import { usePermissions } from 'components/managers/accounts/utils/permissions';
+import { useMaterials } from 'components/managers/materials/components/useMaterials';
 import { MovementsList } from 'components/managers/materials/components/movements-tab';
 import { useTechCard } from 'components/managers/tech-cards/components/useTechCardQuery';
 import { ROUTES, SECTION } from 'constants/routes';
 import { useSnackBarStore } from 'lib/stores/store';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { Button } from 'ui/components/button';
 import { ConfirmationModal } from 'ui/components/confirmation-modal';
 import Text from 'ui/components/text';
 import { decimalToInput } from 'utils/decimal';
+import { AuxRunPlan } from './components/aux-run-plan';
 import { LinesGrid } from './components/lines-grid';
 import { MarkerBlock } from './components/marker-block';
 import { MaterialPlan } from './components/material-plan';
@@ -40,6 +42,17 @@ export function ProductionRunDetail() {
   const { data: techCard } = useTechCard(ins?.techCardId ? ins.techCardId : undefined);
   const tcName = techCard?.techCard?.styleNumber || techCard?.techCard?.name || '';
 
+  // NF-07 / B-3: an auxiliary card produces a MATERIAL, not products. Its run is a single
+  // product-less quantity received into output_material_id, so it swaps the colour-model grid for
+  // a plain quantity plan and the receive posts into the material warehouse.
+  const isAux = techCard?.techCard?.purpose === 'auxiliary';
+  const outputMaterialId = techCard?.techCard?.outputMaterialId ?? 0;
+  const { data: materialsData } = useMaterials('', true, isAux);
+  const outputMaterial = useMemo(
+    () => (materialsData?.materials ?? []).find((m) => m.id === outputMaterialId),
+    [materialsData, outputMaterialId],
+  );
+
   const [editOpen, setEditOpen] = useState(false);
   const [receiveOpen, setReceiveOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -47,9 +60,12 @@ export function ProductionRunDetail() {
   const locked = isRunLocked(ins?.status);
   const receivable = isRunReceivable(ins?.status);
   // Lines planned but not yet tied to a product can't be booked on receive (NF-06) — hint it.
-  const unassignedPlanned = (ins?.lines ?? []).filter(
-    (l) => (l.plannedQty ?? 0) > 0 && !l.productId,
-  ).length;
+  // Auxiliary lines legitimately carry no product (they book into a material), so never flag them.
+  const unassignedPlanned = isAux
+    ? 0
+    : (ins?.lines ?? []).filter((l) => (l.plannedQty ?? 0) > 0 && !l.productId).length;
+  // An aux run can't be received until the card names an output material (FailedPrecondition).
+  const auxNoMaterial = isAux && !outputMaterialId;
 
   const confirmDelete = () =>
     del.mutate(runId, {
@@ -99,9 +115,11 @@ export function ProductionRunDetail() {
                 size='lg'
                 className='uppercase'
                 title={
-                  unassignedPlanned
-                    ? `${unassignedPlanned} line(s) have no product — publish them or zero their received qty`
-                    : undefined
+                  auxNoMaterial
+                    ? 'set an output material on the tech card before receiving'
+                    : unassignedPlanned
+                      ? `${unassignedPlanned} line(s) have no product — publish them or zero their received qty`
+                      : undefined
                 }
                 onClick={() => setReceiveOpen(true)}
               >
@@ -134,7 +152,17 @@ export function ProductionRunDetail() {
 
       {canReadCosting ? <PlanFactBlock run={run} actuals={actuals} /> : null}
 
-      <LinesGrid run={run} canEdit={canEdit} locked={locked} />
+      {isAux ? (
+        <AuxRunPlan
+          run={run}
+          canEdit={canEdit}
+          locked={locked}
+          outputMaterialId={outputMaterialId}
+          outputMaterial={outputMaterial}
+        />
+      ) : (
+        <LinesGrid run={run} canEdit={canEdit} locked={locked} />
+      )}
 
       <MarkerBlock run={run} canEdit={canEdit} locked={locked} />
 
@@ -150,7 +178,14 @@ export function ProductionRunDetail() {
       </div>
 
       <ProductionRunModal open={editOpen} onOpenChange={setEditOpen} run={run} />
-      <ReceiveModal open={receiveOpen} onOpenChange={setReceiveOpen} run={run} />
+      <ReceiveModal
+        open={receiveOpen}
+        onOpenChange={setReceiveOpen}
+        run={run}
+        isAux={isAux}
+        outputMaterialId={outputMaterialId}
+        outputMaterial={outputMaterial}
+      />
       <ConfirmationModal
         open={deleteOpen}
         onOpenChange={setDeleteOpen}

--- a/src/components/managers/production-runs/index.tsx
+++ b/src/components/managers/production-runs/index.tsx
@@ -73,23 +73,18 @@ export function ProductionRuns() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const { data, isLoading, isError } = useProductionRuns(Number(techCardId) || 0, status);
+  // ?stale=<days> (attention-strip deep link): ask the backend for only the non-terminal runs
+  // sitting at least that long — the same server-side predicate the strip counts, so the link
+  // shows exactly those runs (no client rescan of the full list).
+  const staleDays = Number(searchParams.get('stale')) || 0;
+  const { data, isLoading, isError } = useProductionRuns(
+    Number(techCardId) || 0,
+    status,
+    staleDays,
+  );
   const del = useDeleteProductionRun();
   const { showMessage } = useSnackBarStore();
-  // ?stale=<days> (attention-strip deep link): show only non-terminal runs sitting at least
-  // that long — the same predicate the strip counted, so the link shows exactly those runs.
-  const staleDays = Number(searchParams.get('stale')) || 0;
-  const allRuns = data?.runs ?? [];
-  const runs = staleDays
-    ? allRuns.filter((r) => {
-        const s = r.run?.status ?? '';
-        if (s !== 'PRODUCTION_RUN_STATUS_PLANNED' && s !== 'PRODUCTION_RUN_STATUS_IN_PROGRESS')
-          return false;
-        const started = r.run?.startedAt ?? r.createdAt;
-        if (!started) return false;
-        return (Date.now() - new Date(started).getTime()) / 86_400_000 >= staleDays;
-      })
-    : allRuns;
+  const runs = data?.runs ?? [];
 
   const openCreate = () => {
     setEditing(undefined);

--- a/src/components/managers/tasks/utils/entity-configs.ts
+++ b/src/components/managers/tasks/utils/entity-configs.ts
@@ -246,6 +246,7 @@ export const runConfig: EntityConfig = {
       status: undefined,
       limit: 100,
       offset: undefined,
+      staleDays: undefined,
     });
     return (r.runs ?? []).map(runOption);
   },

--- a/src/components/managers/tech-card/components/index.tsx
+++ b/src/components/managers/tech-card/components/index.tsx
@@ -256,13 +256,6 @@ export function TechCardForm({
   async function doSubmit(data: TechCardFormData) {
     setConflict(false);
     const techCardInsert = mapFormToTechCardInsert(data, techCard?.techCard, canWriteCosting);
-    // The mapper mints an IDEA-<ts> draft number when the field is blank — write it back into
-    // the form, or every save of a blank IDEA card mints a NEW identity (and the header keeps
-    // showing nothing).
-    if (!data.styleNumber?.trim() && techCardInsert.styleNumber) {
-      data = { ...data, styleNumber: techCardInsert.styleNumber };
-      form.setValue('styleNumber', techCardInsert.styleNumber);
-    }
     try {
       if (isEditMode) {
         await updateTechCard.mutateAsync({
@@ -500,12 +493,12 @@ export function TechCardForm({
                 <InputField
                   name='styleNumber'
                   label={isIdea ? 'style number' : 'style number *'}
-                  placeholder={isIdea ? 'auto IDEA-… draft' : 'артикул'}
+                  placeholder={isIdea ? 'optional — set before PROTO' : 'артикул'}
                 />
                 {isIdea && (
                   <Text variant='inactive' size='small'>
-                    optional at idea — a draft number is assigned on save; set the real one before
-                    PROTO
+                    optional while this is an idea — a real style number is required before the card
+                    can advance to PROTO
                   </Text>
                 )}
                 <InputField name='name' label='name *' placeholder='название изделия' />

--- a/src/components/managers/tech-card/components/samples-tab.tsx
+++ b/src/components/managers/tech-card/components/samples-tab.tsx
@@ -55,6 +55,10 @@ export function SamplesTab({
   const sizeName = (sizeId?: number) =>
     sizeId ? String(findInDictionary(dictionary, sizeId, 'size') || sizeId) : '—';
 
+  const colorways = techCard?.techCard?.colorways ?? [];
+  const colorwayName = (id?: number) =>
+    id ? colorwayLabel(colorways.find((c) => c.id === id)) : '—';
+
   const setExpanded = (v: string) =>
     setParams(
       (prev) => {
@@ -116,6 +120,7 @@ export function SamplesTab({
                 <th className={th}>#</th>
                 <th className={th}>purpose</th>
                 <th className={th}>size</th>
+                <th className={th}>colourway</th>
                 <th className={th}>fabric</th>
                 <th className={th}>status</th>
               </tr>
@@ -137,12 +142,13 @@ export function SamplesTab({
                       </td>
                       <td className={td}>{samplePurposeLabel(s.sample?.purpose)}</td>
                       <td className={td}>{sizeName(s.sample?.sizeId)}</td>
+                      <td className={td}>{colorwayName(s.sample?.colorwayId)}</td>
                       <td className={td}>{sampleFabricSourceLabel(s.sample?.fabricSource)}</td>
                       <td className={td}>{sampleStatusLabel(s.sample?.status)}</td>
                     </tr>
                     {open ? (
                       <tr>
-                        <td className={td} colSpan={5}>
+                        <td className={td} colSpan={6}>
                           <SampleEditor
                             sample={s}
                             techCardId={techCardId}
@@ -168,6 +174,7 @@ export function SamplesTab({
 type Draft = {
   purpose: string;
   sizeId: number;
+  colorwayId: number;
   status: string;
   fabricSource: string;
   notes: string;
@@ -183,6 +190,7 @@ function draftFrom(s?: common_Sample): Draft {
   return {
     purpose: i?.purpose || 'proto',
     sizeId: i?.sizeId ?? 0,
+    colorwayId: i?.colorwayId ?? 0,
     status: i?.status || 'planned',
     fabricSource: i?.fabricSource || 'sample',
     notes: i?.notes ?? '',
@@ -192,6 +200,12 @@ function draftFrom(s?: common_Sample): Draft {
     patternUrl: i?.patternUrl ?? '',
     patternNote: i?.patternNote ?? '',
   };
+}
+
+// A colourway's label for a picker / display cell (keyed by its stable id, not index).
+function colorwayLabel(c?: { code?: string; name?: string; id?: number }): string {
+  if (!c) return '—';
+  return c.name || c.code || `колорвей #${c.id ?? '?'}`;
 }
 
 function SampleEditor({
@@ -245,6 +259,10 @@ function SampleEditor({
     setD((prev) => ({ ...prev, ...patch }));
   };
   const sizeIds = techCard?.techCard?.sizeIds ?? [];
+  // B-10: colourways carry a stable, output-only id (re-pointed by identity when the card is
+  // full-replaced on save). Reading them off the live `techCard` query means the picker always
+  // offers fresh ids — the exact ones to link a sample to right now.
+  const colorways = techCard?.techCard?.colorways ?? [];
 
   const mediaLinks = d.mediaIds
     .map((id) => mediaById.get(id))
@@ -269,7 +287,7 @@ function SampleEditor({
           techCardId,
           purpose: d.purpose,
           sizeId: d.sizeId || 0,
-          colorwayId: sample?.sample?.colorwayId ?? 0, // preserved; no reliable colourway id to pick (B-10)
+          colorwayId: d.colorwayId || 0,
           status: d.status,
           fabricSource: d.fabricSource,
           notes: d.notes.trim(),
@@ -330,6 +348,27 @@ function SampleEditor({
             {sizeIds.map((sid) => (
               <option key={sid} value={sid}>
                 {findInDictionary(dictionary, sid, 'size') || sid}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className='flex flex-col gap-1'>
+          <Text size='small'>colourway</Text>
+          <select
+            className={cell}
+            disabled={!canEdit || colorways.length === 0}
+            value={d.colorwayId || 0}
+            onChange={(e) => set({ colorwayId: Number(e.target.value) || 0 })}
+          >
+            <option value={0}>— unset —</option>
+            {/* A saved colourway the picker no longer offers (renamed then re-saved, so its id
+                changed) — keep it selectable so an existing link isn't silently dropped on save. */}
+            {d.colorwayId > 0 && !colorways.some((c) => c.id === d.colorwayId) ? (
+              <option value={d.colorwayId}>колорвей #{d.colorwayId}</option>
+            ) : null}
+            {colorways.map((c) => (
+              <option key={c.id} value={c.id ?? 0}>
+                {colorwayLabel(c)}
               </option>
             ))}
           </select>

--- a/src/components/managers/tech-card/components/schema.ts
+++ b/src/components/managers/tech-card/components/schema.ts
@@ -391,7 +391,7 @@ const techCardObject = z.object({
   revisions: z.array(revisionSchema).default([]),
 });
 
-// style_number is required past the IDEA stage; at IDEA it may be blank (auto-filled on save).
+// style_number is required past the IDEA stage; at IDEA it may be blank (the backend accepts it).
 export const techCardSchema = techCardObject.superRefine((data, ctx) => {
   if (data.stage !== 'TECH_CARD_STAGE_IDEA' && !data.styleNumber?.trim()) {
     ctx.addIssue({
@@ -849,13 +849,11 @@ export function mapFormToTechCardInsert(
   // costing. Preserve the original block instead so a non-costing editor can never destroy it.
   canWriteCosting: boolean = true,
 ): common_TechCardInsert {
-  // B-2: the backend requires style_number even for an IDEA card, so fill an empty one with a draft
-  // `IDEA-<base36 time>` the user renames before PROTO. Edits preserve the existing number (the form
-  // seeds it from the loaded card), so this only ever fires on a fresh blank IDEA concept.
-  const trimmedStyleNumber = data.styleNumber?.trim() || '';
-  const styleNumber =
-    trimmedStyleNumber ||
-    (data.stage === 'TECH_CARD_STAGE_IDEA' ? `IDEA-${Date.now().toString(36).toUpperCase()}` : '');
+  // B-2: an IDEA card may carry an empty style_number — the backend now accepts it while
+  // stage == IDEA and only enforces a real number when the card moves out (to PROTO+). So we
+  // send whatever the user typed verbatim; the schema refine below still requires a number at
+  // non-IDEA stages, blocking a stage advance client-side before the server would reject it.
+  const styleNumber = data.styleNumber?.trim() || '';
   return {
     ...original,
     styleNumber,

--- a/src/components/managers/tech-cards/components/attention-strip.tsx
+++ b/src/components/managers/tech-cards/components/attention-strip.tsx
@@ -50,6 +50,7 @@ export function AttentionStrip() {
         status: 'planned',
         limit: 200,
         offset: 0,
+        staleDays: undefined,
       }),
     enabled: canRuns,
   });
@@ -61,6 +62,7 @@ export function AttentionStrip() {
         status: 'in_progress',
         limit: 200,
         offset: 0,
+        staleDays: undefined,
       }),
     enabled: canRuns,
   });

--- a/src/components/managers/tech-cards/components/attention-strip.tsx
+++ b/src/components/managers/tech-cards/components/attention-strip.tsx
@@ -7,7 +7,6 @@ import Text from 'ui/components/text';
 
 const DAY = 86_400_000;
 const ageDays = (ts?: string) => (ts ? (Date.now() - new Date(ts).getTime()) / DAY : 0);
-const NON_TERMINAL = new Set(['planned', 'in_progress']);
 
 // "What needs attention" across the flow, surfaced where the styles live (R-6): materials below
 // their min stock, production runs sitting too long, and fittings due this week. Each fragment is a
@@ -39,45 +38,23 @@ export function AttentionStrip() {
   });
   const staleDays = alerts.data?.settings?.productionRunStaleDays || 14;
 
-  // Fetch status-filtered pages (one per non-terminal status) so the 200-row cap applies to the
-  // relevant subset: unfiltered newest-first paging dropped exactly the OLD planned/in-progress
-  // runs — the ones most likely stale — silently undercounting (potentially to 0).
-  const plannedRuns = useQuery({
-    queryKey: ['attention', 'runs', 'planned'],
+  // #10: one server-side stale query — stale_days returns only the non-terminal runs sitting at
+  // least that long, so the 200-row cap no longer drops exactly the old runs we're counting. Wait
+  // for the alert settings (success OR error → 14 fallback) so the threshold is resolved before the
+  // query fires, and re-run if the setting changes (staleDays is in the key).
+  const staleRunsQuery = useQuery({
+    queryKey: ['attention', 'runs', 'stale', staleDays],
     queryFn: () =>
       adminService.ListProductionRuns({
         techCardId: undefined,
-        status: 'planned',
+        status: undefined,
         limit: 200,
         offset: 0,
-        staleDays: undefined,
+        staleDays,
       }),
-    enabled: canRuns,
+    enabled: canRuns && !alerts.isLoading,
   });
-  const inProgressRuns = useQuery({
-    queryKey: ['attention', 'runs', 'in_progress'],
-    queryFn: () =>
-      adminService.ListProductionRuns({
-        techCardId: undefined,
-        status: 'in_progress',
-        limit: 200,
-        offset: 0,
-        staleDays: undefined,
-      }),
-    enabled: canRuns,
-  });
-  const staleRuns = [
-    ...(plannedRuns.data?.runs ?? []),
-    ...(inProgressRuns.data?.runs ?? []),
-  ].filter((r) => {
-    if (
-      !NON_TERMINAL.has(
-        r.run?.status ? r.run.status.replace('PRODUCTION_RUN_STATUS_', '').toLowerCase() : '',
-      )
-    )
-      return false;
-    return ageDays(r.run?.startedAt ?? r.createdAt) >= staleDays;
-  }).length;
+  const staleRuns = staleRunsQuery.data?.total ?? staleRunsQuery.data?.runs?.length ?? 0;
 
   const fittings = useQuery({
     queryKey: ['attention', 'fittings'],
@@ -111,8 +88,8 @@ export function AttentionStrip() {
     fragments.push({
       key: 'runs',
       label: `${staleRuns} run${staleRuns > 1 ? 's' : ''} stale ${staleDays}d+`,
-      // ?stale=<days> — the runs list applies the same client-side staleness filter, so the
-      // link shows exactly the counted runs instead of the full unfiltered list.
+      // ?stale=<days> — the runs list runs the same server-side stale_days query, so the link
+      // shows exactly the counted runs instead of the full unfiltered list.
       to: `${ROUTES.productionRuns}?stale=${staleDays}`,
     });
   if (fittingsThisWeek > 0)

--- a/src/components/managers/tech-cards/components/aux-badge.tsx
+++ b/src/components/managers/tech-cards/components/aux-badge.tsx
@@ -1,0 +1,13 @@
+// #8: mark auxiliary tech cards (dust bags, shoppers, packaging…) so a list/board reader can tell
+// them apart from sellable styles at a glance. Driven by TechCardListItem.purpose, which the list
+// RPCs now carry, so no N+1 GetTechCard. Renders nothing for sellable (default) cards.
+export function AuxBadge({ purpose, className = '' }: { purpose?: string; className?: string }) {
+  if (purpose !== 'auxiliary') return null;
+  return (
+    <span
+      className={`inline-block shrink-0 border border-textInactiveColor px-1 text-textBaseSize uppercase leading-tight text-textInactiveColor ${className}`}
+    >
+      aux
+    </span>
+  );
+}

--- a/src/components/managers/tech-cards/components/pipeline-board.tsx
+++ b/src/components/managers/tech-cards/components/pipeline-board.tsx
@@ -1,6 +1,7 @@
 import { common_TechCardListItem, common_TechCardStage } from 'api/proto-http/admin';
 import { Link, useNavigate } from 'react-router-dom';
 import Text from 'ui/components/text';
+import { AuxBadge } from './aux-badge';
 import { approvalStateLabel } from './utils';
 import { useStylePipeline } from './useTechCardQuery';
 
@@ -122,9 +123,12 @@ function PipelineCard({ card }: { card: common_TechCardListItem }) {
         ) : null}
       </div>
       <div className='flex min-w-0 flex-col'>
-        <Text variant='uppercase' size='small' className='truncate'>
-          {card.styleNumber || '—'}
-        </Text>
+        <div className='flex items-center gap-1.5'>
+          <Text variant='uppercase' size='small' className='truncate'>
+            {card.styleNumber || '—'}
+          </Text>
+          <AuxBadge purpose={card.purpose} />
+        </div>
         <Text variant='inactive' size='small' className='truncate'>
           {card.name || '—'}
         </Text>

--- a/src/components/managers/tech-cards/components/tech-card-list.tsx
+++ b/src/components/managers/tech-cards/components/tech-card-list.tsx
@@ -11,6 +11,7 @@ import { ConfirmationModal } from 'ui/components/confirmation-modal';
 import Input from 'ui/components/input';
 import Select from 'ui/components/select';
 import Text from 'ui/components/text';
+import { AuxBadge } from './aux-badge';
 import { approvalStateLabel, formatTechCardDate, stageLabel } from './utils';
 import { useDeleteTechCard, useInfiniteTechCards } from './useTechCardQuery';
 
@@ -166,7 +167,10 @@ export function TechCardList() {
                       <Text variant='uppercase'>{tc.styleNumber || '—'}</Text>
                     </td>
                     <td className='px-2 py-2'>
-                      <Text>{tc.name || '—'}</Text>
+                      <div className='flex items-center gap-2'>
+                        <Text>{tc.name || '—'}</Text>
+                        <AuxBadge purpose={tc.purpose} />
+                      </div>
                     </td>
                     <td className='px-2 py-2'>
                       <Text variant='inactive'>{tc.brand || '—'}</Text>


### PR DESCRIPTION
Pulls the proto submodule to **4016a8a** (backend closed every open new-flow ask) and wires the frontend to the now-available contract.

## What's in this batch
- **Proto 4016a8a regen** — regenerated `src/api/proto-http/*`; new required request fields stubbed to legacy defaults so existing call sites compile.
- **B-2** — dropped the `IDEA-<base36>` style-number auto-mint; an IDEA card can now be truly numberless (backend accepts empty style_number at IDEA, enforces it from PROTO). Schema refine still blocks a stage advance without a real number.
- **B-3** — auxiliary production-run receive: an aux card (`purpose = auxiliary`) produces a MATERIAL, so its run swaps the colour-model grid for a single product-less quantity plan and receives Σ qty into the card's `output_material_id` in the material warehouse (no per-product grouping / orphan guard / cost_price; gated on the card naming an output material).
- **#8** — `aux` badge on the tech-card list + pipeline board from `TechCardListItem.purpose` (no N+1).
- **#9** — optimistic lock: the run section read-modify-write echoes the fetched `lock_version` as `expected_lock_version`; all six save paths map a 409 to a reload-and-retry hint.
- **#10** — the attention strip's stale-run count uses one server-side `stale_days` query instead of two client-scanned status pages; the runs list `?stale=` deep link passes it through.
- **B-10** — link a sample to a colourway via the new stable `TechCardColorway.id` (picker in the sample editor + colourway column in the samples table).

Not yet wired (net-new gap-07 v2 surface, follow-up): employee registry, packaging BOM, per-colourway cost display, material lots, nesting markers.

`yarn build:check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)