### PR TITLE
Release beta → master: analytics period-compare + invoice QR fix

### DIFF
--- a/src/api/proto-http/admin/index.ts
+++ b/src/api/proto-http/admin/index.ts
@@ -1011,6 +1011,16 @@ export type GetMetricsRequest = {
   sections: MetricsSection[] | undefined;
   limit: number | undefined;
   trendGranularity: TrendGranularity | undefined;
+  // Explicit comparison window — an arbitrary analyst baseline (e.g. "this week vs the launch
+  // week", "Black Friday vs a normal week") instead of the fixed compare_mode presets. When BOTH
+  // from and to are set it OVERRIDES compare_mode; otherwise compare_mode applies. from inclusive,
+  // to exclusive, same as the primary period.
+  comparePeriod: TimeRange | undefined;
+};
+
+export type TimeRange = {
+  from: wellKnownTimestamp | undefined;
+  to: wellKnownTimestamp | undefined;
 };
 
 export type GetMetricsResponse = {
@@ -1080,11 +1090,6 @@ export type BusinessMetrics = {
   margin: MarginMetrics | undefined;
   traffic: TrafficMetrics | undefined;
   email: EmailMetrics | undefined;
-};
-
-export type TimeRange = {
-  from: wellKnownTimestamp | undefined;
-  to: wellKnownTimestamp | undefined;
 };
 
 // CommerceCoreMetrics is the DB-authoritative commerce view: sales, customers, discounts,
@@ -2068,6 +2073,10 @@ export type GetDashboardRequest = {
   endAt: wellKnownTimestamp | undefined;
   // Max rows per action list (top-by-margin, reorder, clear, drops). 0 = server default.
   limit: number | undefined;
+  // Period-over-period comparison of the headline figures. NONE/UNSPECIFIED (default) = no
+  // comparison; PREVIOUS_PERIOD = the same-length window immediately before; SAME_PERIOD_LAST_YEAR
+  // = the same calendar dates a year earlier. When a real mode is set, the response carries `compare`.
+  compareMode: CompareMode | undefined;
 };
 
 // DashboardAlert is a server-computed, threshold-driven alert. Rate-based alerts are gated on
@@ -2111,6 +2120,34 @@ export type GetDashboardResponse = {
   opexTotal: googletype_Decimal | undefined;
   marketingSpend: googletype_Decimal | undefined;
   opexCaveat: string | undefined;
+  // Period-over-period comparison of the six headline figures. Present only when the request set
+  // compare_mode to a real mode. Every headline metric is higher-is-better, so a positive change
+  // is always a good move (no per-field direction flag needed). The margin/contribution/operating
+  // figures here (values AND change fields) are confidential and redacted for accounts without
+  // costing:read, exactly like their top-level twins.
+  compare: DashboardComparison | undefined;
+};
+
+// DashboardComparison is the prior-period snapshot of the dashboard headline figures plus the
+// period-over-period change, so each headline tile can render "€42,300 ▲12% vs prev". *_change_pct
+// is 100*(current−prior)/prior, left 0 when prior is 0 (no base). The gross-margin-% delta is a
+// percentage-POINT change (change_pp), NOT a percent-of-a-percent. revenue and orders are public;
+// the margin/contribution/operating figures and their change fields are confidential (redacted
+// without costing:read).
+export type DashboardComparison = {
+  period: TimeRange | undefined;
+  revenue: googletype_Decimal | undefined;
+  revenueChangePct: number | undefined;
+  orders: number | undefined;
+  ordersChangePct: number | undefined;
+  grossMargin: googletype_Decimal | undefined;
+  grossMarginChangePct: number | undefined;
+  grossMarginPct: number | undefined;
+  grossMarginPctChangePp: number | undefined;
+  contributionMargin: googletype_Decimal | undefined;
+  contributionMarginChangePct: number | undefined;
+  operatingResult: googletype_Decimal | undefined;
+  operatingResultChangePct: number | undefined;
 };
 
 // AlertSettings are the operator-tunable thresholds behind the dashboard alerts.
@@ -6380,6 +6417,12 @@ export function createAdminServiceClient(
       if (request.trendGranularity) {
         queryParams.push(`trendGranularity=${encodeURIComponent(request.trendGranularity.toString())}`)
       }
+      if (request.comparePeriod?.from) {
+        queryParams.push(`comparePeriod.from=${encodeURIComponent(request.comparePeriod.from.toString())}`)
+      }
+      if (request.comparePeriod?.to) {
+        queryParams.push(`comparePeriod.to=${encodeURIComponent(request.comparePeriod.to.toString())}`)
+      }
       let uri = path;
       if (queryParams.length > 0) {
         uri += `?${queryParams.join("&")}`
@@ -6405,6 +6448,9 @@ export function createAdminServiceClient(
       }
       if (request.limit) {
         queryParams.push(`limit=${encodeURIComponent(request.limit.toString())}`)
+      }
+      if (request.compareMode) {
+        queryParams.push(`compareMode=${encodeURIComponent(request.compareMode.toString())}`)
       }
       let uri = path;
       if (queryParams.length > 0) {

--- a/src/components/managers/page/components/DateRangePicker.tsx
+++ b/src/components/managers/page/components/DateRangePicker.tsx
@@ -6,7 +6,7 @@ import { DateRange, DayPicker } from 'react-day-picker';
 import 'react-day-picker/style.css';
 import Text from 'ui/components/text';
 import type { MetricsPeriod } from '../useMetricsQuery';
-import { COMPARE_MODE_OPTIONS, PERIOD_OPTIONS } from '../useMetricsQuery';
+import { PERIOD_OPTIONS } from '../useMetricsQuery';
 import { compareModeHintLine } from '../utils';
 
 interface MetricsPeriodPickerProps {
@@ -14,10 +14,22 @@ interface MetricsPeriodPickerProps {
   compareMode: CompareMode;
   customFrom?: Date;
   customTo?: Date;
+  // Arbitrary compare baseline window ("this week vs launch week"). Set → overrides the preset.
+  compareFrom?: Date;
+  compareTo?: Date;
   onPeriodChange: (p: MetricsPeriod) => void;
   onCompareModeChange: (m: CompareMode) => void;
   onCustomRangeChange?: (from: Date, to: Date) => void;
+  onCompareBaselineChange?: (from: Date, to: Date) => void;
 }
+
+type CompareChoice = 'none' | 'previous' | 'custom';
+
+const COMPARE_CHOICES: Array<{ value: CompareChoice; label: string }> = [
+  { value: 'none', label: 'No comparison' },
+  { value: 'previous', label: 'Previous period' },
+  { value: 'custom', label: 'Custom baseline' },
+];
 
 function formatDateRange(from?: Date, to?: Date): string {
   if (!from || !to) return 'Select range';
@@ -29,12 +41,17 @@ export const DateRangePicker: FC<MetricsPeriodPickerProps> = ({
   compareMode,
   customFrom,
   customTo,
+  compareFrom,
+  compareTo,
   onPeriodChange,
   onCompareModeChange,
   onCustomRangeChange,
+  onCompareBaselineChange,
 }) => {
   const [open, setOpen] = useState(false);
   const [selectingRange, setSelectingRange] = useState<DateRange | undefined>(undefined);
+  const [compareOpen, setCompareOpen] = useState(false);
+  const [selectingCompare, setSelectingCompare] = useState<DateRange | undefined>(undefined);
 
   const handleCustomSelect = (range: DateRange | undefined) => {
     if (!range) {
@@ -49,16 +66,48 @@ export const DateRangePicker: FC<MetricsPeriodPickerProps> = ({
     }
   };
 
+  const handleCompareSelect = (range: DateRange | undefined) => {
+    if (!range) {
+      setSelectingCompare(undefined);
+      return;
+    }
+    setSelectingCompare(range);
+    if (range.from && range.to && range.from.getTime() !== range.to.getTime()) {
+      onCompareBaselineChange?.(range.from, range.to);
+      setCompareOpen(false);
+      setSelectingCompare(undefined);
+    }
+  };
+
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen) setSelectingRange(undefined);
     setOpen(nextOpen);
   };
 
+  const handleCompareOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) setSelectingCompare(undefined);
+    setCompareOpen(nextOpen);
+  };
+
   const isCustom = period === 'custom';
-  const compareHint = compareModeHintLine(compareMode, period, customFrom, customTo);
+  const hasBaseline = !!(compareFrom && compareTo);
+  const [compareChoice, setCompareChoice] = useState<CompareChoice>(
+    compareMode === 'COMPARE_MODE_NONE' ? 'none' : hasBaseline ? 'custom' : 'previous',
+  );
+
+  const handleCompareChoice = (value: CompareChoice) => {
+    setCompareChoice(value);
+    if (value === 'none') onCompareModeChange('COMPARE_MODE_NONE');
+    else if (value === 'previous') onCompareModeChange('COMPARE_MODE_PREVIOUS_PERIOD');
+    else setCompareOpen(true); // custom — open the baseline picker; commit on range select
+  };
+
+  const compareHint = hasBaseline
+    ? `Deltas compare to ${formatDateRange(compareFrom, compareTo)} (custom baseline).`
+    : compareModeHintLine(compareMode, period, customFrom, customTo);
 
   return (
-    <div className='flex flex-wrap items-end gap-4 pb-6'>
+    <div className='flex flex-wrap items-start gap-4 pb-6'>
       <div className='flex flex-col gap-1'>
         <Text variant='uppercase' className='text-textInactiveColor'>
           period
@@ -114,17 +163,52 @@ export const DateRangePicker: FC<MetricsPeriodPickerProps> = ({
         <Text variant='uppercase' className='text-textInactiveColor'>
           compare
         </Text>
-        <select
-          value={compareMode}
-          onChange={(e) => onCompareModeChange(e.target.value as CompareMode)}
-          className='h-9 min-w-[180px] border border-textInactiveColor bg-bgColor px-2 text-textBaseSize uppercase'
-        >
-          {COMPARE_MODE_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
+        <div className='flex gap-2'>
+          <select
+            value={compareChoice}
+            onChange={(e) => handleCompareChoice(e.target.value as CompareChoice)}
+            className='h-9 min-w-[180px] border border-textInactiveColor bg-bgColor px-2 text-textBaseSize uppercase'
+          >
+            {COMPARE_CHOICES.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          {compareChoice === 'custom' && (
+            <Popover.Root open={compareOpen} onOpenChange={handleCompareOpenChange}>
+              <Popover.Trigger asChild>
+                <button
+                  type='button'
+                  className='h-9 flex items-center border border-textInactiveColor bg-bgColor px-3 text-textBaseSize text-left min-w-[200px] hover:border-textInactiveColor transition-colors'
+                >
+                  {hasBaseline ? formatDateRange(compareFrom, compareTo) : 'Select baseline'}
+                </button>
+              </Popover.Trigger>
+              <Popover.Content
+                className='z-50 bg-bgColor p-4 rounded-none border border-textInactiveColor shadow-lg'
+                align='start'
+                onOpenAutoFocus={(e) => e.preventDefault()}
+                onInteractOutside={(e) => {
+                  if (selectingCompare?.from && !selectingCompare?.to) {
+                    e.preventDefault();
+                  }
+                }}
+              >
+                <DayPicker
+                  mode='range'
+                  selected={
+                    selectingCompare ??
+                    (compareFrom && compareTo ? { from: compareFrom, to: compareTo } : undefined)
+                  }
+                  onSelect={handleCompareSelect}
+                  numberOfMonths={2}
+                  defaultMonth={compareFrom ?? new Date()}
+                />
+              </Popover.Content>
+            </Popover.Root>
+          )}
+        </div>
         {compareHint && (
           <Text className='text-[10px] text-textInactiveColor leading-snug mt-0.5'>
             {compareHint}

--- a/src/components/managers/page/components/ProfitabilityPanel.tsx
+++ b/src/components/managers/page/components/ProfitabilityPanel.tsx
@@ -13,6 +13,10 @@ import {
 interface ProfitabilityPanelProps {
   profitability: ProfitabilitySection | undefined;
   compareEnabled?: boolean;
+  // Period-over-period change of the operating result, from GetDashboard's DashboardComparison.
+  // ProfitabilitySection.operatingResult is a plain Decimal with no compare, so this is the only
+  // source of its delta. Percent change; higher is better.
+  operatingResultChangePct?: number;
 }
 
 // Below this coverage the margin % is a biased average of an unrepresentative slice — match the
@@ -96,9 +100,23 @@ const UnitTile: FC<{ label: string; value: ReactNode; sub?: ReactNode; muted?: b
  * fields without costing:read). Absorbs the operating-result waterfall that used to live in
  * OperatingResultStrip, so the money story appears once, period-consistent, with compare deltas.
  */
+// Percent-change delta node in the shared arrow grammar (higher is better).
+const PctDelta: FC<{ pct: number | undefined; enabled: boolean }> = ({ pct, enabled }) => {
+  if (!enabled || pct == null || !Number.isFinite(pct)) return null;
+  const color = pct > 0 ? 'text-success' : pct < 0 ? 'text-error' : 'text-textInactiveColor';
+  const arrow = pct > 0 ? '↑ ' : pct < 0 ? '↓ ' : '';
+  return (
+    <Text variant='uppercase' className={`text-textBaseSize ${color}`}>
+      {arrow}
+      {Math.abs(pct).toFixed(0)}% vs prev
+    </Text>
+  );
+};
+
 export const ProfitabilityPanel: FC<ProfitabilityPanelProps> = ({
   profitability,
   compareEnabled = false,
+  operatingResultChangePct,
 }) => {
   if (!profitability) return null;
 
@@ -198,6 +216,7 @@ export const ProfitabilityPanel: FC<ProfitabilityPanelProps> = ({
                   value={formatCurrency(operating)}
                   strong
                   valueTone={operating < 0 ? 'text-error' : ''}
+                  delta={<PctDelta pct={operatingResultChangePct} enabled={compareEnabled} />}
                 />
               </div>
             </>

--- a/src/components/managers/page/index.tsx
+++ b/src/components/managers/page/index.tsx
@@ -56,6 +56,10 @@ export function Analitic() {
   const [compareMode, setCompareMode] = useState<CompareMode>('COMPARE_MODE_NONE');
   const [customFrom, setCustomFrom] = useState(defaultCustom.from);
   const [customTo, setCustomTo] = useState(defaultCustom.to);
+  // Arbitrary compare baseline (GetMetrics compare_period). Set only when the operator picks a
+  // "Custom baseline" window; clearing it falls back to the compare_mode preset.
+  const [compareFrom, setCompareFrom] = useState<Date | undefined>(undefined);
+  const [compareTo, setCompareTo] = useState<Date | undefined>(undefined);
 
   const [searchParams, setSearchParams] = useSearchParams();
   const tabParam = searchParams.get('tab');
@@ -92,6 +96,23 @@ export function Analitic() {
     setCustomTo(to);
   };
 
+  // Selecting a preset (none / previous) clears any custom baseline so the two never conflict.
+  const handleCompareModeChange = (m: CompareMode) => {
+    setCompareMode(m);
+    setCompareFrom(undefined);
+    setCompareTo(undefined);
+  };
+
+  // Picking a custom baseline window implies a real compare mode (previous-period), which
+  // compare_period then overrides with this explicit window on GetMetrics.
+  const handleCompareBaselineChange = (from: Date, to: Date) => {
+    setCompareFrom(from);
+    setCompareTo(to);
+    setCompareMode('COMPARE_MODE_PREVIOUS_PERIOD');
+  };
+
+  const hasBaseline = !!(compareFrom && compareTo);
+
   const {
     data: metricsResponse,
     isLoading,
@@ -101,15 +122,20 @@ export function Analitic() {
     compareMode,
     customFrom: period === 'custom' ? customFrom : undefined,
     customTo: period === 'custom' ? customTo : undefined,
+    compareFrom,
+    compareTo,
   });
 
   const compareEnabled = compareMode !== 'COMPARE_MODE_NONE';
 
   // Operating result + GA4 coverage come from GetDashboard, only needed on the Revenue tab.
+  // GetDashboard supports only the compare_mode preset (no arbitrary baseline), so when a custom
+  // baseline is active we suppress the dashboard compare rather than show a mismatched "vs prev".
   const { data: dashboard } = useDashboardQuery(period, {
     enabled: activeTab === 'revenue',
     customFrom: period === 'custom' ? customFrom : undefined,
     customTo: period === 'custom' ? customTo : undefined,
+    compareMode: hasBaseline ? 'COMPARE_MODE_NONE' : compareMode,
   });
 
   // Settled-revenue channel ROAS lives on the Growth tab next to GA4 attribution.
@@ -162,9 +188,12 @@ export function Analitic() {
           compareMode={compareMode}
           customFrom={customFrom}
           customTo={customTo}
+          compareFrom={compareFrom}
+          compareTo={compareTo}
           onPeriodChange={handlePeriodChange}
-          onCompareModeChange={setCompareMode}
+          onCompareModeChange={handleCompareModeChange}
           onCustomRangeChange={handleCustomRangeChange}
+          onCompareBaselineChange={handleCompareBaselineChange}
         />
         <PersistentKpiBar metrics={metricsResponse?.business} compareEnabled={compareEnabled} />
       </div>

--- a/src/components/managers/page/tabs/RevenueTab.tsx
+++ b/src/components/managers/page/tabs/RevenueTab.tsx
@@ -238,6 +238,7 @@ export function RevenueTab({
         <ProfitabilityPanel
           profitability={metricsResponse.profitability}
           compareEnabled={compareEnabled}
+          operatingResultChangePct={dashboard?.compare?.operatingResultChangePct}
         />
       )}
 

--- a/src/components/managers/page/useDashboardQuery.ts
+++ b/src/components/managers/page/useDashboardQuery.ts
@@ -1,14 +1,23 @@
 import { useQuery } from '@tanstack/react-query';
 import { adminService } from 'api/api';
-import type { GetDashboardResponse } from 'api/proto-http/admin';
+import type { CompareMode, GetDashboardResponse } from 'api/proto-http/admin';
 import { dateRangeToIso8601Duration, type MetricsPeriod } from './useMetricsQuery';
 
 // GetDashboard is a separate server-computed rollup from GetMetrics; we use it only for the
 // figures the metrics tabs don't carry — operating_result / opex / marketing_spend and the
-// GA4-vs-DB revenue coverage. Period grammar matches GetMetrics.
+// GA4-vs-DB revenue coverage. Period grammar matches GetMetrics. With compareMode set it also
+// returns `compare` (DashboardComparison): prior-period revenue/orders/margin/contribution/
+// operating-result + their change %, so the operating result can show a period-over-period delta.
 export function useDashboardQuery(
   period: MetricsPeriod,
-  options?: { enabled?: boolean; customFrom?: Date; customTo?: Date },
+  options?: {
+    enabled?: boolean;
+    customFrom?: Date;
+    customTo?: Date;
+    // GetDashboard supports only the compare_mode preset (no arbitrary compare_period baseline —
+    // that field is GetMetrics-only). A real mode makes the response carry `compare`.
+    compareMode?: CompareMode;
+  },
 ) {
   const isCustom = period === 'custom';
   const periodParam =
@@ -17,12 +26,18 @@ export function useDashboardQuery(
       : period;
 
   return useQuery({
-    queryKey: ['dashboard', periodParam, options?.customTo?.toISOString()],
+    queryKey: [
+      'dashboard',
+      periodParam,
+      options?.customTo?.toISOString(),
+      options?.compareMode,
+    ],
     queryFn: async (): Promise<GetDashboardResponse> =>
       adminService.GetDashboard({
         period: periodParam,
         endAt: options?.customTo?.toISOString(),
         limit: undefined,
+        compareMode: options?.compareMode,
       }),
     enabled: options?.enabled ?? true,
     staleTime: 2 * 60 * 1000,

--- a/src/components/managers/page/useTabMetricsQuery.ts
+++ b/src/components/managers/page/useTabMetricsQuery.ts
@@ -65,6 +65,8 @@ export const tabMetricsKeys = {
     period: string;
     endAt?: string;
     compareMode?: CompareMode;
+    compareFrom?: string;
+    compareTo?: string;
   }) => [...tabMetricsKeys.all, params] as const,
 };
 
@@ -75,6 +77,10 @@ export function useTabMetricsQuery(
     compareMode?: CompareMode;
     customFrom?: Date;
     customTo?: Date;
+    // Arbitrary compare baseline ("this week vs launch week"). When both are set the backend
+    // uses this window instead of the compare_mode preset (compare_period overrides compare_mode).
+    compareFrom?: Date;
+    compareTo?: Date;
     limit?: number;
   },
 ) {
@@ -85,6 +91,10 @@ export function useTabMetricsQuery(
       : period;
 
   const sections = TAB_SECTIONS[tabId];
+  const comparePeriod =
+    options?.compareFrom && options?.compareTo
+      ? { from: options.compareFrom.toISOString(), to: options.compareTo.toISOString() }
+      : undefined;
 
   return useQuery({
     queryKey: tabMetricsKeys.tabMetrics({
@@ -92,12 +102,15 @@ export function useTabMetricsQuery(
       period: periodParam,
       endAt: options?.customTo?.toISOString(),
       compareMode: options?.compareMode,
+      compareFrom: options?.compareFrom?.toISOString(),
+      compareTo: options?.compareTo?.toISOString(),
     }),
     queryFn: async (): Promise<GetMetricsResponse> => {
       const response = await adminService.GetMetrics({
         period: periodParam,
         endAt: options?.customTo?.toISOString(),
         compareMode: options?.compareMode,
+        comparePeriod,
         sections,
         limit: options?.limit,
         trendGranularity: undefined,

--- a/src/lib/storefront-links.ts
+++ b/src/lib/storefront-links.ts
@@ -134,8 +134,11 @@ export function buildOrderTrackingUrl(
   } catch {
     return ''; // non-Latin1 email — can't encode
   }
+  // The storefront order route is case-sensitive and keys on the UPPERCASE order reference
+  // (e.g. /gb/en/order/ORD-XXXX/<b64email>). The backend can return the uuid lowercased, which
+  // 404s the link — so normalise to upper case here before encoding.
   return `${STOREFRONT_ORIGIN}/${ORDER_TRACKING_COUNTRY}/${ORDER_TRACKING_LOCALE}/order/${encodeURIComponent(
-    orderUuid.trim(),
+    orderUuid.trim().toUpperCase(),
   )}/${b64Email}`;
 }
 


### PR DESCRIPTION
Promote `beta` to `master` (production, admin.grbpwr.com).

## What ships (#361)
- **Period-compare**: custom compare baseline + dashboard operating-result delta (proto `740ad09`).
- **Invoice QR fix**: uppercase order uuid so the case-sensitive storefront order link resolves.
- **PERIOD/COMPARE layout fix**.

Additive contract; compare deltas populate once the backend period-compare support deploys, degrade cleanly until then. `tsc` + `vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En4pgGj4hfK2DKKeqKYyLN