### PR TITLE
invoice: QR code to customer's order on the storefront

### DIFF
--- a/src/components/managers/order/components/invoice-document.tsx
+++ b/src/components/managers/order/components/invoice-document.tsx
@@ -1,7 +1,9 @@
 import { common_Dictionary } from 'api/proto-http/admin';
 import { common_AddressInsert, common_OrderFull } from 'api/proto-http/frontend';
 import { formatDateShort } from 'components/managers/orders-catalog/components/utility';
+import { buildOrderTrackingUrl } from 'lib/storefront-links';
 import { ReactNode } from 'react';
+import { PatternQR } from 'ui/components/pattern-qr';
 import { GrbpwrMark } from 'ui/icons/grbpwr-mark';
 
 const TD = 'border border-black px-1.5 py-1 align-top';
@@ -127,6 +129,11 @@ export function InvoiceDocument({
   const paymentMethod = payment?.paymentMethod?.replace('PAYMENT_METHOD_NAME_ENUM_', '');
   const paid = !!payment?.isTransactionDone;
 
+  // Customer-facing link to this order on the storefront, scannable off the printed
+  // invoice. Origin tracks the admin environment (beta admin → beta store), so it works
+  // in both. Only shown when we have the uuid + email needed to resolve it.
+  const trackingUrl = buildOrderTrackingUrl(order.uuid, buyer?.email);
+
   return (
     <div className='mx-auto max-w-[210mm] bg-white px-8 py-6 text-black'>
       {/* HEADER / IDENTITY */}
@@ -144,10 +151,20 @@ export function InvoiceDocument({
               <div className='break-all text-[11px] text-labelColor'>ref {order.uuid || '—'}</div>
             </div>
           </div>
-          <div className='shrink-0 text-right text-[11px] leading-tight'>
-            <div className='font-semibold uppercase'>{orderStatus || '—'}</div>
-            <div>placed {formatDateShort(order.placed, true) || '—'}</div>
-            <div className='text-labelColor'>{currency || '—'}</div>
+          <div className='flex shrink-0 items-start gap-4'>
+            <div className='text-right text-[11px] leading-tight'>
+              <div className='font-semibold uppercase'>{orderStatus || '—'}</div>
+              <div>placed {formatDateShort(order.placed, true) || '—'}</div>
+              <div className='text-labelColor'>{currency || '—'}</div>
+            </div>
+            {trackingUrl && (
+              <div className='shrink-0 text-center'>
+                <PatternQR value={trackingUrl} size={76} />
+                <div className='mt-1 text-[8px] uppercase tracking-wide text-labelColor'>
+                  scan to view order
+                </div>
+              </div>
+            )}
           </div>
         </div>
       </header>

--- a/src/lib/storefront-links.ts
+++ b/src/lib/storefront-links.ts
@@ -105,6 +105,40 @@ const STOREFRONT_ORIGIN = (() => {
   }
 })();
 
+// ---- order tracking -------------------------------------------------------
+
+// Storefront order route expects a /{country}/{locale} prefix; the order lookup itself
+// is keyed by uuid + email, so any valid prefix resolves. Match the app default used by
+// the archive preview.
+const ORDER_TRACKING_COUNTRY = 'gb';
+const ORDER_TRACKING_LOCALE = 'en';
+
+/**
+ * Absolute storefront URL a customer can open (or scan) to view their order, e.g.
+ *   https://grbpwr.com/gb/en/order/ORD-XXXX/<base64-email>
+ *
+ * Origin comes from VITE_STOREFRONT_URL (set per environment in Vercel: beta admin →
+ * beta.grbpwr.com, prod admin → grbpwr.com), so the link always targets the storefront
+ * paired with THIS admin's backend — a beta order resolves on beta, a prod order on prod.
+ * The email is base64-encoded exactly as the storefront's order route expects. Returns ''
+ * when either input is missing so callers can conditionally render.
+ */
+export function buildOrderTrackingUrl(
+  orderUuid: string | undefined,
+  email: string | undefined,
+): string {
+  if (!orderUuid?.trim() || !email?.trim()) return '';
+  let b64Email: string;
+  try {
+    b64Email = btoa(email.trim());
+  } catch {
+    return ''; // non-Latin1 email — can't encode
+  }
+  return `${STOREFRONT_ORIGIN}/${ORDER_TRACKING_COUNTRY}/${ORDER_TRACKING_LOCALE}/order/${encodeURIComponent(
+    orderUuid.trim(),
+  )}/${b64Email}`;
+}
+
 // ---- build ----------------------------------------------------------------
 
 /** Serialize a StorefrontLink to the URL string stored in the form / contract. */


### PR DESCRIPTION
Adds a **"scan to view order" QR code** to the invoice header, linking to the customer's order on the storefront.

- Target built in `storefront-links.ts` (`buildOrderTrackingUrl`): `{STOREFRONT_ORIGIN}/gb/en/order/{uuid}/{base64-email}` — e.g. `https://grbpwr.com/gb/en/order/ORD-XXXX/<b64email>`.
- Origin comes from `VITE_STOREFRONT_URL` (set per env in Vercel: beta admin → beta.grbpwr.com, prod admin → grbpwr.com), so the link resolves against the storefront paired with this admin's backend — works in **both beta and prod**.
- Only rendered when the order uuid + buyer email are present.

Verified end-to-end: rendered QR decodes to `https://beta.grbpwr.com/gb/en/order/ORD-C3XHNUX/amVrYWJvbHRAeWFob28uY29t`. `tsc` clean, `vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En4pgGj4hfK2DKKeqKYyLN