### PR TITLE
Analytics + tech-card UX: match approved designs, brand colors

### DIFF
--- a/src/components/managers/page/components/ActionList.tsx
+++ b/src/components/managers/page/components/ActionList.tsx
@@ -1,30 +1,53 @@
-import { FC } from 'react';
+import { FC, ReactNode } from 'react';
 import Text from 'ui/components/text';
 import type { ActionItem } from '../productSignals';
 import { ProductNameLink } from './ProductNameLink';
+import { ActPill, MiniPill, VerdictList, VerdictRow } from './VerdictList';
 
-/** Bounded, scannable action list: name on the left, the signal + action on the right. */
+// Signals read "<reason> — <action>"; split so the action becomes a pill and a leading
+// "€X frozen" becomes a mini-pill, matching the products-final CLEAR rows.
+function parseSignal(signal: string): { reason: ReactNode; action?: string } {
+  const [rawReason, ...rest] = signal.split(' — ');
+  const action = rest.length > 0 ? rest.join(' — ') : undefined;
+  const frozen = rawReason.match(/^(€[\d.,]+\s*frozen)\s*·?\s*(.*)$/i);
+  if (frozen) {
+    return {
+      reason: (
+        <>
+          <MiniPill>{frozen[1]}</MiniPill>
+          {frozen[2]}
+        </>
+      ),
+      action,
+    };
+  }
+  return { reason: rawReason, action };
+}
+
+/** Bounded, scannable action list: bold name · reason (with a frozen badge) · action pill. */
 export const ActionList: FC<{ items: ActionItem[]; total: number }> = ({ items, total }) => {
   if (items.length === 0) return null;
   return (
-    <ul className='divide-y divide-textInactiveColor/60'>
-      {items.map((it) => (
-        <li
-          key={it.key}
-          className='flex flex-wrap items-baseline justify-between gap-x-3 gap-y-0.5 py-2'
-        >
-          <div className='min-w-0 max-w-[55%] font-bold'>
-            {/* Only linkify numeric DB colorway ids. OOS / notify-me rows carry BigQuery string
-                ids that are not colorway ids, so linking them would land on a blank product page. */}
-            {typeof it.productId === 'number' && it.productId > 0 ? (
-              <ProductNameLink productId={it.productId} productName={it.name} maxWidth='100%' />
-            ) : (
-              <Text className='truncate'>{it.name}</Text>
-            )}
-          </div>
-          <Text className='text-labelColor text-textBaseSize text-right'>{it.signal}</Text>
-        </li>
-      ))}
+    <VerdictList>
+      {items.map((it) => {
+        const { reason, action } = parseSignal(it.signal);
+        const crit = it.key.startsWith('dead');
+        const linkable = typeof it.productId === 'number' && it.productId > 0;
+        return (
+          <VerdictRow
+            key={it.key}
+            name={
+              linkable ? (
+                <ProductNameLink productId={it.productId} productName={it.name} maxWidth='100%' />
+              ) : (
+                it.name
+              )
+            }
+            why={reason}
+            act={action ? <ActPill tone={crit ? 'crit' : 'neutral'}>{action}</ActPill> : undefined}
+          />
+        );
+      })}
       {total > items.length && (
         <li className='py-2'>
           <Text className='text-labelColor text-textBaseSize'>
@@ -32,6 +55,6 @@ export const ActionList: FC<{ items: ActionItem[]; total: number }> = ({ items, 
           </Text>
         </li>
       )}
-    </ul>
+    </VerdictList>
   );
 };

--- a/src/components/managers/page/components/DropVerdictTable.tsx
+++ b/src/components/managers/page/components/DropVerdictTable.tsx
@@ -13,7 +13,7 @@ interface DropVerdictTableProps {
 function verdict(pct: number): { label: string; cls: string } {
   if (pct >= 75) return { label: 'Strong', cls: 'text-success' };
   if (pct >= 40) return { label: 'OK', cls: 'text-textColor' };
-  return { label: 'Weak', cls: 'text-warning' };
+  return { label: 'Weak', cls: 'text-error' };
 }
 
 export const DropVerdictTable: FC<DropVerdictTableProps> = ({ sellThroughByDrop }) => {
@@ -51,7 +51,7 @@ export const DropVerdictTable: FC<DropVerdictTableProps> = ({ sellThroughByDrop 
           // Card = the decision verb (reprint / hold / cut), a sell-through bar coloured by band,
           // then the supporting numbers. Matches the approved "drop cards" pick.
           const action = pct >= 75 ? 'Reprint' : pct >= 40 ? 'Hold' : 'Cut';
-          const barCls = pct >= 75 ? 'bg-success' : pct >= 40 ? 'bg-textColor' : 'bg-warning';
+          const barCls = pct >= 75 ? 'bg-success' : pct >= 40 ? 'bg-textColor' : 'bg-error';
           return (
             <div key={idx} className='border border-textInactiveColor p-3'>
               <div className='flex items-baseline justify-between gap-2'>

--- a/src/components/managers/page/components/ExecutiveHealthStrip.tsx
+++ b/src/components/managers/page/components/ExecutiveHealthStrip.tsx
@@ -3,6 +3,7 @@ import { type FC } from 'react';
 import { Link } from 'react-router-dom';
 import Text from 'ui/components/text';
 import { computeExecutiveAlerts, deriveHealthStatus, type HealthStatus } from '../executiveAlerts';
+import { SectionHead } from './SectionHead';
 
 const STATUS_LABEL: Record<HealthStatus, string> = {
   needs_attention: 'Needs attention',
@@ -10,12 +11,14 @@ const STATUS_LABEL: Record<HealthStatus, string> = {
   on_track: 'On track',
 };
 
+// Status pill: colored border + text on a gray surface (no coral/opacity-red wash).
 const STATUS_SHELL: Record<HealthStatus, string> = {
   needs_attention: 'border-error text-error bg-bgSecondary',
-  mixed: 'border-warning text-textColor bg-bgSecondary',
-  on_track: 'border-textInactiveColor text-textColor bg-bgSecondary/40',
+  mixed: 'border-warning text-warning bg-bgSecondary',
+  on_track: 'border-textInactiveColor text-textColor bg-bgSecondary',
 };
 
+// Alert title: high = red, warning = blue (the design's warning token), matching the stub a-t.crit / a-t.warn.
 const ALERT_TITLE_CLASS: Record<'high' | 'warning', string> = {
   high: 'text-error',
   warning: 'text-warning',
@@ -29,6 +32,8 @@ export interface ExecutiveHealthStripProps {
   comparePeriodLabel: string | null;
 }
 
+/** Health / act now (config: Health=pill) — a status pill + the act-now list, matching the
+ *  approved today-config stub: sec-h header → pill + count → ranked issues with an Open link. */
 export const ExecutiveHealthStrip: FC<ExecutiveHealthStripProps> = ({
   metrics,
   compareEnabled,
@@ -40,62 +45,49 @@ export const ExecutiveHealthStrip: FC<ExecutiveHealthStripProps> = ({
   const status = deriveHealthStatus(alerts, metrics, compareEnabled);
 
   return (
-    <div className='space-y-4 border-2 border-textInactiveColor/15 bg-bgSecondary/20 p-4'>
-      <div className='space-y-1'>
-        <Text variant='uppercase' className='text-textBaseSize font-semibold text-labelColor'>
-          Business health
-        </Text>
-        <Text className='text-textBaseSize text-textColor/90 leading-relaxed'>
-          <span className='text-labelColor'>Current: </span>
-          {currentPeriodLabel}
-          {comparePeriodLabel && (
-            <>
-              <span className='text-labelColor'> · Compared to: </span>
-              {comparePeriodLabel}
-            </>
-          )}
-        </Text>
-      </div>
+    <section className='space-y-2.5'>
+      <SectionHead title='Health / act now' sub='— what needs a decision this period' />
 
       <div className='flex flex-wrap items-center gap-3'>
         <span
-          className={`inline-flex items-center border px-2.5 py-1 text-textBaseSize font-bold uppercase tracking-wide ${STATUS_SHELL[status]}`}
+          className={`inline-flex items-center border px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide ${STATUS_SHELL[status]}`}
         >
           {STATUS_LABEL[status]}
         </span>
-        <Text className='text-textBaseSize text-labelColor uppercase'>
+        <Text variant='uppercase' className='text-labelColor text-[11px]'>
           {alerts.length === 0
             ? 'Nothing needs action this period'
             : `${alerts.length} thing${alerts.length === 1 ? '' : 's'} to act on`}
         </Text>
       </div>
 
-      {alerts.length > 0 && (
-        <div className='space-y-2 border-t border-textInactiveColor/40 pt-3'>
-          <Text variant='uppercase' className='text-textBaseSize font-semibold text-labelColor'>
-            Act now
-          </Text>
-          <ul className='space-y-2'>
-            {alerts.map((a, i) => (
-              <li key={`${a.title}-${i}`} className='text-textBaseSize leading-snug'>
-                <span className={`font-semibold ${ALERT_TITLE_CLASS[a.severity]}`}>{a.title}</span>
-                {a.detail && (
-                  <Text className='text-labelColor text-textBaseSize mt-0.5 block'>{a.detail}</Text>
-                )}
-                {a.href && (
-                  <Link
-                    to={a.href}
-                    replace
-                    className='text-textBaseSize underline underline-offset-2 mt-0.5 inline-block hover:text-textColor'
-                  >
-                    Open
-                  </Link>
-                )}
-              </li>
-            ))}
-          </ul>
-        </div>
+      {compareEnabled && comparePeriodLabel && (
+        <Text className='text-labelColor text-textBaseSize'>
+          {currentPeriodLabel} vs {comparePeriodLabel}
+        </Text>
       )}
-    </div>
+
+      {alerts.length > 0 && (
+        <ul className='divide-y divide-textInactiveColor/50 border-t border-textInactiveColor/50'>
+          {alerts.map((a, i) => (
+            <li key={`${a.title}-${i}`} className='py-2 text-textBaseSize leading-snug'>
+              <span className={`font-bold ${ALERT_TITLE_CLASS[a.severity]}`}>{a.title}</span>
+              {a.detail && (
+                <Text className='text-labelColor text-textBaseSize mt-0.5 block'>{a.detail}</Text>
+              )}
+              {a.href && (
+                <Link
+                  to={a.href}
+                  replace
+                  className='mt-0.5 inline-block text-textBaseSize underline underline-offset-2 hover:text-textColor'
+                >
+                  Open ▸
+                </Link>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
   );
 };

--- a/src/components/managers/page/components/MoneySummary.tsx
+++ b/src/components/managers/page/components/MoneySummary.tsx
@@ -6,42 +6,27 @@ import Text from 'ui/components/text';
 import { marginExtremes, valuationSummary } from '../productSignals';
 import { formatCurrency, formatCurrencyCompact, parseDecimal } from '../utils';
 import { ProductSection } from './ProductSection';
+import { ActPill, ColHead, VerdictColumns, VerdictList, VerdictRow } from './VerdictList';
 
-/** Style name → tech-card link, or plain text with a reason when there is no primary style
- *  (tech_card_id = 0/undefined). Fixes the old silent dead-end on those aggregate rows. */
+/** Style name → tech-card link (bold 12px, matches stub `.nm`), or plain text with a reason when
+ *  there is no primary style (tech_card_id = 0/undefined). */
 const StyleName: FC<{ row: MarginByStyleRow }> = ({ row }) => {
   const label = row.styleNumber || row.name || (row.techCardId ? `TC-${row.techCardId}` : '—');
   if (row.techCardId) {
     return (
       <Link
         to={generatePath(ROUTES.singleTechCard, { id: String(row.techCardId) })}
-        className='truncate underline underline-offset-2 hover:text-textColor'
+        className='underline-offset-2 hover:underline'
       >
         {label}
       </Link>
     );
   }
-  return (
-    <Text className='truncate' title='No tech card linked to this style'>
-      {label}
-    </Text>
-  );
+  return <span title='No tech card linked to this style'>{label}</span>;
 };
 
-const MarginRow: FC<{ row: MarginByStyleRow }> = ({ row }) => (
-  <li className='flex items-baseline justify-between gap-3 py-1.5'>
-    <div className='min-w-0 max-w-[55%] font-bold'>
-      <StyleName row={row} />
-    </div>
-    <Text className='text-textBaseSize text-right'>
-      {formatCurrency(parseDecimal(row.grossMargin))}
-      <span className='text-labelColor'> · {(row.grossMarginPct ?? 0).toFixed(0)}%</span>
-    </Text>
-  </li>
-);
-
-/** MONEY decision: how much cash is tied in stock (with coverage + concentration), and
- *  which styles make vs lose money after COGS. Summaries, not tables. */
+/** MONEY decision: how much cash is tied in stock (with coverage + concentration), and which
+ *  styles make vs lose money after COGS. Buckets + two verdict lists, matching products-final. */
 export const MoneySummary: FC<{ metricsResponse: GetMetricsResponse }> = ({ metricsResponse }) => {
   const val = valuationSummary(metricsResponse.inventoryValuation);
   const { top, bottom, anyCosted } = marginExtremes(metricsResponse.marginByStyle);
@@ -61,14 +46,14 @@ export const MoneySummary: FC<{ metricsResponse: GetMetricsResponse }> = ({ metr
       subtitle='— cash in stock & which styles make vs lose margin'
       verdict={verdict}
     >
-      <div className='space-y-4'>
+      <div className='space-y-3'>
         {val && (
-          <div className='grid grid-cols-3 border border-textInactiveColor bg-bgSecondary/30'>
+          <div className='grid grid-cols-3 border border-textInactiveColor'>
             <div className='border-r border-textInactiveColor px-3 py-2'>
               <Text variant='uppercase' className='text-labelColor block text-[10px]'>
                 Cash in stock
               </Text>
-              <Text className='text-lg font-bold tabular-nums'>
+              <Text className='block font-bold text-[17px] tabular-nums'>
                 {formatCurrencyCompact(val.total)}
               </Text>
               <Text variant='uppercase' className='text-labelColor block text-[10px]'>
@@ -80,7 +65,7 @@ export const MoneySummary: FC<{ metricsResponse: GetMetricsResponse }> = ({ metr
                 In dead stock
               </Text>
               <Text
-                className={`text-lg font-bold tabular-nums ${val.deadValue > 0 ? 'text-error' : ''}`}
+                className={`block font-bold text-[17px] tabular-nums ${val.deadValue > 0 ? 'text-error' : ''}`}
               >
                 {formatCurrency(val.deadValue)}
               </Text>
@@ -94,7 +79,7 @@ export const MoneySummary: FC<{ metricsResponse: GetMetricsResponse }> = ({ metr
               <Text variant='uppercase' className='text-labelColor block text-[10px]'>
                 Concentration
               </Text>
-              <Text className='text-lg font-bold tabular-nums'>
+              <Text className='block font-bold text-[17px] tabular-nums'>
                 {val.top3Share > 0 ? `${val.top3Share.toFixed(0)}%` : '—'}
               </Text>
               <Text variant='uppercase' className='text-labelColor block text-[10px]'>
@@ -105,30 +90,42 @@ export const MoneySummary: FC<{ metricsResponse: GetMetricsResponse }> = ({ metr
         )}
 
         {anyCosted && (
-          <div className='grid gap-4 md:grid-cols-2'>
+          <VerdictColumns>
             <div>
-              <Text variant='uppercase' className='text-labelColor text-textBaseSize mb-1 block'>
-                Best margin €
-              </Text>
-              <ul>
+              <ColHead>Best margin €</ColHead>
+              <VerdictList>
                 {top.map((r, i) => (
-                  <MarginRow key={`t-${r.techCardId ?? r.styleNumber ?? i}`} row={r} />
+                  <VerdictRow
+                    key={`t-${r.techCardId ?? r.styleNumber ?? i}`}
+                    name={<StyleName row={r} />}
+                    act={
+                      <ActPill tone='good'>{formatCurrency(parseDecimal(r.grossMargin))}</ActPill>
+                    }
+                  />
                 ))}
-              </ul>
+              </VerdictList>
             </div>
             {bottom.length > 0 && (
               <div>
-                <Text variant='uppercase' className='text-labelColor text-textBaseSize mb-1 block'>
-                  Losing / thin margin
-                </Text>
-                <ul>
-                  {bottom.map((r, i) => (
-                    <MarginRow key={`b-${r.techCardId ?? r.styleNumber ?? i}`} row={r} />
-                  ))}
-                </ul>
+                <ColHead crit>Losing / thin margin</ColHead>
+                <VerdictList>
+                  {bottom.map((r, i) => {
+                    const m = parseDecimal(r.grossMargin);
+                    const pct = r.grossMarginPct ?? 0;
+                    const crit = m < 0 || pct < 10;
+                    const label = m < 0 ? `−${formatCurrency(Math.abs(m))}` : `${pct.toFixed(0)}%`;
+                    return (
+                      <VerdictRow
+                        key={`b-${r.techCardId ?? r.styleNumber ?? i}`}
+                        name={<StyleName row={r} />}
+                        act={<ActPill tone={crit ? 'crit' : 'neutral'}>{label}</ActPill>}
+                      />
+                    );
+                  })}
+                </VerdictList>
               </div>
             )}
-          </div>
+          </VerdictColumns>
         )}
       </div>
     </ProductSection>

--- a/src/components/managers/page/components/ReorderList.tsx
+++ b/src/components/managers/page/components/ReorderList.tsx
@@ -21,7 +21,7 @@ const GroupHead: FC<{ title: string; total: ReactNode; crit?: boolean }> = ({
   crit,
 }) => (
   <div
-    className={`mb-1.5 flex items-baseline justify-between border-b border-textInactiveColor pb-1 text-textBaseSize uppercase ${crit ? 'text-error' : 'text-labelColor'}`}
+    className={`mb-1.5 flex items-baseline justify-between border-b border-textInactiveColor pb-1 text-[11px] tracking-wide uppercase ${crit ? 'text-error' : 'text-labelColor'}`}
   >
     <span>{title}</span>
     <span className='text-textColor font-bold tabular-nums'>{total}</span>
@@ -29,7 +29,7 @@ const GroupHead: FC<{ title: string; total: ReactNode; crit?: boolean }> = ({
 );
 
 const Buy: FC<{ children: ReactNode }> = ({ children }) => (
-  <span className='shrink-0 justify-self-end border border-textColor px-2 py-0.5 text-textBaseSize font-bold whitespace-nowrap uppercase'>
+  <span className='shrink-0 justify-self-end border border-textColor px-2 py-0.5 text-[11px] font-bold whitespace-nowrap uppercase'>
     {children}
   </span>
 );

--- a/src/components/managers/page/components/SizeVerdict.tsx
+++ b/src/components/managers/page/components/SizeVerdict.tsx
@@ -1,22 +1,17 @@
 import type { SizeRunEfficiencyRow } from 'api/proto-http/admin';
 import { FC } from 'react';
-import Text from 'ui/components/text';
 import { sizeVerdict } from '../productSignals';
 import { ProductNameLink } from './ProductNameLink';
 import { ProductSection } from './ProductSection';
+import { ActPill, ColHead, VerdictColumns, VerdictList, VerdictRow } from './VerdictList';
 
-const Row: FC<{ row: SizeRunEfficiencyRow; note: string }> = ({ row, note }) => (
-  <li className='flex items-baseline justify-between gap-3 py-1.5'>
-    <div className='min-w-0 max-w-[55%] font-bold'>
-      <ProductNameLink productId={row.productId} productName={row.productName} maxWidth='100%' />
-    </div>
-    <Text className='text-labelColor text-textBaseSize text-right'>
-      sold {row.unitsSold}/{row.unitsBought} · {note}
-    </Text>
-  </li>
-);
+function soldPct(row: SizeRunEfficiencyRow): number {
+  const bought = row.unitsBought ?? 0;
+  return bought > 0 ? Math.round(((row.unitsSold ?? 0) / bought) * 100) : 0;
+}
 
-/** Sizes as a verdict, not a bar chart: which styles were under- vs over-bought. */
+/** Sizes as a verdict, not a bar chart: which styles were under- vs over-bought. Two columns
+ *  (sold-out early = red, dead weight = gray) with a buy/cut act pill — matches products-final. */
 export const SizeVerdict: FC<{ sizeRunEfficiency: SizeRunEfficiencyRow[] | undefined }> = ({
   sizeRunEfficiency,
 }) => {
@@ -36,32 +31,50 @@ export const SizeVerdict: FC<{ sizeRunEfficiency: SizeRunEfficiencyRow[] | undef
       subtitle='— which sizes to buy deeper vs shallower next run'
       verdict={verdict}
     >
-      <div className='grid gap-4 md:grid-cols-2'>
+      <VerdictColumns>
         {under.length > 0 && (
           <div>
-            <Text variant='uppercase' className='text-labelColor text-textBaseSize mb-1 block'>
-              Buy deeper · sold out early
-            </Text>
-            <ul>
+            <ColHead crit>Buy deeper · sold out early</ColHead>
+            <VerdictList>
               {under.map((r, i) => (
-                <Row key={`u-${r.productId ?? i}`} row={r} note='buy deeper' />
+                <VerdictRow
+                  key={`u-${r.productId ?? i}`}
+                  name={
+                    <ProductNameLink
+                      productId={r.productId}
+                      productName={r.productName}
+                      maxWidth='100%'
+                    />
+                  }
+                  why={`${soldPct(r)}% sold — under-bought`}
+                  act={<ActPill tone='crit'>+ buy</ActPill>}
+                />
               ))}
-            </ul>
+            </VerdictList>
           </div>
         )}
         {over.length > 0 && (
           <div>
-            <Text variant='uppercase' className='text-labelColor text-textBaseSize mb-1 block'>
-              Buy shallower · dead weight
-            </Text>
-            <ul>
+            <ColHead>Buy shallower · dead weight</ColHead>
+            <VerdictList>
               {over.map((r, i) => (
-                <Row key={`o-${r.productId ?? i}`} row={r} note='buy shallower' />
+                <VerdictRow
+                  key={`o-${r.productId ?? i}`}
+                  name={
+                    <ProductNameLink
+                      productId={r.productId}
+                      productName={r.productName}
+                      maxWidth='100%'
+                    />
+                  }
+                  why={`${soldPct(r)}% sold — over-bought`}
+                  act={<ActPill>− cut</ActPill>}
+                />
               ))}
-            </ul>
+            </VerdictList>
           </div>
         )}
-      </div>
+      </VerdictColumns>
     </ProductSection>
   );
 };

--- a/src/components/managers/page/components/VerdictList.tsx
+++ b/src/components/managers/page/components/VerdictList.tsx
@@ -1,0 +1,68 @@
+import { FC, ReactNode } from 'react';
+
+/** Column header for the two-up verdict lists (stub `.col-h`): 11px uppercase, underlined;
+ *  red when it flags a problem (losing margin / sold-out sizes). */
+export const ColHead: FC<{ children: ReactNode; crit?: boolean }> = ({ children, crit }) => (
+  <div
+    className={`mb-1 border-b border-textInactiveColor pb-[3px] text-[11px] uppercase tracking-wide ${
+      crit ? 'text-error' : 'text-labelColor'
+    }`}
+  >
+    {children}
+  </div>
+);
+
+/** Small bordered action / amount pill (stub `.act`): green (good), red (crit), or ink (neutral). */
+export const ActPill: FC<{ children: ReactNode; tone?: 'good' | 'crit' | 'neutral' }> = ({
+  children,
+  tone = 'neutral',
+}) => {
+  const cls =
+    tone === 'good'
+      ? 'border-success text-success'
+      : tone === 'crit'
+        ? 'border-error text-error'
+        : 'border-textColor text-textColor';
+  return (
+    <span
+      className={`shrink-0 whitespace-nowrap border px-[7px] py-0.5 text-[11px] font-bold uppercase tabular-nums ${cls}`}
+    >
+      {children}
+    </span>
+  );
+};
+
+/** Tiny inline badge (stub `.pill`): gray, or red border+text when crit. */
+export const MiniPill: FC<{ children: ReactNode; crit?: boolean }> = ({ children, crit }) => (
+  <span
+    className={`mr-1 inline-block whitespace-nowrap border px-1.5 py-px text-[10px] uppercase tabular-nums ${
+      crit ? 'border-error text-error' : 'border-textInactiveColor text-labelColor'
+    }`}
+  >
+    {children}
+  </span>
+);
+
+/** One verdict row (stub `ul.rows li`): bold 12px name, optional gray reason, right-aligned
+ *  act pill. Wraps on narrow widths. */
+export const VerdictRow: FC<{ name: ReactNode; why?: ReactNode; act?: ReactNode }> = ({
+  name,
+  why,
+  act,
+}) => (
+  <li className='flex flex-wrap items-baseline justify-between gap-x-2.5 gap-y-1 border-b border-textInactiveColor/50 py-1.5 last:border-0'>
+    <span className='min-w-0 flex-[1_1_40%] truncate text-textBaseSize font-bold'>{name}</span>
+    {why != null && <span className='text-labelColor flex-[1_1_34%] text-textBaseSize'>{why}</span>}
+    {act}
+  </li>
+);
+
+/** Two-column verdict layout (stub `.two`). */
+export const VerdictColumns: FC<{ children: ReactNode }> = ({ children }) => (
+  <div className='grid gap-x-6 gap-y-3 md:grid-cols-2'>{children}</div>
+);
+
+/** Reset-styled `<ul>` for verdict rows. */
+export const VerdictList: FC<{ children: ReactNode }> = ({ children }) => (
+  <ul className='m-0 list-none p-0'>{children}</ul>
+);

--- a/src/components/managers/page/components/index.ts
+++ b/src/components/managers/page/components/index.ts
@@ -33,6 +33,7 @@ export { PromoBars } from './PromoBars';
 export { SectionHead } from './SectionHead';
 export { ShareBars } from './ShareBars';
 export { StatGrid } from './StatGrid';
+export { ActPill, ColHead, MiniPill, VerdictColumns, VerdictList, VerdictRow } from './VerdictList';
 export { ProfitabilityPanel } from './ProfitabilityPanel';
 export { PersistentKpiBar } from './PersistentKpiBar';
 export { ProductCharts } from './ProductCharts';

--- a/src/components/managers/page/tabs/GrowthTab.tsx
+++ b/src/components/managers/page/tabs/GrowthTab.tsx
@@ -10,8 +10,10 @@ import {
   CrossSellTable,
   GeographyCharts,
   NewVsReturningPanel,
+  StatGrid,
   TrafficCharts,
 } from '../components';
+import type { StatCell } from '../components/StatGrid';
 import { ProductSection } from '../components/ProductSection';
 import { countryDisplay } from '../countries';
 import {
@@ -43,30 +45,6 @@ const Drill: FC<{ summary: string; children: ReactNode }> = ({ summary, children
   </details>
 );
 
-const Stat: FC<{
-  label: string;
-  value: ReactNode;
-  sub?: string;
-  hero?: boolean;
-  tone?: string;
-}> = ({ label, value, sub, hero, tone }) => (
-  <div className='min-w-0'>
-    <Text variant='uppercase' className='text-labelColor block text-[10px]'>
-      {label}
-    </Text>
-    <Text
-      className={`font-bold tabular-nums ${hero ? 'text-2xl leading-none' : 'text-lg'} ${tone ?? ''}`}
-    >
-      {value}
-    </Text>
-    {sub && (
-      <Text variant='uppercase' className='text-labelColor block text-[10px]'>
-        {sub}
-      </Text>
-    )}
-  </div>
-);
-
 /**
  * Where growth comes from — decision-first, matching the approved stub grammar (ProductSection):
  * repeat economics (DB-true) → what to bundle → channels/ROAS → geography. GA4/channel signals stay
@@ -86,6 +64,25 @@ export function GrowthTab({ metricsResponse, channelRoas }: GrowthTabProps) {
   const newShare = split?.newRevenueSharePct ?? null;
   const hasRepeat =
     repeatRate.value > 0 || ordersPerCustomer.value > 0 || uniqueBuyers.value > 0 || !!split;
+
+  // Repeat hero: three big stats + an ink/gray revenue split bar (config: Repeat=hero).
+  const repeatStats: StatCell[] = [
+    {
+      label: 'Repeat rate',
+      value: `${repeatRate.value.toFixed(0)}%`,
+      sub: <span className='text-labelColor'>ordered before</span>,
+      big: true,
+    },
+    { label: 'Orders / customer', value: ordersPerCustomer.value.toFixed(1), big: true },
+    {
+      label: 'Days to 2nd order',
+      value:
+        daysBetweenOrders.value > 0 ? formatAvgDaysBetweenOrders(daysBetweenOrders.value) : '—',
+      big: true,
+    },
+  ];
+  const splitNewShare = split ? Math.max(0, Math.min(100, split.newRevenueSharePct ?? 0)) : 0;
+  const splitRetShare = 100 - splitNewShare;
 
   // Cross-sell pairs — same gating as the full table (real support + lift), ranked by lift.
   const allPairs = commerce?.crossSellPairs ?? [];
@@ -149,36 +146,39 @@ export function GrowthTab({ metricsResponse, channelRoas }: GrowthTabProps) {
               </Text>
             </div>
           )}
-          <div className='mb-4 grid grid-cols-2 gap-3 md:grid-cols-4'>
-            <Stat
-              label='Repeat rate'
-              value={`${repeatRate.value.toFixed(0)}%`}
-              sub='ordered before'
-              hero
-            />
-            <Stat
-              label='Orders / customer'
-              value={ordersPerCustomer.value.toFixed(1)}
-              sub='lifetime avg'
-            />
-            <Stat
-              label='Days to 2nd order'
-              value={
-                daysBetweenOrders.value > 0
-                  ? formatAvgDaysBetweenOrders(daysBetweenOrders.value)
-                  : '—'
-              }
-              sub='avg gap'
-            />
-            {uniqueBuyers.value > 0 && (
-              <Stat
-                label='Unique buyers'
-                value={formatNumber(uniqueBuyers.value)}
-                sub='this period'
-              />
-            )}
+          <StatGrid minCol={150} cells={repeatStats} />
+          {split && (
+            <div className='mt-3 space-y-2'>
+              <div className='flex h-[30px] border border-textColor'>
+                <div
+                  className='flex items-center justify-center overflow-hidden bg-textColor px-1 text-[10px] whitespace-nowrap text-bgColor'
+                  style={{ width: `${splitNewShare}%` }}
+                >
+                  {splitNewShare >= 20 ? `New revenue ${splitNewShare.toFixed(0)}%` : ''}
+                </div>
+                <div
+                  className='flex items-center justify-center overflow-hidden bg-textInactiveColor px-1 text-[10px] whitespace-nowrap'
+                  style={{ width: `${splitRetShare}%` }}
+                >
+                  {splitRetShare >= 14 ? `Repeat ${splitRetShare.toFixed(0)}%` : ''}
+                </div>
+              </div>
+              <Text variant='uppercase' className='text-labelColor block text-[10px]'>
+                growth {splitNewShare >= 50 ? 'new-led' : 'repeat-led'} — a rising repeat rate is
+                the flywheel to watch
+              </Text>
+            </div>
+          )}
+          <div className='mt-3'>
+            <Drill summary='Full new vs returning'>
+              {uniqueBuyers.value > 0 && (
+                <Text className='text-labelColor text-textBaseSize'>
+                  {formatNumber(uniqueBuyers.value)} unique buyers this period.
+                </Text>
+              )}
+              <NewVsReturningPanel split={split} />
+            </Drill>
           </div>
-          <NewVsReturningPanel split={split} />
         </ProductSection>
       )}
 

--- a/src/components/managers/page/tabs/ThisWeekTab.tsx
+++ b/src/components/managers/page/tabs/ThisWeekTab.tsx
@@ -132,7 +132,7 @@ const TopMoverCards: FC<{
 }> = ({ products, source }) => (
   <div className='grid grid-cols-2 gap-3 sm:grid-cols-4'>
     {products.map((p, idx) => (
-      <div key={idx} className='border border-textInactiveColor bg-bgSecondary/30 p-3'>
+      <div key={idx} className='border border-textInactiveColor p-3'>
         <ProductNameLink productId={p.productId} productName={p.productName} maxWidth='100%' />
         <Text className='mt-1 block font-bold text-lg tabular-nums'>
           {formatCurrency(p.revenue)}
@@ -144,7 +144,7 @@ const TopMoverCards: FC<{
       </div>
     ))}
     {source && (
-      <div className='border border-textInactiveColor bg-bgSecondary/30 p-3'>
+      <div className='border border-textInactiveColor p-3'>
         <Text variant='uppercase' className='text-labelColor block text-[10px]'>
           Top source
         </Text>

--- a/src/components/managers/tech-card/components/colorway-recipe.tsx
+++ b/src/components/managers/tech-card/components/colorway-recipe.tsx
@@ -28,6 +28,11 @@ import {
 const cell = 'w-full border border-textInactiveColor bg-bgColor px-2 py-1 text-textBaseSize';
 
 const REJECTED = 'TECH_CARD_LAB_DIP_STATUS_REJECTED';
+const APPROVED = 'TECH_CARD_LAB_DIP_STATUS_APPROVED';
+const UNKNOWN_LAB_DIP = 'TECH_CARD_LAB_DIP_STATUS_UNKNOWN';
+
+// Ink → gray fibre shades for the composition bar (grays only, per the brand palette).
+const COMP_SHADES = ['#111111', '#666666', '#aaaaaa', '#cccccc', '#dddddd'];
 
 // Measured sections cost by a rate (consumption, per metre/gram) and support per-size grading; the
 // rest are counted (quantity, per piece). Mirrors colorways-field.tsx so the per-size grid only
@@ -169,6 +174,24 @@ function buildLabDipRequest(
 const labDipStatusLabel = new Map<common_TechCardLabDipStatus, string>(
   techCardLabDipStatusOptions.map((o) => [o.value, o.label]),
 );
+
+// Lab-dip status badge (approved = green, pending = blue/warning, rejected = red). Surfaces the
+// colour-approval state on the roster row and the collapsed lab-dip line (config: LabState B).
+function LabDipBadge({ status }: { status?: string }) {
+  if (!status || status === UNKNOWN_LAB_DIP) return null;
+  const label = labDipStatusLabel.get(status as common_TechCardLabDipStatus) ?? status;
+  const cls =
+    status === APPROVED
+      ? 'border-success text-success'
+      : status === REJECTED
+        ? 'border-error text-error'
+        : 'border-warning text-warning';
+  return (
+    <span className={`shrink-0 border px-1.5 py-px text-[10px] whitespace-nowrap uppercase ${cls}`}>
+      {label}
+    </span>
+  );
+}
 
 function labDipSaveErrorMessage(e: unknown): string {
   const status = (e as { status?: number } | undefined)?.status;
@@ -627,6 +650,18 @@ function LabDipEditor({
     });
   };
 
+  // Compact one-line summary shown while collapsed (config: LabDeep B): round · decided-by ·
+  // decided-date (or the reject reason when rejected).
+  const labDipSummary = [
+    draft.labDipRound ? `R${draft.labDipRound}` : '',
+    draft.labDipDecidedBy,
+    draft.labDipStatus === REJECTED && draft.labDipRejectReason
+      ? `“${draft.labDipRejectReason}”`
+      : draft.labDipDecidedAt,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
   return (
     <div className='border-t border-textColor pt-4'>
       <button
@@ -634,14 +669,29 @@ function LabDipEditor({
         className='flex w-full items-center justify-between gap-2 text-left'
         onClick={() => setOpen((o) => !o)}
       >
-        <Text variant='uppercase' size='small'>
+        <Text variant='uppercase' size='small' className='shrink-0'>
           {open ? '▾' : '▸'} dye · lab-dip
         </Text>
-        <Text variant='label' size='small'>
-          {dirty
-            ? 'unsaved'
-            : labDipStatusLabel.get(draft.labDipStatus as common_TechCardLabDipStatus) ?? '—'}
-        </Text>
+        <span className='flex min-w-0 shrink items-center justify-end gap-2'>
+          {dirty ? (
+            <Text variant='label' size='small'>
+              unsaved
+            </Text>
+          ) : draft.labDipStatus === UNKNOWN_LAB_DIP && !labDipSummary ? (
+            <Text variant='label' size='small'>
+              —
+            </Text>
+          ) : (
+            <>
+              <LabDipBadge status={draft.labDipStatus} />
+              {labDipSummary && (
+                <Text variant='label' size='small' className='truncate'>
+                  {labDipSummary}
+                </Text>
+              )}
+            </>
+          )}
+        </span>
       </button>
       {open && (
         <div className='mt-3 flex flex-col gap-3'>
@@ -857,10 +907,13 @@ function ColorwayRecipeEditor({
             {colorway.baseSku ? ` · ${colorway.baseSku}` : ''}
           </Text>
         </span>
-        <Text variant='label' size='small'>
-          {usages.length} material{usages.length === 1 ? '' : 's'}
-          {dirty ? ' · unsaved' : ''}
-        </Text>
+        <span className='flex shrink-0 items-center gap-2'>
+          <LabDipBadge status={colorway.labDipStatus} />
+          <Text variant='label' size='small'>
+            {usages.length} material{usages.length === 1 ? '' : 's'}
+            {dirty ? ' · unsaved' : ''}
+          </Text>
+        </span>
       </button>
 
       {open && (
@@ -886,17 +939,32 @@ function ColorwayRecipeEditor({
             ))
           )}
 
-          {/* #29 derived composition — approximate, parsed from BOM free-text, weighted by consumption */}
+          {/* #29 derived composition — approximate, parsed from BOM free-text, weighted by
+              consumption. Shown as a fibre bar (config: Recipe A + composition bar from BOM). */}
           {derived.fibers.length > 0 && (
             <div className='border border-textInactiveColor p-2'>
               <Text variant='uppercase' size='small'>
                 derived composition (approx · from BOM)
               </Text>
-              <Text size='small' className='mt-1'>
-                {derived.fibers.map((f) => `${f.percent}% ${f.name}`).join(' · ')}
-              </Text>
+              <div className='mt-1.5 flex h-4 w-full overflow-hidden border border-textInactiveColor'>
+                {derived.fibers.map((f, i) => (
+                  <div
+                    key={`${f.name}-${i}`}
+                    className='flex items-center justify-center overflow-hidden px-1 text-[10px] whitespace-nowrap'
+                    style={{
+                      width: `${f.percent}%`,
+                      backgroundColor: COMP_SHADES[i % COMP_SHADES.length],
+                      color: i < 2 ? '#fff' : '#000',
+                    }}
+                    title={`${f.name} ${f.percent}%`}
+                  >
+                    {f.percent >= 12 ? `${f.name} ${f.percent}%` : ''}
+                  </div>
+                ))}
+              </div>
               <Text variant='label' size='small' className='mt-1 block'>
-                parsed from each article’s free-text composition, weighted by consumption
+                {derived.fibers.map((f) => `${f.percent}% ${f.name}`).join(' · ')} · weighted by
+                consumption
                 {derived.skipped > 0
                   ? ` · ${derived.skipped} article${derived.skipped > 1 ? 's' : ''} excluded (no readable composition)`
                   : ''}

--- a/src/components/managers/tech-card/components/costing-field.tsx
+++ b/src/components/managers/tech-card/components/costing-field.tsx
@@ -58,6 +58,37 @@ export function CostingField({ techCard }: { techCard?: common_TechCard }) {
     !!rollup?.orderCost?.value ||
     colorwayCosts.length > 0;
 
+  // Grouped cost tree (config: Breakdown B): manual articles from the form fields, materials +
+  // unit cost from the server rollup. Materials aren't broken out by section (the rollup returns
+  // only the per-unit total), so that group shows its subtotal alone.
+  const costing = (useWatch({ control, name: 'costing' }) ?? {}) as {
+    cmtCost?: string;
+    hardwareCost?: string;
+    packagingCost?: string;
+    logisticsCost?: string;
+    overheadCost?: string;
+    defectPercent?: string;
+    currency?: string;
+  };
+  const num = (s?: string) => {
+    const n = parseFloat((s ?? '').replace(',', '.'));
+    return Number.isFinite(n) ? n : 0;
+  };
+  const cur = costing.currency || rollup?.baseCurrency || '';
+  const money = (n: number) => `${cur ? `${cur} ` : ''}${n.toFixed(2)}`;
+  const articleRows = [
+    { l: 'CMT', v: num(costing.cmtCost) },
+    { l: 'Hardware', v: num(costing.hardwareCost) },
+    { l: 'Packaging', v: num(costing.packagingCost) },
+    { l: 'Logistics', v: num(costing.logisticsCost) },
+    { l: 'Overhead', v: num(costing.overheadCost) },
+  ].filter((r) => r.v > 0);
+  const articlesSubtotal = articleRows.reduce((s, r) => s + r.v, 0);
+  const materialsPerUnitStr = decimalToInput(rollup?.materialsPerUnit);
+  const unitCostStr = decimalToInput(rollup?.unitCost);
+  const defect = num(costing.defectPercent);
+  const showTree = articleRows.length > 0 || !!materialsPerUnitStr || !!unitCostStr;
+
   return (
     <div className='space-y-3'>
       <Text variant='label' size='small'>
@@ -100,6 +131,50 @@ export function CostingField({ techCard }: { techCard?: common_TechCard }) {
         </Text>
         {hasRollup ? (
           <>
+            {/* Grouped cost tree (config: Breakdown B) — materials subtotal, then the manual
+                articles, then the unit cost total. */}
+            {showTree && (
+              <div className='border border-textInactiveColor'>
+                <div className='flex items-baseline justify-between border-b border-textInactiveColor px-3 py-1.5'>
+                  <Text variant='uppercase' className='text-[11px] font-bold tracking-wide'>
+                    Materials
+                  </Text>
+                  <Text className='text-textBaseSize font-bold tabular-nums'>
+                    {materialsPerUnitStr ? money(num(materialsPerUnitStr)) : '—'}
+                  </Text>
+                </div>
+                {articleRows.length > 0 && (
+                  <>
+                    <div className='flex items-baseline justify-between border-b border-textInactiveColor px-3 py-1.5'>
+                      <Text variant='uppercase' className='text-[11px] font-bold tracking-wide'>
+                        Articles
+                      </Text>
+                      <Text className='text-textBaseSize font-bold tabular-nums'>
+                        {money(articlesSubtotal)}
+                      </Text>
+                    </div>
+                    {articleRows.map((r) => (
+                      <div
+                        key={r.l}
+                        className='flex items-baseline justify-between border-b border-textInactiveColor/50 px-3 py-1 pl-6'
+                      >
+                        <Text className='text-labelColor text-textBaseSize'>{r.l}</Text>
+                        <Text className='text-textBaseSize tabular-nums'>{money(r.v)}</Text>
+                      </div>
+                    ))}
+                  </>
+                )}
+                <div className='flex items-baseline justify-between px-3 py-1.5'>
+                  <Text variant='uppercase' className='text-[11px] font-bold tracking-wide'>
+                    Unit cost{defect > 0 ? ` (defect ${defect}% incl.)` : ''}
+                  </Text>
+                  <Text className='text-textBaseSize font-bold tabular-nums'>
+                    {unitCostStr ? money(num(unitCostStr)) : '—'}
+                  </Text>
+                </div>
+              </div>
+            )}
+
             {/* Summary-first: headline per-unit / per-order figures as tiles, before the
                 per-currency detail and per-colourway breakdown. */}
             <div className='grid grid-cols-2 gap-2 sm:grid-cols-4'>

--- a/src/components/managers/tech-card/components/dev-expenses-field.tsx
+++ b/src/components/managers/tech-card/components/dev-expenses-field.tsx
@@ -114,6 +114,16 @@ export function DevExpensesField({
   );
   const scopedHasUnconverted = scoped && expenses.some((e) => !e.amountBase?.value);
 
+  // Dev summary (config: DevRnD B) — total + amortised per-unit + by-kind bars.
+  const byKind = (summary?.byKind ?? [])
+    .map((b) => ({ kind: b.kind ?? '—', amt: parseDecimalNumber(b.amountBase?.value) || 0 }))
+    .filter((b) => b.amt > 0)
+    .sort((a, b) => b.amt - a.amt);
+  const maxKind = Math.max(...byKind.map((b) => b.amt), 1);
+  const totalBaseNum = parseDecimalNumber(summary?.totalBase?.value) || 0;
+  const orderQty = summary?.orderQty || 0;
+  const devPerUnit = orderQty > 0 ? totalBaseNum / orderQty : 0;
+
   if (isLoading) return <Text size='small'>loading…</Text>;
 
   return (
@@ -135,24 +145,67 @@ export function DevExpensesField({
             </div>
           )
         : summary && (
-            <div className='flex flex-col gap-1 border border-textInactiveColor p-3'>
-              <Text size='small'>
-                total dev cost (EUR): {decimalToInput(summary.totalBase) || '—'}
-                {summary.hasUnconverted ? ' ⚠ partial (some rows have no FX rate)' : ''}
+            <div className='flex flex-col gap-3 border border-textInactiveColor p-3'>
+              <div className='grid grid-cols-2 gap-2 sm:grid-cols-3'>
+                <div>
+                  <Text variant='uppercase' className='text-labelColor block text-[10px]'>
+                    Total dev (EUR)
+                  </Text>
+                  <Text className='block font-bold text-lg tabular-nums'>
+                    {decimalToInput(summary.totalBase) || '—'}
+                  </Text>
+                  <Text variant='uppercase' className='text-labelColor block text-[10px]'>
+                    {expenses.length} line{expenses.length === 1 ? '' : 's'}
+                    {summary.hasUnconverted ? ' · partial' : ''}
+                  </Text>
+                </div>
+                <div>
+                  <Text variant='uppercase' className='text-labelColor block text-[10px]'>
+                    Per unit {orderQty > 0 ? `(÷${orderQty})` : ''}
+                  </Text>
+                  <Text className='block font-bold text-lg tabular-nums'>
+                    {devPerUnit > 0 ? devPerUnit.toFixed(2) : '—'}
+                  </Text>
+                  <Text variant='uppercase' className='text-labelColor block text-[10px]'>
+                    amortised · informational
+                  </Text>
+                </div>
+                <div>
+                  <Text variant='uppercase' className='text-labelColor block text-[10px]'>
+                    Unit cost + dev
+                  </Text>
+                  <Text className='block font-bold text-lg tabular-nums'>
+                    {decimalToInput(summary.unitCostWithDev) || '—'}
+                  </Text>
+                  <Text variant='uppercase' className='text-labelColor block text-[10px]'>
+                    reference, not COGS
+                  </Text>
+                </div>
+              </div>
+              {byKind.length > 0 && (
+                <div className='space-y-1'>
+                  {byKind.map((b) => (
+                    <div
+                      key={b.kind}
+                      className='grid grid-cols-[110px_1fr_64px] items-center gap-2'
+                    >
+                      <Text className='truncate text-textBaseSize uppercase'>{b.kind}</Text>
+                      <span className='h-3 bg-bgSecondary'>
+                        <span
+                          className='block h-3 bg-textColor'
+                          style={{ width: `${(b.amt / maxKind) * 100}%` }}
+                        />
+                      </span>
+                      <Text className='text-right text-textBaseSize tabular-nums'>
+                        {b.amt.toFixed(2)}
+                      </Text>
+                    </div>
+                  ))}
+                </div>
+              )}
+              <Text variant='label' size='small'>
+                dev is a period R&amp;D cost, amortised for info only — NOT folded into unit COGS
               </Text>
-              {(summary.byKind ?? []).length > 0 && (
-                <Text variant='inactive' size='small'>
-                  {(summary.byKind ?? [])
-                    .map((b) => `${b.kind}: ${decimalToInput(b.amountBase) || '—'}`)
-                    .join(' · ')}
-                </Text>
-              )}
-              {summary.unitCostWithDev?.value && (
-                <Text variant='inactive' size='small'>
-                  unit cost incl. dev (reference, {summary.orderQty || 0} units):{' '}
-                  {decimalToInput(summary.unitCostWithDev)} — amortised, not the COGS
-                </Text>
-              )}
             </div>
           )}
 

--- a/src/components/managers/tech-card/components/packaging-field.tsx
+++ b/src/components/managers/tech-card/components/packaging-field.tsx
@@ -1,3 +1,4 @@
+import { useFormContext, useWatch } from 'react-hook-form';
 import Text from 'ui/components/text';
 import ComboField from 'ui/form/fields/combo-field';
 import InputField from 'ui/form/fields/input-field';
@@ -8,6 +9,48 @@ import {
   insertsOptions,
   polybagOptions,
 } from './tech-card-options';
+
+type PackagingValues = {
+  foldingMethod?: string;
+  polybag?: string;
+  weightNetGrams?: number | string;
+  weightGrossGrams?: number | string;
+  unitsPerBox?: number | string;
+  bagSticker?: string;
+  inserts?: string;
+};
+
+// Packaging summary card (config: Packaging A) — the key pack facts as stat tiles, always
+// visible, so the spec reads at a glance instead of hiding in a collapsed block that looks empty.
+function PackagingSummary() {
+  const { control } = useFormContext();
+  const pkg = (useWatch({ control, name: 'packaging' }) ?? {}) as PackagingValues;
+  const txt = (v?: string | number) => (v || v === 0 ? String(v) : '—');
+  const wt = (g?: string | number) => {
+    const n = Number(g);
+    return Number.isFinite(n) && n > 0 ? `${n} g` : '—';
+  };
+  const tiles = [
+    { k: 'Fold', v: txt(pkg.foldingMethod) },
+    { k: 'Polybag', v: txt(pkg.polybag) },
+    { k: 'Net weight', v: wt(pkg.weightNetGrams) },
+    { k: 'Gross (carton)', v: wt(pkg.weightGrossGrams) },
+    { k: 'Units / box', v: txt(pkg.unitsPerBox) },
+    { k: 'Sticker / inserts', v: [pkg.bagSticker, pkg.inserts].filter(Boolean).join(' · ') || '—' },
+  ];
+  return (
+    <div className='grid grid-cols-2 border-l border-t border-textInactiveColor sm:grid-cols-3'>
+      {tiles.map((t) => (
+        <div key={t.k} className='border-r border-b border-textInactiveColor px-3 py-2'>
+          <Text variant='uppercase' className='text-labelColor block text-[10px]'>
+            {t.k}
+          </Text>
+          <Text className='block text-textBaseSize font-bold break-words'>{t.v}</Text>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 // Packaging spec (Sheet «Этикетки и упаковка»). 1:1 — sent as unset when every field
 // is blank (see mapPackagingOut). Nothing here is required by the backend, so the whole
@@ -20,86 +63,89 @@ import {
 // in/out) and prints to the tech pack; only their placement changes.
 export function PackagingField() {
   return (
-    <details>
-      <summary className='cursor-pointer select-none text-textBaseSize uppercase text-labelColor hover:text-text'>
-        packaging spec — всё опционально, заполняйте только нужное фабрике
-      </summary>
-      <div className='mt-3 space-y-3'>
-        {/* Per-garment: how this style is folded/bagged and its own net weight. */}
-        <div className='grid grid-cols-1 gap-3 lg:grid-cols-2'>
-          <ComboField
-            name='packaging.foldingMethod'
-            label='folding method'
-            options={foldingMethodOptions}
-          />
-          <ComboField
-            name='packaging.polybag'
-            label='polybag (type / size)'
-            options={polybagOptions}
-          />
-          <InputField
-            name='packaging.weightNetGrams'
-            type='number'
-            valueAsNumber
-            keyboardRestriction={/[0-9]/}
-            label='weight net (g)'
-          />
-        </div>
+    <div className='space-y-3'>
+      <PackagingSummary />
+      <details>
+        <summary className='cursor-pointer select-none text-textBaseSize uppercase text-labelColor hover:text-text'>
+          edit packaging spec — всё опционально, заполняйте только нужное фабрике
+        </summary>
+        <div className='mt-3 space-y-3'>
+          {/* Per-garment: how this style is folded/bagged and its own net weight. */}
+          <div className='grid grid-cols-1 gap-3 lg:grid-cols-2'>
+            <ComboField
+              name='packaging.foldingMethod'
+              label='folding method'
+              options={foldingMethodOptions}
+            />
+            <ComboField
+              name='packaging.polybag'
+              label='polybag (type / size)'
+              options={polybagOptions}
+            />
+            <InputField
+              name='packaging.weightNetGrams'
+              type='number'
+              valueAsNumber
+              keyboardRestriction={/[0-9]/}
+              label='weight net (g)'
+            />
+          </div>
 
-        <TextareaField name='packaging.notes' label='notes' rows={2} maxLength={2000} />
+          <TextareaField name='packaging.notes' label='notes' rows={2} maxLength={2000} />
 
-        {/* Per-shipment logistics + brand-wide label defaults — rarely edited per style, so
+          {/* Per-shipment logistics + brand-wide label defaults — rarely edited per style, so
             they're one level deeper. All fields still round-trip and print to the tech pack. */}
-        <details className='border border-textInactiveColor'>
-          <summary className='cursor-pointer select-none px-3 py-2 text-textBaseSize uppercase hover:bg-highlightColor/5'>
-            shipping carton (optional) — логистика отгрузки, не дизайн изделия
-          </summary>
-          <div className='flex flex-col gap-3 border-t border-textInactiveColor p-3'>
-            <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
-              <InputField
-                name='packaging.unitsPerBox'
-                type='number'
-                valueAsNumber
-                keyboardRestriction={/[0-9]/}
-                label='units per box'
-              />
-              <InputField
-                name='packaging.boxMarking'
-                label='box marking'
-                placeholder='style number + qty'
-              />
-              <InputField
-                name='packaging.boxDimensions'
-                label='box dimensions (L×W×H)'
-                placeholder='напр. 40×30×20'
-              />
-              <InputField
-                name='packaging.weightGrossGrams'
-                type='number'
-                valueAsNumber
-                keyboardRestriction={/[0-9]/}
-                label='weight gross (g)'
-              />
-            </div>
-
-            {/* Brand-wide defaults — usually the same for every style (see the Labels tab).
-                Kept here (still in the schema + PDF) so they don't restate Labels up top. */}
-            <div className='space-y-3 border-t border-textInactiveColor pt-3'>
-              <Text variant='label' size='small'>
-                бренд-умолчания — обычно одинаковы для всех стилей (см. вкладку Labels)
-              </Text>
+          <details className='border border-textInactiveColor'>
+            <summary className='cursor-pointer select-none px-3 py-2 text-textBaseSize uppercase hover:bg-highlightColor/5'>
+              shipping carton (optional) — логистика отгрузки, не дизайн изделия
+            </summary>
+            <div className='flex flex-col gap-3 border-t border-textInactiveColor p-3'>
               <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
-                <ComboField
-                  name='packaging.bagSticker'
-                  label='bag sticker'
-                  options={bagStickerOptions}
+                <InputField
+                  name='packaging.unitsPerBox'
+                  type='number'
+                  valueAsNumber
+                  keyboardRestriction={/[0-9]/}
+                  label='units per box'
                 />
-                <ComboField name='packaging.inserts' label='inserts' options={insertsOptions} />
+                <InputField
+                  name='packaging.boxMarking'
+                  label='box marking'
+                  placeholder='style number + qty'
+                />
+                <InputField
+                  name='packaging.boxDimensions'
+                  label='box dimensions (L×W×H)'
+                  placeholder='напр. 40×30×20'
+                />
+                <InputField
+                  name='packaging.weightGrossGrams'
+                  type='number'
+                  valueAsNumber
+                  keyboardRestriction={/[0-9]/}
+                  label='weight gross (g)'
+                />
+              </div>
+
+              {/* Brand-wide defaults — usually the same for every style (see the Labels tab).
+                Kept here (still in the schema + PDF) so they don't restate Labels up top. */}
+              <div className='space-y-3 border-t border-textInactiveColor pt-3'>
+                <Text variant='label' size='small'>
+                  бренд-умолчания — обычно одинаковы для всех стилей (см. вкладку Labels)
+                </Text>
+                <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
+                  <ComboField
+                    name='packaging.bagSticker'
+                    label='bag sticker'
+                    options={bagStickerOptions}
+                  />
+                  <ComboField name='packaging.inserts' label='inserts' options={insertsOptions} />
+                </div>
               </div>
             </div>
-          </div>
-        </details>
-      </div>
-    </details>
+          </details>
+        </div>
+      </details>
+    </div>
   );
 }


### PR DESCRIPTION
Promotes the beta analytics + tech-card redesign to prod. All changes verified on admin.beta.grbpwr.com.

**Analytics (matched to the approved HTML docs):**
- Products: verdict pills (green/red), 12px names, buckets, drops cards
- Today: Health sec-h + status pill + act-now rows; white top-mover cards
- Revenue: two KPI grids + waterfall (gray deduction bars), green big-basket band, share bars
- Growth: 3 big stats + ink/gray split bar + drill

**Tech-card:**
- Construction: summary stat strip (ops · SAM · zones · unpinned)
- Colorways: lab-dip status badge on roster + lab-dip line; composition bar from BOM; compact lab-dip
- Costing: grouped cost tree (Materials/Articles/Unit cost); dev summary (tiles + by-kind bars)
- Labels: packaging summary card (was collapsed-empty)

**Colors:** every coral (opacity-red washes / salmon bars) replaced with pure red where it means loss, gray shades otherwise — brand tokens only.

No backend changes (uses existing RPC fields). No file overlap with the prod-only PLM commit — clean merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)