### PR TITLE
gap-07 v2: material lots, per-colourway cost, employee registry, packaging BOM, nesting markers

### DIFF
--- a/src/components/managers/employees/index.tsx
+++ b/src/components/managers/employees/index.tsx
@@ -1,0 +1,383 @@
+import * as DialogPrimitives from '@radix-ui/react-dialog';
+import { Employee } from 'api/proto-http/admin';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
+import { SECTION } from 'constants/routes';
+import { CURRENCIES } from 'constants/constants';
+import { useSnackBarStore } from 'lib/stores/store';
+import { useEffect, useState } from 'react';
+import { Button } from 'ui/components/button';
+import { ConfirmationModal } from 'ui/components/confirmation-modal';
+import Text from 'ui/components/text';
+import { decimalToInput, normalizeDecimalInput, parseDecimalNumber } from 'utils/decimal';
+import { useArchiveEmployee, useEmployees, useUpsertEmployee } from './utils/hooks';
+
+const cell = 'w-full border border-textInactiveColor bg-bgColor px-2 py-1.5 text-textBaseSize';
+const th =
+  'border border-textInactiveColor bg-textInactiveColor/20 px-2 py-1 text-left text-textBaseSize uppercase';
+const td = 'border border-textInactiveColor px-2 py-1 text-textBaseSize';
+const day = (v?: string) => (v ? v.slice(0, 10) : '');
+
+// Employee registry (gap-07 v2 A): a simple people list an OPEX salary template can link to.
+// Analytics-gated like OPEX; default_monthly_cost is a template pre-fill only, not a booked cost.
+export function Employees() {
+  const { canWrite } = usePermissions();
+  const canEdit = canWrite(SECTION.analytics);
+  const { showMessage } = useSnackBarStore();
+  const [showArchived, setShowArchived] = useState(false);
+  const { data, isLoading, isError, refetch } = useEmployees(showArchived);
+  const archive = useArchiveEmployee();
+  const rows = data?.employees ?? [];
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<Employee | undefined>();
+  const [archiving, setArchiving] = useState<Employee | undefined>();
+
+  const confirmArchive = () => {
+    if (!archiving?.id) return;
+    archive.mutate(archiving.id, {
+      onSuccess: () => showMessage('Employee archived', 'success'),
+      onError: (e) => showMessage(e instanceof Error ? e.message : 'Failed to archive', 'error'),
+      onSettled: () => setArchiving(undefined),
+    });
+  };
+
+  return (
+    <div className='flex flex-col gap-6 pb-16'>
+      <div className='-mx-2.5 flex flex-wrap items-center justify-between gap-3 border-b border-textInactiveColor bg-bgColor px-2.5 py-3'>
+        <Text variant='uppercase' size='large'>
+          employees
+        </Text>
+        {canEdit && (
+          <Button
+            type='button'
+            variant='main'
+            size='lg'
+            className='uppercase'
+            onClick={() => {
+              setEditing(undefined);
+              setFormOpen(true);
+            }}
+          >
+            + employee
+          </Button>
+        )}
+      </div>
+
+      <label className='flex items-center gap-2'>
+        <input
+          type='checkbox'
+          checked={showArchived}
+          onChange={(e) => setShowArchived(e.target.checked)}
+        />
+        <Text size='small'>show archived</Text>
+      </label>
+
+      {isLoading ? (
+        <Text variant='inactive' size='small'>
+          loading…
+        </Text>
+      ) : isError ? (
+        <div className='flex items-center gap-3'>
+          <Text variant='error' size='small'>
+            failed to load employees
+          </Text>
+          <button
+            type='button'
+            className='text-textBaseSize uppercase underline'
+            onClick={() => refetch()}
+          >
+            retry
+          </button>
+        </div>
+      ) : rows.length === 0 ? (
+        <Text variant='inactive' size='small'>
+          no employees
+        </Text>
+      ) : (
+        <div className='overflow-x-auto'>
+          <table className='w-full min-w-max border-collapse'>
+            <thead>
+              <tr>
+                <th className={th}>name</th>
+                <th className={th}>role</th>
+                <th className={th}>from</th>
+                <th className={th}>to</th>
+                <th className={th}>default / month</th>
+                <th className={th}>note</th>
+                <th className={th} />
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => {
+                const e = r.employee;
+                return (
+                  <tr key={r.id} className={r.archived ? 'opacity-50' : ''}>
+                    <td className={td}>
+                      {e?.fullName || '—'}
+                      {r.archived ? ' · archived' : ''}
+                    </td>
+                    <td className={td}>{e?.role || '—'}</td>
+                    <td className={`${td} whitespace-nowrap`}>{day(e?.employmentStart) || '—'}</td>
+                    <td className={`${td} whitespace-nowrap`}>{day(e?.employmentEnd) || 'open'}</td>
+                    <td className={td}>
+                      {e?.defaultMonthlyCost?.value
+                        ? `${decimalToInput(e.defaultMonthlyCost)} ${e.defaultCurrency || ''}`
+                        : '—'}
+                    </td>
+                    <td className={td}>{e?.note || '—'}</td>
+                    <td className={`${td} whitespace-nowrap`}>
+                      {canEdit && !r.archived && (
+                        <div className='flex items-center gap-2'>
+                          <button
+                            type='button'
+                            className='uppercase underline hover:text-textColor'
+                            onClick={() => {
+                              setEditing(r);
+                              setFormOpen(true);
+                            }}
+                          >
+                            edit
+                          </button>
+                          <button
+                            type='button'
+                            className='uppercase text-textInactiveColor hover:text-error'
+                            onClick={() => setArchiving(r)}
+                          >
+                            archive
+                          </button>
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <EmployeeFormModal open={formOpen} onOpenChange={setFormOpen} existing={editing} />
+
+      <ConfirmationModal
+        open={archiving != null}
+        onOpenChange={(v) => !v && setArchiving(undefined)}
+        onConfirm={confirmArchive}
+        title='archive employee?'
+        confirmLabel='archive'
+      >
+        <Text size='small'>
+          Archive “{archiving?.employee?.fullName}”? They stop appearing in the salary-template
+          picker.
+        </Text>
+      </ConfirmationModal>
+    </div>
+  );
+}
+
+type Draft = {
+  fullName: string;
+  role: string;
+  employmentStart: string;
+  employmentEnd: string;
+  defaultCurrency: string;
+  defaultMonthlyCost: string;
+  note: string;
+};
+
+const emptyDraft: Draft = {
+  fullName: '',
+  role: '',
+  employmentStart: '',
+  employmentEnd: '',
+  defaultCurrency: 'EUR',
+  defaultMonthlyCost: '',
+  note: '',
+};
+
+function EmployeeFormModal({
+  open,
+  onOpenChange,
+  existing,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  existing?: Employee;
+}) {
+  const { showMessage } = useSnackBarStore();
+  const upsert = useUpsertEmployee();
+  const [d, setD] = useState<Draft>(emptyDraft);
+
+  useEffect(() => {
+    if (!open) return;
+    const e = existing?.employee;
+    setD(
+      e
+        ? {
+            fullName: e.fullName ?? '',
+            role: e.role ?? '',
+            employmentStart: day(e.employmentStart),
+            employmentEnd: day(e.employmentEnd),
+            defaultCurrency: e.defaultCurrency ?? 'EUR',
+            defaultMonthlyCost: decimalToInput(e.defaultMonthlyCost),
+            note: e.note ?? '',
+          }
+        : emptyDraft,
+    );
+  }, [existing, open]);
+
+  const set = (patch: Partial<Draft>) => setD((prev) => ({ ...prev, ...patch }));
+
+  const submit = async () => {
+    if (!d.fullName.trim()) {
+      showMessage('Enter a name', 'error');
+      return;
+    }
+    if (d.defaultMonthlyCost.trim()) {
+      const n = parseDecimalNumber(d.defaultMonthlyCost);
+      if (!Number.isFinite(n) || n < 0) {
+        showMessage('Default monthly cost must be a non-negative number', 'error');
+        return;
+      }
+    }
+    // YYYY-MM-DD strings compare lexicographically.
+    if (d.employmentEnd && d.employmentStart && d.employmentEnd < d.employmentStart) {
+      showMessage('End date is before the start date', 'error');
+      return;
+    }
+    try {
+      await upsert.mutateAsync({
+        id: existing?.id ?? 0,
+        employee: {
+          fullName: d.fullName.trim(),
+          role: d.role.trim(),
+          employmentStart: d.employmentStart,
+          employmentEnd: d.employmentEnd,
+          defaultCurrency: d.defaultCurrency,
+          defaultMonthlyCost: d.defaultMonthlyCost.trim()
+            ? { value: normalizeDecimalInput(d.defaultMonthlyCost) }
+            : undefined,
+          note: d.note.trim(),
+        },
+      });
+      showMessage(existing ? 'Employee saved' : 'Employee added', 'success');
+      onOpenChange(false);
+    } catch (e) {
+      showMessage(e instanceof Error ? e.message : 'Failed to save employee', 'error');
+    }
+  };
+
+  return (
+    <DialogPrimitives.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitives.Portal>
+        <DialogPrimitives.Overlay className='fixed inset-0 z-20 h-screen bg-overlay' />
+        <DialogPrimitives.Content className='fixed inset-x-2.5 top-1/2 z-50 flex max-h-[90vh] w-auto -translate-y-1/2 flex-col overflow-y-auto border border-textInactiveColor bg-bgColor text-textColor lg:inset-x-auto lg:left-1/2 lg:w-[440px] lg:-translate-x-1/2'>
+          <div className='sticky top-0 z-10 flex items-center justify-between gap-2 border-b border-textInactiveColor bg-bgColor px-4 py-3'>
+            <DialogPrimitives.Title className='text-lg uppercase'>
+              {existing ? 'edit employee' : 'add employee'}
+            </DialogPrimitives.Title>
+            <DialogPrimitives.Close asChild>
+              <Button type='button' className='shrink-0 cursor-pointer'>
+                [x]
+              </Button>
+            </DialogPrimitives.Close>
+          </div>
+          <DialogPrimitives.Description className='sr-only'>
+            employee registry entry
+          </DialogPrimitives.Description>
+          <div className='flex flex-col gap-3 p-4'>
+            <label className='flex flex-col gap-1'>
+              <Text size='small'>full name *</Text>
+              <input
+                className={cell}
+                value={d.fullName}
+                onChange={(e) => set({ fullName: e.target.value })}
+              />
+            </label>
+            <label className='flex flex-col gap-1'>
+              <Text size='small'>role</Text>
+              <input
+                className={cell}
+                value={d.role}
+                onChange={(e) => set({ role: e.target.value })}
+                placeholder='e.g. pattern maker'
+              />
+            </label>
+            <div className='grid grid-cols-2 gap-2'>
+              <label className='flex flex-col gap-1'>
+                <Text size='small'>employment from</Text>
+                <input
+                  className={cell}
+                  type='date'
+                  value={d.employmentStart}
+                  onChange={(e) => set({ employmentStart: e.target.value })}
+                />
+              </label>
+              <label className='flex flex-col gap-1'>
+                <Text size='small'>to (optional)</Text>
+                <input
+                  className={cell}
+                  type='date'
+                  value={d.employmentEnd}
+                  onChange={(e) => set({ employmentEnd: e.target.value })}
+                />
+              </label>
+            </div>
+            <div className='grid grid-cols-[1fr_7rem] gap-2'>
+              <label className='flex flex-col gap-1'>
+                <Text size='small'>default monthly cost</Text>
+                <input
+                  className={cell}
+                  type='number'
+                  step='0.01'
+                  min='0'
+                  value={d.defaultMonthlyCost}
+                  onChange={(e) => set({ defaultMonthlyCost: e.target.value })}
+                />
+              </label>
+              <label className='flex flex-col gap-1'>
+                <Text size='small'>currency</Text>
+                <select
+                  className={cell}
+                  value={d.defaultCurrency}
+                  onChange={(e) => set({ defaultCurrency: e.target.value })}
+                >
+                  {CURRENCIES.map((c) => (
+                    <option key={c.value} value={c.value}>
+                      {c.value}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            <Text variant='inactive' size='small'>
+              Default monthly cost only pre-fills a salary OPEX template — it is never itself a
+              booked cost.
+            </Text>
+            <label className='flex flex-col gap-1'>
+              <Text size='small'>note (optional)</Text>
+              <input
+                className={cell}
+                value={d.note}
+                onChange={(e) => set({ note: e.target.value })}
+              />
+            </label>
+          </div>
+          <div className='sticky bottom-0 flex justify-end gap-2 border-t border-textInactiveColor bg-bgColor px-4 py-3'>
+            <Button type='button' variant='secondary' size='lg' onClick={() => onOpenChange(false)}>
+              cancel
+            </Button>
+            <Button
+              type='button'
+              variant='main'
+              size='lg'
+              disabled={upsert.isPending}
+              onClick={submit}
+            >
+              {upsert.isPending ? 'saving…' : 'save'}
+            </Button>
+          </div>
+        </DialogPrimitives.Content>
+      </DialogPrimitives.Portal>
+    </DialogPrimitives.Root>
+  );
+}

--- a/src/components/managers/employees/utils/hooks.ts
+++ b/src/components/managers/employees/utils/hooks.ts
@@ -1,0 +1,36 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { adminService } from 'api/api';
+import { EmployeeInsert } from 'api/proto-http/admin';
+
+// Employee registry (gap-07 v2 A): the people an OPEX salary recurring template can point at.
+// Analytics-gated (mirrors OPEX). default_monthly_cost only pre-fills an OPEX template — it is
+// never itself a booked figure; the journal (OpexRecurring) stays the source of truth for cost.
+export const employeeKeys = {
+  all: ['employees'] as const,
+  list: (includeArchived: boolean) => [...employeeKeys.all, 'list', includeArchived] as const,
+};
+
+export function useEmployees(includeArchived: boolean, enabled = true) {
+  return useQuery({
+    queryKey: employeeKeys.list(includeArchived),
+    queryFn: () => adminService.ListEmployees({ includeArchived }),
+    enabled,
+  });
+}
+
+export function useUpsertEmployee() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, employee }: { id: number; employee: EmployeeInsert }) =>
+      adminService.UpsertEmployee({ id, employee }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: employeeKeys.all }),
+  });
+}
+
+export function useArchiveEmployee() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => adminService.ArchiveEmployee({ id }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: employeeKeys.all }),
+  });
+}

