### PR TITLE
remove brand mark from top nav

### DIFF
--- a/src/ui/layout.tsx
+++ b/src/ui/layout.tsx
@@ -2,7 +2,6 @@ import { ADMIN_GROUP, ROUTES } from 'constants/routes';
 import { cn } from 'lib/utility';
 import { FC, ReactNode, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { GrbpwrMark } from './icons/grbpwr-mark';
 import { Button } from './components/button';
 import { LeftSideNavMenu } from './components/left-side-nav-menu';
 import { NavDropdownMenu } from './components/nav-dropdown-menu';
@@ -44,10 +43,7 @@ export const Layout: FC<LayoutProps> = ({ children }) => {
             size='lg'
             className='text-center transition-colors hover:opacity-70 active:opacity-50'
           >
-            <Link to='/' className='flex items-center gap-2'>
-              <GrbpwrMark className='h-5 w-5 shrink-0' />
-              grbpwr
-            </Link>
+            <Link to='/'>grbpwr</Link>
           </Button>
         </div>
 


### PR DESCRIPTION
The logo isn't needed in the nav bar — revert the home link to the plain `grbpwr` wordmark. `GrbpwrMark` stays in the invoice, tech pack, and login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En4pgGj4hfK2DKKeqKYyLN