--- a/src/components/managers/materials/components/lots-tab.tsx
+++ b/src/components/managers/materials/components/lots-tab.tsx
@@ -1,0 +1,124 @@
+import { useSearchParams } from 'react-router-dom';
+import Text from 'ui/components/text';
+import { decimalToInput } from 'utils/decimal';
+import { MaterialPicker } from './material-picker';
+import { useMaterialLots } from './useWarehouse';
+
+const th =
+  'border border-textInactiveColor bg-textInactiveColor/20 px-2 py-1 text-left text-textBaseSize uppercase';
+const td = 'border border-textInactiveColor px-2 py-1 text-textBaseSize';
+const day = (ts?: string) => (ts ? ts.slice(0, 10) : '—');
+
+// Read-only material-lots view (gap-07 v2 D): the received batches (roll / dye-lot) of a material,
+// each a supplier lot code with a running remaining quantity. Lots are created as a side effect of
+// receives — there is no create/edit here. unit_cost is informational only (valuation is
+// moving-average, not FIFO). The chosen material lives in the URL (?material=) so the view is a
+// shareable link and survives a tab switch (materials/index.tsx preserves ?material=).
+export function LotsTab() {
+  const [params, setParams] = useSearchParams();
+  const materialId = Number(params.get('material')) || 0;
+  const includeArchived = params.get('archived') === '1';
+
+  const setParam = (key: string, value: string) =>
+    setParams(
+      (prev) => {
+        const p = new URLSearchParams(prev);
+        if (value) p.set(key, value);
+        else p.delete(key);
+        return p;
+      },
+      { replace: true },
+    );
+
+  const { data, isLoading, isError, refetch } = useMaterialLots(
+    materialId,
+    includeArchived,
+    materialId > 0,
+  );
+  const lots = data?.lots ?? [];
+
+  return (
+    <div className='flex flex-col gap-4'>
+      <div className='flex flex-wrap items-end justify-between gap-3'>
+        <div className='w-72'>
+          <Text size='small'>material</Text>
+          <MaterialPicker
+            value={materialId}
+            onChange={(id) => setParam('material', id ? String(id) : '')}
+            includeArchived
+            placeholder='search material to see its lots'
+          />
+        </div>
+        <label className='flex items-center gap-2'>
+          <input
+            type='checkbox'
+            checked={includeArchived}
+            onChange={(e) => setParam('archived', e.target.checked ? '1' : '')}
+          />
+          <Text size='small'>show archived</Text>
+        </label>
+      </div>
+
+      {materialId === 0 ? (
+        <Text variant='inactive' size='small'>
+          pick a material to see its received lots
+        </Text>
+      ) : isLoading ? (
+        <Text variant='inactive' size='small'>
+          loading…
+        </Text>
+      ) : isError ? (
+        <div className='flex items-center gap-3'>
+          <Text variant='error' size='small'>
+            failed to load lots
+          </Text>
+          <button
+            type='button'
+            className='text-textBaseSize uppercase underline'
+            onClick={() => refetch()}
+          >
+            retry
+          </button>
+        </div>
+      ) : lots.length === 0 ? (
+        <Text variant='inactive' size='small'>
+          no lots for this material
+        </Text>
+      ) : (
+        <div className='overflow-x-auto'>
+          <table className='w-full min-w-max border-collapse'>
+            <thead>
+              <tr>
+                <th className={th}>lot</th>
+                <th className={th}>supplier doc</th>
+                <th className={th}>received</th>
+                <th className={th}>remaining</th>
+                <th className={th}>unit cost</th>
+                <th className={th}>received at</th>
+                <th className={th}>note</th>
+              </tr>
+            </thead>
+            <tbody>
+              {lots.map((l) => (
+                <tr key={l.id} className={l.archived ? 'opacity-50' : ''}>
+                  <td className={td}>
+                    {l.lotCode || '—'}
+                    {l.archived ? ' · archived' : ''}
+                  </td>
+                  <td className={td}>{l.supplierDoc || '—'}</td>
+                  <td className={td}>{decimalToInput(l.receivedQty) || '—'}</td>
+                  <td className={td}>{decimalToInput(l.remainingQty) || '0'}</td>
+                  <td className={td}>
+                    {l.unitCost?.value ? `${decimalToInput(l.unitCost)} ${l.currency || ''}` : '—'}
+                  </td>
+                  <td className={`${td} whitespace-nowrap`}>{day(l.receivedAt)}</td>
+                  <td className={td}>{l.note || '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/managers/materials/components/movement-modals.tsx
+++ b/src/components/managers/materials/components/movement-modals.tsx
@@ -10,6 +10,7 @@ import { decimalToInput, inputToDecimal, parseDecimalNumber, sanitizeDecimal } f
 import {
   useAdjustMaterialStock,
   useIssueMaterialStock,
+  useMaterialLots,
   useReceiveMaterialStock,
 } from './useWarehouse';
 
@@ -252,6 +253,9 @@ export function IssueStockModal({
   const [isReturn, setIsReturn] = useState(false);
   const [occurredAt, setOccurredAt] = useState(todayISO());
   const [comment, setComment] = useState('');
+  // gap-07 v2 D: optionally attribute the issue to a specific received lot (roll / dye-lot) for
+  // traceability — informational only, never a costing basis.
+  const [lotId, setLotId] = useState(0);
 
   const defRun = defaultTarget?.productionRunId ?? 0;
   const defSample = defaultTarget?.sampleId ?? 0;
@@ -265,7 +269,19 @@ export function IssueStockModal({
     setIsReturn(false);
     setOccurredAt(todayISO());
     setComment('');
+    setLotId(0);
   }, [open, defaultQty, defRun, defSample]);
+
+  // Lots to draw from: this material's non-archived batches with stock left. Only fetched while
+  // the modal is open (a returned lot with 0 remaining stays selectable if it was pre-picked).
+  const { data: lotsData } = useMaterialLots(
+    target.materialId,
+    false,
+    open && target.materialId > 0,
+  );
+  const lots = (lotsData?.lots ?? []).filter(
+    (l) => l.id === lotId || Number(l.remainingQty?.value ?? '0') > 0,
+  );
 
   const qtyNum = parseDecimalNumber(quantity);
   const onHandNum = parseDecimalNumber(target.onHand);
@@ -295,10 +311,10 @@ export function IssueStockModal({
         isReturn,
         occurredAt,
         comment: comment.trim(),
-        // gap-07 v2: optional per-colourway (product_id) and structured-lot attribution — not
-        // surfaced in this generic issue modal yet.
+        // gap-07 v2: lot attribution (below); per-colourway product_id attribution is set from the
+        // run's colourway on the run-detail issue flow, not this generic modal.
         productId: 0,
-        lotId: 0,
+        lotId,
       });
       showMessage(posted(res.movement), 'success');
       onOpenChange(false);
@@ -381,6 +397,23 @@ export function IssueStockModal({
           onChange={(e) => setOccurredAt(e.target.value)}
         />
       </Field>
+      {lots.length > 0 ? (
+        <Field label='lot (optional)'>
+          <select
+            className={cell}
+            value={lotId || 0}
+            onChange={(e) => setLotId(Number(e.target.value) || 0)}
+          >
+            <option value={0}>— any / unspecified —</option>
+            {lots.map((l) => (
+              <option key={l.id} value={l.id ?? 0}>
+                {l.lotCode || `lot #${l.id}`} · rem {decimalToInput(l.remainingQty) || '0'}
+                {target.unit ? ` ${target.unit}` : ''}
+              </option>
+            ))}
+          </select>
+        </Field>
+      ) : null}
       <Field label='comment'>
         <input className={cell} value={comment} onChange={(e) => setComment(e.target.value)} />
       </Field>

--- a/src/components/managers/materials/components/movement-modals.tsx
+++ b/src/components/managers/materials/components/movement-modals.tsx
@@ -236,6 +236,7 @@ export function IssueStockModal({
   defaultTarget,
   defaultQty,
   lockTarget,
+  colorways,
 }: {
   open: boolean;
   onOpenChange: (v: boolean) => void;
@@ -244,6 +245,9 @@ export function IssueStockModal({
   defaultTarget?: { productionRunId?: number; sampleId?: number };
   defaultQty?: string;
   lockTarget?: boolean;
+  // gap-07 v2 C: the run's colourways, so a run issue can be attributed to the product it was cut
+  // for (feeds ProductionRunActuals.by_colorway). Only meaningful when issuing to a run.
+  colorways?: { productId: number; label: string }[];
 }) {
   const { showMessage } = useSnackBarStore();
   const issue = useIssueMaterialStock();
@@ -256,6 +260,8 @@ export function IssueStockModal({
   // gap-07 v2 D: optionally attribute the issue to a specific received lot (roll / dye-lot) for
   // traceability — informational only, never a costing basis.
   const [lotId, setLotId] = useState(0);
+  // gap-07 v2 C: which colourway (product) this fabric was cut for; 0 = whole run (unattributed).
+  const [productId, setProductId] = useState(0);
 
   const defRun = defaultTarget?.productionRunId ?? 0;
   const defSample = defaultTarget?.sampleId ?? 0;
@@ -270,6 +276,7 @@ export function IssueStockModal({
     setOccurredAt(todayISO());
     setComment('');
     setLotId(0);
+    setProductId(0);
   }, [open, defaultQty, defRun, defSample]);
 
   // Lots to draw from: this material's non-archived batches with stock left. Only fetched while
@@ -311,9 +318,9 @@ export function IssueStockModal({
         isReturn,
         occurredAt,
         comment: comment.trim(),
-        // gap-07 v2: lot attribution (below); per-colourway product_id attribution is set from the
-        // run's colourway on the run-detail issue flow, not this generic modal.
-        productId: 0,
+        // gap-07 v2: colourway (product_id) attribution only applies to a run issue; lot (lot_id)
+        // is optional traceability. Both default to 0 (whole-run / unspecified).
+        productId: targetKind === 'run' ? productId : 0,
         lotId,
       });
       showMessage(posted(res.movement), 'success');
@@ -384,6 +391,23 @@ export function IssueStockModal({
           </Field>
         </div>
       )}
+
+      {targetKind === 'run' && colorways && colorways.length > 0 ? (
+        <Field label='colourway (optional — attributes cost)'>
+          <select
+            className={cell}
+            value={productId || 0}
+            onChange={(e) => setProductId(Number(e.target.value) || 0)}
+          >
+            <option value={0}>— whole run (unattributed) —</option>
+            {colorways.map((c) => (
+              <option key={c.productId} value={c.productId}>
+                {c.label}
+              </option>
+            ))}
+          </select>
+        </Field>
+      ) : null}
 
       <label className='flex items-center gap-2'>
         <input type='checkbox' checked={isReturn} onChange={(e) => setIsReturn(e.target.checked)} />

--- a/src/components/managers/materials/components/packaging-bom-tab.tsx
+++ b/src/components/managers/materials/components/packaging-bom-tab.tsx
@@ -1,0 +1,276 @@
+import { PackagingBomItem } from 'api/proto-http/admin';
+import { usePermissions } from 'components/managers/accounts/utils/permissions';
+import { SECTION } from 'constants/routes';
+import { useSnackBarStore } from 'lib/stores/store';
+import { useEffect, useState } from 'react';
+import { Button } from 'ui/components/button';
+import Text from 'ui/components/text';
+import {
+  decimalToInput,
+  normalizeDecimalInput,
+  parseDecimalNumber,
+  sanitizeDecimal,
+} from 'utils/decimal';
+import { MaterialPicker } from './material-picker';
+import { usePackagingBom, useUpsertPackagingBom } from './useMaterials';
+
+const cell = 'w-full border border-textInactiveColor bg-bgColor px-2 py-1.5 text-textBaseSize';
+const th =
+  'border border-textInactiveColor bg-textInactiveColor/20 px-2 py-1 text-left text-textBaseSize uppercase';
+const td = 'border border-textInactiveColor px-2 py-1 align-top text-textBaseSize';
+
+type Row = {
+  materialId: number;
+  materialName: string;
+  materialUnit: string;
+  qtyPerOrder: string;
+  qtyPerItem: string;
+  active: boolean;
+};
+
+const rowFrom = (i: PackagingBomItem): Row => ({
+  materialId: i.materialId ?? 0,
+  materialName: i.materialName ?? '',
+  materialUnit: i.materialUnit ?? '',
+  qtyPerOrder: decimalToInput(i.qtyPerOrder),
+  qtyPerItem: decimalToInput(i.qtyPerItem),
+  active: i.active ?? true,
+});
+
+// Packaging BOM editor (gap-07 v2 B): the single global recipe of packaging materials consumed on
+// ship — a per-order quantity (fixed, e.g. one box) and/or a per-item quantity (scales with the
+// order, e.g. a polybag per garment). UpsertPackagingBom is a full replace, so the editor holds the
+// whole list in local state and submits every row at once.
+export function PackagingBomTab() {
+  const { canWrite } = usePermissions();
+  const canEdit = canWrite(SECTION.techCards);
+  const { showMessage } = useSnackBarStore();
+  const { data, isLoading, isError, refetch } = usePackagingBom();
+  const upsert = useUpsertPackagingBom();
+
+  const [rows, setRows] = useState<Row[]>([]);
+  // A refetch (e.g. after save) must not clobber unsaved edits mid-flow.
+  const [dirty, setDirty] = useState(false);
+  useEffect(() => {
+    if (dirty) return;
+    setRows((data?.items ?? []).map(rowFrom));
+  }, [data, dirty]);
+
+  const patch = (i: number, p: Partial<Row>) => {
+    setDirty(true);
+    setRows((prev) => prev.map((r, idx) => (idx === i ? { ...r, ...p } : r)));
+  };
+  const addRow = () => {
+    setDirty(true);
+    setRows((prev) => [
+      ...prev,
+      {
+        materialId: 0,
+        materialName: '',
+        materialUnit: '',
+        qtyPerOrder: '',
+        qtyPerItem: '',
+        active: true,
+      },
+    ]);
+  };
+  const removeRow = (i: number) => {
+    setDirty(true);
+    setRows((prev) => prev.filter((_, idx) => idx !== i));
+  };
+
+  const save = async () => {
+    for (const r of rows) {
+      if (!r.materialId) {
+        showMessage('Every row needs a material (or remove it)', 'error');
+        return;
+      }
+      for (const q of [r.qtyPerOrder, r.qtyPerItem]) {
+        if (q.trim()) {
+          const n = parseDecimalNumber(q);
+          if (!Number.isFinite(n) || n < 0) {
+            showMessage('Quantities must be zero or more', 'error');
+            return;
+          }
+        }
+      }
+      if (!r.qtyPerOrder.trim() && !r.qtyPerItem.trim()) {
+        showMessage('Each material needs a per-order or per-item quantity', 'error');
+        return;
+      }
+    }
+    if (new Set(rows.map((r) => r.materialId)).size !== rows.length) {
+      showMessage('A material appears twice — merge the rows', 'error');
+      return;
+    }
+    const items: PackagingBomItem[] = rows.map((r) => ({
+      materialId: r.materialId,
+      materialName: r.materialName || undefined,
+      materialUnit: r.materialUnit || undefined,
+      qtyPerOrder: r.qtyPerOrder.trim()
+        ? { value: normalizeDecimalInput(r.qtyPerOrder) }
+        : undefined,
+      qtyPerItem: r.qtyPerItem.trim() ? { value: normalizeDecimalInput(r.qtyPerItem) } : undefined,
+      active: r.active,
+    }));
+    try {
+      await upsert.mutateAsync(items);
+      setDirty(false);
+      showMessage('Packaging BOM saved', 'success');
+    } catch (e) {
+      showMessage(e instanceof Error ? e.message : 'Failed to save packaging BOM', 'error');
+    }
+  };
+
+  return (
+    <div className='flex flex-col gap-4'>
+      <div className='flex flex-wrap items-center justify-between gap-3'>
+        <Text variant='inactive' size='small'>
+          materials consumed on every shipment — per order (fixed) and/or per item (scales with the
+          order). Booked as cost on ship.
+          {dirty ? <span className='ml-2 text-labelColor'>· unsaved</span> : null}
+        </Text>
+        {canEdit && (
+          <div className='flex items-center gap-2'>
+            <Button
+              type='button'
+              variant='secondary'
+              size='lg'
+              className='uppercase'
+              onClick={addRow}
+            >
+              + material
+            </Button>
+            <Button
+              type='button'
+              variant='main'
+              size='lg'
+              className='uppercase'
+              disabled={upsert.isPending || !dirty}
+              onClick={save}
+            >
+              {upsert.isPending ? 'saving…' : 'save'}
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {isLoading ? (
+        <Text variant='inactive' size='small'>
+          loading…
+        </Text>
+      ) : isError ? (
+        <div className='flex items-center gap-3'>
+          <Text variant='error' size='small'>
+            failed to load packaging BOM
+          </Text>
+          <button
+            type='button'
+            className='text-textBaseSize uppercase underline'
+            onClick={() => refetch()}
+          >
+            retry
+          </button>
+        </div>
+      ) : rows.length === 0 ? (
+        <Text variant='inactive' size='small'>
+          no packaging materials yet{canEdit ? ' — add one to start the recipe' : ''}
+        </Text>
+      ) : (
+        <div className='overflow-x-auto'>
+          <table className='w-full min-w-max border-collapse'>
+            <thead>
+              <tr>
+                <th className={th}>material</th>
+                <th className={th}>qty / order</th>
+                <th className={th}>qty / item</th>
+                <th className={th}>active</th>
+                {canEdit ? <th className={th} /> : null}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r, i) => (
+                <tr key={i}>
+                  <td className={`${td} w-72`}>
+                    {canEdit ? (
+                      <MaterialPicker
+                        value={r.materialId}
+                        onChange={(materialId, material) =>
+                          patch(i, {
+                            materialId,
+                            materialName: material?.name ?? '',
+                            materialUnit: material?.unit ?? '',
+                          })
+                        }
+                      />
+                    ) : (
+                      <Text size='small'>{r.materialName || `#${r.materialId}`}</Text>
+                    )}
+                  </td>
+                  <td className={td}>
+                    <div className='flex items-center gap-1'>
+                      {canEdit ? (
+                        <input
+                          className={`${cell} w-24`}
+                          inputMode='decimal'
+                          value={r.qtyPerOrder}
+                          onChange={(e) =>
+                            patch(i, { qtyPerOrder: sanitizeDecimal(e.target.value) })
+                          }
+                        />
+                      ) : (
+                        <Text size='small'>{r.qtyPerOrder || '—'}</Text>
+                      )}
+                      <Text variant='inactive' size='small'>
+                        {r.materialUnit}
+                      </Text>
+                    </div>
+                  </td>
+                  <td className={td}>
+                    <div className='flex items-center gap-1'>
+                      {canEdit ? (
+                        <input
+                          className={`${cell} w-24`}
+                          inputMode='decimal'
+                          value={r.qtyPerItem}
+                          onChange={(e) =>
+                            patch(i, { qtyPerItem: sanitizeDecimal(e.target.value) })
+                          }
+                        />
+                      ) : (
+                        <Text size='small'>{r.qtyPerItem || '—'}</Text>
+                      )}
+                      <Text variant='inactive' size='small'>
+                        {r.materialUnit}
+                      </Text>
+                    </div>
+                  </td>
+                  <td className={`${td} text-center`}>
+                    <input
+                      type='checkbox'
+                      disabled={!canEdit}
+                      checked={r.active}
+                      onChange={(e) => patch(i, { active: e.target.checked })}
+                    />
+                  </td>
+                  {canEdit ? (
+                    <td className={td}>
+                      <Button
+                        type='button'
+                        variant='secondary'
+                        aria-label='remove material'
+                        onClick={() => removeRow(i)}
+                      >
+                        ✕
+                      </Button>
+                    </td>
+                  ) : null}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/managers/materials/components/useMaterials.ts
+++ b/src/components/managers/materials/components/useMaterials.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { adminService } from 'api/api';
-import { common_Material, common_MaterialPrice } from 'api/proto-http/admin';
+import { PackagingBomItem, common_Material, common_MaterialPrice } from 'api/proto-http/admin';
 
 const materialKeys = {
   all: ['materials'] as const,
@@ -60,5 +60,26 @@ export function useAddMaterialPrice() {
     mutationFn: (price: common_MaterialPrice) => adminService.AddMaterialPrice({ price }),
     // invalidate both the price history and the list (latest_price on each material).
     onSuccess: () => qc.invalidateQueries({ queryKey: materialKeys.all }),
+  });
+}
+
+// Packaging BOM (gap-07 v2 B): ONE global recipe — the materials consumed per order (qty_per_order,
+// e.g. a shipping box) and per item (qty_per_item, e.g. a polybag), booked as OPEX/COGS on ship.
+// UpsertPackagingBom is a FULL REPLACE of the whole list (submit every row at once, not per-row);
+// material_name / material_unit are output-only (the server fills them from the material).
+export const packagingBomKey = ['packagingBom'] as const;
+
+export function usePackagingBom() {
+  return useQuery({
+    queryKey: packagingBomKey,
+    queryFn: () => adminService.ListPackagingBom({}),
+  });
+}
+
+export function useUpsertPackagingBom() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (items: PackagingBomItem[]) => adminService.UpsertPackagingBom({ items }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: packagingBomKey }),
   });
 }

--- a/src/components/managers/materials/components/useWarehouse.ts
+++ b/src/components/managers/materials/components/useWarehouse.ts
@@ -18,6 +18,8 @@ export const warehouseKeys = {
   stock: (filter: MaterialStockFilter) => [...warehouseKeys.all, 'stock', filter] as const,
   movements: (filter: MovementFilter, limit: number) =>
     [...warehouseKeys.all, 'movements', filter, limit] as const,
+  lots: (materialId: number, includeArchived: boolean) =>
+    [...warehouseKeys.all, 'lots', materialId, includeArchived] as const,
 };
 
 export type MaterialStockFilter = {
@@ -95,6 +97,19 @@ function useMovementMutation<TReq, TRes>(fn: (req: TReq) => Promise<TRes>) {
       if (target.productionRunId) qc.invalidateQueries({ queryKey: productionRunKeys.all });
       if (target.sampleId) qc.invalidateQueries({ queryKey: sampleKeys.all });
     },
+  });
+}
+
+// Material lots (gap-07 v2 D): received batches (roll / dye-lot) of a material with a running
+// remaining quantity, for traceability + colour matching. Read-only from the client — lots are
+// created as a side effect of receives; unit_cost is informational (valuation stays moving-avg,
+// NOT FIFO). materialId 0 lists across all materials. Lives under the warehouse tree so a receive
+// (which invalidates warehouseKeys.all) also refreshes the lot list.
+export function useMaterialLots(materialId: number, includeArchived: boolean, enabled = true) {
+  return useQuery({
+    queryKey: warehouseKeys.lots(materialId, includeArchived),
+    queryFn: () => adminService.ListMaterialLots({ materialId, includeArchived }),
+    enabled,
   });
 }
 

--- a/src/components/managers/materials/index.tsx
+++ b/src/components/managers/materials/index.tsx
@@ -3,15 +3,17 @@ import Text from 'ui/components/text';
 import { cn } from 'lib/utility';
 import { CatalogTab } from './components/catalog-tab';
 import { LotsTab } from './components/lots-tab';
+import { PackagingBomTab } from './components/packaging-bom-tab';
 import { StockTab } from './components/stock-tab';
 import { MovementsTab } from './components/movements-tab';
 
-type Tab = 'catalog' | 'stock' | 'movements' | 'lots';
+type Tab = 'catalog' | 'stock' | 'movements' | 'lots' | 'packaging';
 const TABS: { id: Tab; label: string }[] = [
   { id: 'catalog', label: 'catalog' },
   { id: 'stock', label: 'stock' },
   { id: 'movements', label: 'movements' },
   { id: 'lots', label: 'lots' },
+  { id: 'packaging', label: 'packaging' },
 ];
 
 // /materials is three views of one nomenclature: the catalog (articles + prices), the warehouse
@@ -68,6 +70,8 @@ export function Materials() {
         <MovementsTab />
       ) : tab === 'lots' ? (
         <LotsTab />
+      ) : tab === 'packaging' ? (
+        <PackagingBomTab />
       ) : (
         <CatalogTab />
       )}

--- a/src/components/managers/materials/index.tsx
+++ b/src/components/managers/materials/index.tsx
@@ -2,14 +2,16 @@ import { useSearchParams } from 'react-router-dom';
 import Text from 'ui/components/text';
 import { cn } from 'lib/utility';
 import { CatalogTab } from './components/catalog-tab';
+import { LotsTab } from './components/lots-tab';
 import { StockTab } from './components/stock-tab';
 import { MovementsTab } from './components/movements-tab';
 
-type Tab = 'catalog' | 'stock' | 'movements';
+type Tab = 'catalog' | 'stock' | 'movements' | 'lots';
 const TABS: { id: Tab; label: string }[] = [
   { id: 'catalog', label: 'catalog' },
   { id: 'stock', label: 'stock' },
   { id: 'movements', label: 'movements' },
+  { id: 'lots', label: 'lots' },
 ];
 
 // /materials is three views of one nomenclature: the catalog (articles + prices), the warehouse
@@ -60,7 +62,15 @@ export function Materials() {
         ))}
       </div>
 
-      {tab === 'stock' ? <StockTab /> : tab === 'movements' ? <MovementsTab /> : <CatalogTab />}
+      {tab === 'stock' ? (
+        <StockTab />
+      ) : tab === 'movements' ? (
+        <MovementsTab />
+      ) : tab === 'lots' ? (
+        <LotsTab />
+      ) : (
+        <CatalogTab />
+      )}
     </div>
   );
 }

--- a/src/components/managers/opex/components/recurring-tab.tsx
+++ b/src/components/managers/opex/components/recurring-tab.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 import { Button } from 'ui/components/button';
 import { ConfirmationModal } from 'ui/components/confirmation-modal';
 import Text from 'ui/components/text';
+import { useEmployees } from 'components/managers/employees/utils/hooks';
 import { decimalToInput, normalizeDecimalInput, parseDecimalNumber } from 'utils/decimal';
 import {
   monthToApi,
@@ -173,6 +174,7 @@ type Draft = {
   activeFrom: string;
   activeTo: string;
   note: string;
+  employeeId: number;
 };
 
 function RecurringFormModal({
@@ -186,8 +188,11 @@ function RecurringFormModal({
 }) {
   const { showMessage } = useSnackBarStore();
   const upsert = useUpsertOpexRecurring();
+  // Employees to link a salary template to (gap-07 v2 A). Only fetched while the modal is open.
+  const { data: employeeData } = useEmployees(false, open);
+  const employees = employeeData?.employees ?? [];
 
-  const [d, setD] = useState<Draft>({
+  const emptyDraft: Draft = {
     label: '',
     category: 'salaries',
     amount: '',
@@ -195,7 +200,9 @@ function RecurringFormModal({
     activeFrom: '',
     activeTo: '',
     note: '',
-  });
+    employeeId: 0,
+  };
+  const [d, setD] = useState<Draft>(emptyDraft);
 
   useEffect(() => {
     if (!open) return;
@@ -210,17 +217,11 @@ function RecurringFormModal({
             activeFrom: toMonth(ins.activeFrom),
             activeTo: toMonth(ins.activeTo),
             note: ins.note ?? '',
+            employeeId: ins.employeeId ?? 0,
           }
-        : {
-            label: '',
-            category: 'salaries',
-            amount: '',
-            currency: 'EUR',
-            activeFrom: '',
-            activeTo: '',
-            note: '',
-          },
+        : emptyDraft,
     );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [existing, open]);
 
   const set = (patch: Partial<Draft>) => setD((prev) => ({ ...prev, ...patch }));
@@ -251,8 +252,8 @@ function RecurringFormModal({
           activeFrom: monthToApi(d.activeFrom),
           activeTo: d.activeTo ? monthToApi(d.activeTo) : '',
           note: d.note.trim(),
-          // gap-07 v2 A: salary link to the employee registry — registry UI not built yet.
-          employeeId: 0,
+          // gap-07 v2 A: optional link to the employee registry (salary templates).
+          employeeId: d.employeeId || 0,
         },
       });
       showMessage(existing ? 'Template saved' : 'Template added', 'success');
@@ -304,6 +305,29 @@ function RecurringFormModal({
                 ))}
               </datalist>
             </label>
+            {employees.length > 0 || d.employeeId > 0 ? (
+              <label className='flex flex-col gap-1'>
+                <Text size='small'>employee (optional — salary link)</Text>
+                <select
+                  className={cell}
+                  value={d.employeeId || 0}
+                  onChange={(e) => set({ employeeId: Number(e.target.value) || 0 })}
+                >
+                  <option value={0}>— none —</option>
+                  {/* A linked employee since archived is no longer in the list — keep it selectable
+                      so editing the template doesn't silently drop the link. */}
+                  {d.employeeId > 0 && !employees.some((e) => e.id === d.employeeId) ? (
+                    <option value={d.employeeId}>employee #{d.employeeId}</option>
+                  ) : null}
+                  {employees.map((e) => (
+                    <option key={e.id} value={e.id ?? 0}>
+                      {e.employee?.fullName || `employee #${e.id}`}
+                      {e.employee?.role ? ` · ${e.employee.role}` : ''}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ) : null}
             <div className='grid grid-cols-[1fr_7rem] gap-2'>
               <label className='flex flex-col gap-1'>
                 <Text size='small'>amount</Text>

--- a/src/components/managers/production-runs/components/marker-block.tsx
+++ b/src/components/managers/production-runs/components/marker-block.tsx
@@ -1,5 +1,13 @@
-import { common_ProductionRun, common_TechCardFabricDirection } from 'api/proto-http/admin';
+import {
+  common_ProductionMarkerSource,
+  common_ProductionRun,
+  common_ProductionRunMarker,
+  common_TechCardFabricDirection,
+} from 'api/proto-http/admin';
+import { MaterialPicker } from 'components/managers/materials/components/material-picker';
 import { useTechCard } from 'components/managers/tech-cards/components/useTechCardQuery';
+import { findInDictionary } from 'lib/features/findInDictionary';
+import { useDictionary } from 'lib/providers/dictionary-provider';
 import { useSnackBarStore } from 'lib/stores/store';
 import { useEffect, useMemo, useState } from 'react';
 import { Button } from 'ui/components/button';
@@ -8,6 +16,55 @@ import { decimalToInput, inputToDecimal, sanitizeDecimal } from 'utils/decimal';
 import { updateRunErrorMessage, useUpdateRunSection } from './useProductionRuns';
 
 const cell = 'w-full border border-textInactiveColor bg-bgColor px-2 py-1.5 text-textBaseSize';
+
+// Nesting-marker CAD source (gap-07 v2 E). Default new markers to MANUAL; UNKNOWN is never offered.
+const MARKER_SOURCES: { value: common_ProductionMarkerSource; label: string }[] = [
+  { value: 'PRODUCTION_MARKER_SOURCE_MANUAL', label: 'manual' },
+  { value: 'PRODUCTION_MARKER_SOURCE_GERBER', label: 'gerber' },
+  { value: 'PRODUCTION_MARKER_SOURCE_OPTITEX', label: 'optitex' },
+  { value: 'PRODUCTION_MARKER_SOURCE_LECTRA', label: 'lectra' },
+  { value: 'PRODUCTION_MARKER_SOURCE_AUDACES', label: 'audaces' },
+  { value: 'PRODUCTION_MARKER_SOURCE_OTHER', label: 'other' },
+];
+
+type MarkerDraft = {
+  source: common_ProductionMarkerSource;
+  markerName: string;
+  sizeId: number;
+  materialId: number;
+  markerWidth: string;
+  layLength: string;
+  unitsPerMarker: string;
+  efficiencyPct: string;
+  markerFileUrl: string;
+  notes: string;
+};
+
+const markerDraftFrom = (m: common_ProductionRunMarker): MarkerDraft => ({
+  source: m.source ?? 'PRODUCTION_MARKER_SOURCE_MANUAL',
+  markerName: m.markerName ?? '',
+  sizeId: m.sizeId ?? 0,
+  materialId: m.materialId ?? 0,
+  markerWidth: decimalToInput(m.markerWidth),
+  layLength: decimalToInput(m.layLength),
+  unitsPerMarker: m.unitsPerMarker ? String(m.unitsPerMarker) : '',
+  efficiencyPct: decimalToInput(m.efficiencyPct),
+  markerFileUrl: m.markerFileUrl ?? '',
+  notes: m.notes ?? '',
+});
+
+const emptyMarker: MarkerDraft = {
+  source: 'PRODUCTION_MARKER_SOURCE_MANUAL',
+  markerName: '',
+  sizeId: 0,
+  materialId: 0,
+  markerWidth: '',
+  layLength: '',
+  unitsPerMarker: '',
+  efficiencyPct: '',
+  markerFileUrl: '',
+  notes: '',
+};
 
 const directionLabel = (d?: common_TechCardFabricDirection): string => {
   switch (d) {
@@ -44,6 +101,7 @@ export function MarkerBlock({
   locked: boolean;
 }) {
   const { showMessage } = useSnackBarStore();
+  const { dictionary } = useDictionary();
   const update = useUpdateRunSection();
   const editable = canEdit && !locked;
 
@@ -52,9 +110,12 @@ export function MarkerBlock({
     () => (techCard?.techCard?.bomItems ?? []).filter((b) => FABRIC_SECTIONS.has(b.section ?? '')),
     [techCard],
   );
+  const sizeIds = techCard?.techCard?.sizeIds ?? [];
 
   const [efficiency, setEfficiency] = useState('');
   const [notes, setNotes] = useState('');
+  // The structured nesting markers (gap-07 v2 E) — planning/traceability only, they don't feed cost.
+  const [markers, setMarkers] = useState<MarkerDraft[]>([]);
   // Sibling saves refetch the run — don't let that resync wipe an in-progress draft.
   const [dirty, setDirty] = useState(false);
 
@@ -62,15 +123,42 @@ export function MarkerBlock({
     if (dirty) return;
     setEfficiency(decimalToInput(run.run?.markerEfficiencyPct));
     setNotes(run.run?.markerNotes ?? '');
+    setMarkers((run.run?.markers ?? []).map(markerDraftFrom));
   }, [run, dirty]);
 
+  const patchMarker = (i: number, p: Partial<MarkerDraft>) => {
+    setDirty(true);
+    setMarkers((prev) => prev.map((m, idx) => (idx === i ? { ...m, ...p } : m)));
+  };
+  const addMarker = () => {
+    setDirty(true);
+    setMarkers((prev) => [...prev, { ...emptyMarker }]);
+  };
+  const removeMarker = (i: number) => {
+    setDirty(true);
+    setMarkers((prev) => prev.filter((_, idx) => idx !== i));
+  };
+
   const save = async () => {
+    const outMarkers: common_ProductionRunMarker[] = markers.map((m) => ({
+      source: m.source,
+      markerName: m.markerName.trim(),
+      sizeId: m.sizeId || 0,
+      materialId: m.materialId || 0,
+      markerWidth: inputToDecimal(m.markerWidth),
+      layLength: inputToDecimal(m.layLength),
+      unitsPerMarker: Number(m.unitsPerMarker) || 0,
+      efficiencyPct: inputToDecimal(m.efficiencyPct),
+      markerFileUrl: m.markerFileUrl.trim(),
+      notes: m.notes.trim(),
+    }));
     try {
       await update.mutateAsync({
         id: run.id!,
         patch: {
           markerEfficiencyPct: inputToDecimal(efficiency),
           markerNotes: notes.trim(),
+          markers: outMarkers,
         },
       });
       setDirty(false);
@@ -128,6 +216,163 @@ export function MarkerBlock({
             }}
           />
         </label>
+      </div>
+
+      <div className='flex flex-col gap-2'>
+        <div className='flex items-center justify-between'>
+          <Text variant='inactive' size='small'>
+            nesting markers (раскладки) — from the CAD/nesting software; for planning &
+            traceability, not costing
+          </Text>
+          {editable && (
+            <Button
+              type='button'
+              variant='secondary'
+              size='lg'
+              className='uppercase'
+              onClick={addMarker}
+            >
+              + marker
+            </Button>
+          )}
+        </div>
+        {markers.map((m, i) => (
+          <div key={i} className='flex flex-col gap-2 border border-textInactiveColor p-2'>
+            <div className='flex items-center justify-between'>
+              <Text variant='uppercase' size='small'>
+                marker {i + 1}
+              </Text>
+              {editable && (
+                <Button
+                  type='button'
+                  variant='secondary'
+                  aria-label='remove marker'
+                  onClick={() => removeMarker(i)}
+                >
+                  ✕
+                </Button>
+              )}
+            </div>
+            <div className='grid grid-cols-2 gap-2 sm:grid-cols-4'>
+              <label className='flex flex-col gap-1'>
+                <Text size='small'>source</Text>
+                <select
+                  className={cell}
+                  disabled={!editable}
+                  value={m.source}
+                  onChange={(e) =>
+                    patchMarker(i, { source: e.target.value as common_ProductionMarkerSource })
+                  }
+                >
+                  {MARKER_SOURCES.map((s) => (
+                    <option key={s.value} value={s.value}>
+                      {s.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className='flex flex-col gap-1'>
+                <Text size='small'>name</Text>
+                <input
+                  className={cell}
+                  disabled={!editable}
+                  value={m.markerName}
+                  onChange={(e) => patchMarker(i, { markerName: e.target.value })}
+                />
+              </label>
+              <label className='flex flex-col gap-1'>
+                <Text size='small'>size</Text>
+                <select
+                  className={cell}
+                  disabled={!editable}
+                  value={m.sizeId || 0}
+                  onChange={(e) => patchMarker(i, { sizeId: Number(e.target.value) || 0 })}
+                >
+                  <option value={0}>— all sizes —</option>
+                  {sizeIds.map((sid) => (
+                    <option key={sid} value={sid}>
+                      {findInDictionary(dictionary, sid, 'size') || sid}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className='flex flex-col gap-1'>
+                <Text size='small'>units / marker</Text>
+                <input
+                  className={cell}
+                  inputMode='numeric'
+                  disabled={!editable}
+                  value={m.unitsPerMarker}
+                  onChange={(e) =>
+                    patchMarker(i, { unitsPerMarker: e.target.value.replace(/[^0-9]/g, '') })
+                  }
+                />
+              </label>
+            </div>
+            <div className='grid grid-cols-2 gap-2 sm:grid-cols-3'>
+              <label className='flex flex-col gap-1'>
+                <Text size='small'>marker width</Text>
+                <input
+                  className={cell}
+                  inputMode='decimal'
+                  disabled={!editable}
+                  value={m.markerWidth}
+                  onChange={(e) => patchMarker(i, { markerWidth: sanitizeDecimal(e.target.value) })}
+                />
+              </label>
+              <label className='flex flex-col gap-1'>
+                <Text size='small'>lay length</Text>
+                <input
+                  className={cell}
+                  inputMode='decimal'
+                  disabled={!editable}
+                  value={m.layLength}
+                  onChange={(e) => patchMarker(i, { layLength: sanitizeDecimal(e.target.value) })}
+                />
+              </label>
+              <label className='flex flex-col gap-1'>
+                <Text size='small'>efficiency %</Text>
+                <input
+                  className={cell}
+                  inputMode='decimal'
+                  disabled={!editable}
+                  value={m.efficiencyPct}
+                  onChange={(e) =>
+                    patchMarker(i, { efficiencyPct: sanitizeDecimal(e.target.value) })
+                  }
+                />
+              </label>
+            </div>
+            <label className='flex flex-col gap-1'>
+              <Text size='small'>material</Text>
+              <MaterialPicker
+                value={m.materialId}
+                disabled={!editable}
+                onChange={(materialId) => patchMarker(i, { materialId })}
+              />
+            </label>
+            <div className='grid grid-cols-1 gap-2 sm:grid-cols-[1fr_1fr]'>
+              <label className='flex flex-col gap-1'>
+                <Text size='small'>marker file url</Text>
+                <input
+                  className={cell}
+                  disabled={!editable}
+                  value={m.markerFileUrl}
+                  onChange={(e) => patchMarker(i, { markerFileUrl: e.target.value })}
+                />
+              </label>
+              <label className='flex flex-col gap-1'>
+                <Text size='small'>notes</Text>
+                <input
+                  className={cell}
+                  disabled={!editable}
+                  value={m.notes}
+                  onChange={(e) => patchMarker(i, { notes: e.target.value })}
+                />
+              </label>
+            </div>
+          </div>
+        ))}
       </div>
 
       {fabrics.length > 0 ? (

--- a/src/components/managers/production-runs/components/material-plan.tsx
+++ b/src/components/managers/production-runs/components/material-plan.tsx
@@ -5,9 +5,10 @@ import {
   IssueStockModal,
   MovementTarget,
 } from 'components/managers/materials/components/movement-modals';
+import { useTechCard } from 'components/managers/tech-cards/components/useTechCardQuery';
 import { SECTION } from 'constants/routes';
 import { useSnackBarStore } from 'lib/stores/store';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Button } from 'ui/components/button';
 import Text from 'ui/components/text';
 import { decimalToInput } from 'utils/decimal';
@@ -39,6 +40,21 @@ export function MaterialPlan({ run, canEdit }: { run: common_ProductionRun; canE
   const { data, isLoading, isError, refetch, isFetching } = useMaterialPlan(runId, runId > 0);
   const rows = data?.rows ?? [];
   const caveats = data?.caveats ?? [];
+
+  // The run's colourways (products) so an issue can be attributed to the one it was cut for
+  // (gap-07 v2 C) — only the published ones, since attribution keys on product_id.
+  const techCardId = run.run?.techCardId ?? 0;
+  const { data: techCard } = useTechCard(techCardId ? techCardId : undefined);
+  const colorways = useMemo(
+    () =>
+      (techCard?.techCard?.colorways ?? [])
+        .filter((c) => (c.productId ?? 0) > 0)
+        .map((c) => ({
+          productId: c.productId ?? 0,
+          label: `${c.code ? `${c.code} · ` : ''}${c.name ?? `#${c.productId}`}`,
+        })),
+    [techCard],
+  );
 
   const [issue, setIssue] = useState<{ target: MovementTarget; qty: string } | undefined>();
 
@@ -191,6 +207,7 @@ export function MaterialPlan({ run, canEdit }: { run: common_ProductionRun; canE
           defaultTarget={{ productionRunId: runId }}
           defaultQty={issue.qty}
           lockTarget
+          colorways={colorways}
         />
       ) : null}
     </div>

--- a/src/components/managers/production-runs/detail-page.tsx
+++ b/src/components/managers/production-runs/detail-page.tsx
@@ -1,4 +1,8 @@
-import { common_ProductionRun, common_ProductionRunActuals } from 'api/proto-http/admin';
+import {
+  common_ProductionRun,
+  common_ProductionRunActuals,
+  common_TechCardColorway,
+} from 'api/proto-http/admin';
 import { usePermissions } from 'components/managers/accounts/utils/permissions';
 import { useMaterials } from 'components/managers/materials/components/useMaterials';
 import { MovementsList } from 'components/managers/materials/components/movements-tab';
@@ -152,6 +156,12 @@ export function ProductionRunDetail() {
 
       {canReadCosting ? <PlanFactBlock run={run} actuals={actuals} /> : null}
 
+      {canReadCosting &&
+      actuals &&
+      ((actuals.byColorway?.length ?? 0) > 0 || actuals.unattributedMaterialsBase?.value) ? (
+        <ColorwayCostBlock actuals={actuals} colorways={techCard?.techCard?.colorways ?? []} />
+      ) : null}
+
       {isAux ? (
         <AuxRunPlan
           run={run}
@@ -248,6 +258,83 @@ function PlanFactBlock({
           ! some cost article could not be folded to base — totals are partial
         </Text>
       ) : null}
+    </div>
+  );
+}
+
+// Per-colourway material cost (gap-07 v2 C): stock issues grouped by the product_id they were cut
+// for. Only materials-from-stock is split — manual cost articles stay run-level — and issues booked
+// without a colourway fall into "unattributed". Read-only; costing-gated by the caller.
+const cwCell = 'border border-textInactiveColor bg-bgColor px-2 py-1 text-textBaseSize';
+function ColorwayCostBlock({
+  actuals,
+  colorways,
+}: {
+  actuals: common_ProductionRunActuals;
+  colorways: common_TechCardColorway[];
+}) {
+  const cur = actuals.baseCurrency || '';
+  const label = (productId?: number) => {
+    const c = colorways.find((x) => (x.productId ?? 0) === productId && (productId ?? 0) > 0);
+    if (c) return `${c.code ? `${c.code} · ` : ''}${c.name ?? `#${productId}`}`;
+    return productId ? `#${productId}` : '(unattributed)';
+  };
+  const rows = actuals.byColorway ?? [];
+  const unattributed = actuals.unattributedMaterialsBase;
+
+  return (
+    <div className='flex flex-col gap-2 border border-textInactiveColor p-3'>
+      <Text variant='uppercase' size='small'>
+        materials by colourway
+      </Text>
+      <div className='overflow-x-auto'>
+        <table className='border-collapse'>
+          <thead>
+            <tr>
+              <th className={`${cwCell} text-left uppercase`}>colourway</th>
+              <th className={`${cwCell} text-right uppercase`}>received</th>
+              <th className={`${cwCell} text-right uppercase`}>materials (stock)</th>
+              <th className={`${cwCell} text-right uppercase`}>/ unit</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.productId}>
+                <td className={cwCell}>
+                  {label(r.productId)}
+                  {r.hasUncosted ? (
+                    <Text variant='inactive' size='small'>
+                      ! some issues uncosted — understated
+                    </Text>
+                  ) : null}
+                </td>
+                <td className={`${cwCell} text-right`}>{r.receivedQty ?? 0}</td>
+                <td className={`${cwCell} text-right`}>
+                  {r.materialsFromStockBase?.value ? decimalToInput(r.materialsFromStockBase) : '—'}{' '}
+                  {r.materialsFromStockBase?.value ? cur : ''}
+                </td>
+                <td className={`${cwCell} text-right`}>
+                  {r.materialsUnitCost?.value ? decimalToInput(r.materialsUnitCost) : '—'}
+                </td>
+              </tr>
+            ))}
+            {unattributed?.value && Number(unattributed.value) !== 0 ? (
+              <tr>
+                <td className={cwCell}>(unattributed)</td>
+                <td className={`${cwCell} text-right`}>—</td>
+                <td className={`${cwCell} text-right`}>
+                  {decimalToInput(unattributed)} {cur}
+                </td>
+                <td className={`${cwCell} text-right`}>—</td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+      <Text variant='inactive' size='small'>
+        only stock-issued materials are split here; manual cost articles stay run-level. Attribute
+        an issue to a colourway from its “issue…” action to move it out of unattributed.
+      </Text>
     </div>
   );
 }

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -93,6 +93,7 @@ export enum ROUTES {
   taskDetails = '/tasks/:id',
   accounts = '/accounts',
   opex = '/opex',
+  employees = '/employees',
 }
 
 // Primary navigation, grouped by domain. Desktop renders each group as a top-bar
@@ -104,6 +105,7 @@ export const NAV_GROUPS: NavGroup[] = [
     items: [
       { label: 'analytics', route: ROUTES.main, section: SECTION.analytics },
       { label: 'opex', route: ROUTES.opex, section: SECTION.analytics },
+      { label: 'employees', route: ROUTES.employees, section: SECTION.analytics },
       { label: 'orders', route: ROUTES.orders, section: SECTION.orders },
       { label: 'fulfillment', route: ROUTES.fulfillment, section: SECTION.fulfillment },
       { label: 'tasks', route: ROUTES.tasks, section: SECTION.tasks },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -102,6 +102,9 @@ const Tasks = lazy(() => import('components/managers/tasks').then((m) => ({ defa
 const Opex = lazy(() =>
   import('components/managers/opex/page').then((m) => ({ default: m.OpexPage })),
 );
+const Employees = lazy(() =>
+  import('components/managers/employees').then((m) => ({ default: m.Employees })),
+);
 const TaskDetail = lazy(() =>
   import('components/managers/tasks/task-detail/page').then((m) => ({ default: m.TaskDetail })),
 );
@@ -241,6 +244,7 @@ root.render(
                   <Route path={ROUTES.productionRuns} element={<ProductionRuns />} />
                   <Route path={ROUTES.tasks} element={<Tasks />} />
                   <Route path={ROUTES.opex} element={<Opex />} />
+                  <Route path={ROUTES.employees} element={<Employees />} />
                   <Route path={ROUTES.taskDetails} element={<TaskDetail />} />
                   <Route path={ROUTES.accounts} element={<Accounts />} />
                 </Route>


### PR DESCRIPTION
Builds out the five net-new gap-07 v2 capabilities the backend shipped (beyond the closed asks already released in #349/#350). All read against the already-generated client; `yarn build:check` green.

- **D · Material lots** — read-only "lots" tab on /materials (pick a material → its received batches: lot code, supplier doc, received/remaining qty, informational unit cost, date, note). Optional lot picker on the material-issue modal → `IssueMaterialStock.lot_id`. Lots are read-only (created by receives); unit cost is informational (valuation stays moving-average).
- **C · Per-colourway cost** — "materials by colourway" table on the run detail from `ProductionRunActuals.by_colorway` (+ an unattributed row). To feed it, the run-detail issue flow attributes an issue to the colourway it was cut for via `IssueMaterialStock.product_id`.
- **A · Employee registry** — new `/employees` page (operations nav, analytics-gated): people list with add/edit/archive. The OPEX recurring-template form gains an employee picker → `OpexRecurringInsert.employee_id`.
- **B · Packaging BOM** — "packaging" tab on /materials: the single global recipe (per-order + per-item quantities), full-replace on save.
- **E · Nesting markers** — structured markers editor on the run's marker block (`ProductionRunInsert.markers`): CAD source, name, size, material, width, lay, units, efficiency, file URL, notes; saved via the run RMW/optimistic lock. Planning/traceability only — does not feed cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)