### PR TITLE
Accounting phase-2 VAT admin UI

### DIFF
--- a/src/api/proto-http/admin/index.ts
+++ b/src/api/proto-http/admin/index.ts
@@ -2883,6 +2883,11 @@ export type CreateCustomOrderRequest = {
   shipmentCarrierId: number | undefined;
   currency: string | undefined;
   shipmentCost: googletype_Decimal | undefined;
+  // buyer_vat_id is the B2B buyer's EU VAT identifier (optional; phase 2, wave 1). Its presence
+  // drives the wdt / reverse-charge VAT classification (intra-community supply, 0%) and 4310
+  // wholesale revenue instead of the B2C path. Format: 2-letter country prefix + 8..12 alphanumeric
+  // characters (e.g. DE123456789); free-form, VIES lookup is out of scope.
+  buyerVatId: string | undefined;
 };
 
 // CustomOrderItemInsert allows custom pricing per item (admin-only). Admin addresses the variant by its
@@ -6434,6 +6439,14 @@ export type ReceiveMaterialStockRequest = {
   supplierDoc: string | undefined;
   occurredAt: string | undefined;
   comment: string | undefined;
+  // input_vat_amount / input_vat_regime record this purchase receipt's recoverable input VAT (base
+  // currency EUR) and its treatment, for the extended M1 posting rule (phase 2, wave 1). Both
+  // optional; when either is set, both must be set (amount >= 0, regime one of
+  // wnt|import|domestic_pl|domestic_uk). unit_cost stays NET — do NOT also fold this VAT into it, or
+  // it is double-counted (inflated inventory/COGS AND a 2080 recovery); the server rejects an
+  // input_vat_amount above 30% of the net line cost as a likely gross unit_cost.
+  inputVatAmount: googletype_Decimal | undefined;
+  inputVatRegime: string | undefined;
 };
 
 export type ReceiveMaterialStockResponse = {
@@ -7154,6 +7167,55 @@ export type GetAcctReconciliationResponse = {
   finishedGoods: AcctReconBlock | undefined;
   pending: AcctReconBlock | undefined;
   unpostedMovements: AcctReconBlock | undefined;
+  vat: AcctReconBlock | undefined;
+};
+
+export type GetVatReturnPLRequest = {
+  // month: YYYY-MM-DD, any day within the target filing month (normalised to the 1st).
+  month: string | undefined;
+};
+
+// GetVatReturnPLResponse is the JPK_VAT monthly aggregate (filed by the 25th). Output VAT is split
+// by regime (domestic PL, WNT/import self-charge; OSS shown for reference only — OSS is filed via
+// GetOssReturn, not JPK, and is excluded from net_payable), input VAT is split by purchase type, and
+// net_payable is the resulting liability. Caveats aggregates the period's per-entry caveats.
+export type GetVatReturnPLResponse = {
+  month: string | undefined;
+  outputDomestic: googletype_Decimal | undefined;
+  outputWntSelfCharge: googletype_Decimal | undefined;
+  ossInfoTotal: googletype_Decimal | undefined;
+  inputDomestic: googletype_Decimal | undefined;
+  inputWnt: googletype_Decimal | undefined;
+  inputImport: googletype_Decimal | undefined;
+  netPayable: googletype_Decimal | undefined;
+  // UK is a different jurisdiction — filed on the UK return, deliberately NOT in net_payable.
+  outputUkStockDomestic: googletype_Decimal | undefined;
+  inputUkDomestic: googletype_Decimal | undefined;
+  // Zero-rated NET revenue bases JPK still declares (carry no VAT, not in net_payable).
+  netWdt: googletype_Decimal | undefined;
+  netExport: googletype_Decimal | undefined;
+  caveats: string[] | undefined;
+};
+
+export type GetOssReturnRequest = {
+  // quarter: YYYY-MM-DD, first day of the quarter (any day within the quarter is accepted and
+  // snapped to that quarter's first day — see dto.ParseAcctQuarterStart).
+  quarter: string | undefined;
+};
+
+// AcctOssRow is one destination country's OSS B2C line: country, applied rate, net taxable base and VAT.
+export type AcctOssRow = {
+  country: string | undefined;
+  ratePct: googletype_Decimal | undefined;
+  net: googletype_Decimal | undefined;
+  vat: googletype_Decimal | undefined;
+};
+
+export type GetOssReturnResponse = {
+  quarterStart: string | undefined;
+  rows: AcctOssRow[] | undefined;
+  totalNet: googletype_Decimal | undefined;
+  totalVat: googletype_Decimal | undefined;
 };
 
 export interface AdminService {
@@ -7723,6 +7785,14 @@ export interface AdminService {
   // COGS, materials, finished goods) and lists what is deliberately left unposted, over
   // [from, to) (to exclusive).
   GetAcctReconciliation(request: GetAcctReconciliationRequest): Promise<GetAcctReconciliationResponse>;
+  // GetVatReturnPL returns the JPK_VAT monthly aggregate (filed by the 25th): output VAT by regime
+  // (domestic PL, WNT/import self-charge, OSS shown for reference only), input VAT by type, and the
+  // net payable. Source-type-agnostic and aggregated by the payment period, so it survives wave 2's
+  // prepayment split; refunds net with a minus sign.
+  GetVatReturnPL(request: GetVatReturnPLRequest): Promise<GetVatReturnPLResponse>;
+  // GetOssReturn returns the quarterly OSS aggregate: EU B2C sales (vat_regime=oss) broken down by
+  // destination country with the applied rate, net and VAT.
+  GetOssReturn(request: GetOssReturnRequest): Promise<GetOssReturnResponse>;
 }
 
 type RequestType = {
@@ -12614,6 +12684,46 @@ export function createAdminServiceClient(
         service: "AdminService",
         method: "GetAcctReconciliation",
       }) as Promise<GetAcctReconciliationResponse>;
+    },
+    GetVatReturnPL(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/accounting/reports/vat-return`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      if (request.month) {
+        queryParams.push(`month=${encodeURIComponent(request.month.toString())}`)
+      }
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "GET",
+        body,
+      }, {
+        service: "AdminService",
+        method: "GetVatReturnPL",
+      }) as Promise<GetVatReturnPLResponse>;
+    },
+    GetOssReturn(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/accounting/reports/oss-return`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      if (request.quarter) {
+        queryParams.push(`quarter=${encodeURIComponent(request.quarter.toString())}`)
+      }
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "GET",
+        body,
+      }, {
+        service: "AdminService",
+        method: "GetOssReturn",
+      }) as Promise<GetOssReturnResponse>;
     },
   };
 }

--- a/src/components/managers/accounting/reports/components/reconciliation.tsx
+++ b/src/components/managers/accounting/reports/components/reconciliation.tsx
@@ -19,7 +19,8 @@ type ReconKey =
   | 'materials'
   | 'finishedGoods'
   | 'pending'
-  | 'unpostedMovements';
+  | 'unpostedMovements'
+  | 'vat';
 
 const BLOCKS: { key: ReconKey; label: string }[] = [
   { key: 'revenue', label: 'revenue' },
@@ -29,6 +30,7 @@ const BLOCKS: { key: ReconKey; label: string }[] = [
   { key: 'finishedGoods', label: 'finished goods' },
   { key: 'pending', label: 'pending' },
   { key: 'unpostedMovements', label: 'unposted movements' },
+  { key: 'vat', label: 'vat' },
 ];
 
 // A delta within a cent reads as "matched" (§8.5). NaN (missing delta) → treated as 0 → matched.
@@ -197,7 +199,7 @@ export function ReconciliationTab({ from, to }: Props) {
               key={key}
               block={data?.[key]}
               label={label}
-              linkOrders={key !== 'materials' && key !== 'unpostedMovements'}
+              linkOrders={key !== 'materials' && key !== 'unpostedMovements' && key !== 'vat'}
               isFinishedGoods={key === 'finishedGoods'}
               isPending={key === 'pending'}
             />

--- a/src/components/managers/accounting/reports/components/vat.tsx
+++ b/src/components/managers/accounting/reports/components/vat.tsx
@@ -1,0 +1,190 @@
+import { googletype_Decimal } from 'api/proto-http/admin';
+import Text from 'ui/components/text';
+import { useOssReturn, useVatReturnPL } from '../../utils/hooks';
+import { AmountCell } from '../../components/amount-cell';
+import { CopyTableButton } from './copy-table-button';
+import { CaveatsNote, formatMonthLabel, formatPercent, ReportState } from './report-utils';
+
+type Props = {
+  // Range `from` from the shared search-params contract. VAT is a monthly return, OSS a quarterly
+  // one, so both dimensions are derived from `from` (the backend normalises to 1st / quarter start).
+  from: string;
+};
+
+type VatRow = {
+  label: string;
+  value?: googletype_Decimal;
+  // Rows the JPK return declares but that are settled on another return (OSS, UK) or carry no VAT
+  // (zero-rated bases) — kept visible for completeness, flagged so they're not read into net_payable.
+  note?: string;
+  bold?: boolean;
+};
+
+// First-of-month key ('YYYY-MM-01') of a YYYY-MM-DD date, for the monthly JPK_VAT return + label.
+function monthStartOf(dateStr: string): string {
+  const [y, m] = dateStr.split('-');
+  if (!y || !m) return '';
+  return `${y}-${m}-01`;
+}
+
+// First day of the calendar quarter ('YYYY-01-01' | '-04-01' | '-07-01' | '-10-01') a date falls in.
+function quarterStartOf(dateStr: string): string {
+  const [y, m] = dateStr.split('-').map(Number);
+  if (!y || !m) return '';
+  const startMonth = Math.floor((m - 1) / 3) * 3 + 1;
+  return `${y}-${String(startMonth).padStart(2, '0')}-01`;
+}
+
+// 'Q3 2026' label for the calendar quarter a YYYY-MM-01 quarter-start date belongs to (the OSS return
+// covers a whole quarter, so a month label would misread e.g. Jul–Sep as just "JUL").
+function formatQuarterLabel(quarterStart: string): string {
+  const [y, m] = quarterStart.split('-').map(Number);
+  if (!y || !m) return '';
+  return `Q${Math.floor((m - 1) / 3) + 1} ${y}`;
+}
+
+const INFORMATIONAL = 'informational / filed separately';
+
+// Phase-2 VAT: two statutory returns off the same period. (a) JPK_VAT — the monthly PL return, output
+// VAT by regime minus input VAT = net_payable; OSS and UK figures are declared here for completeness
+// but settled on their own returns, so they're flagged and excluded from net_payable (§backend
+// GetVatReturnPLResponse). (b) OSS — the quarterly EU-B2C aggregate, one line per destination country.
+export function VatTab({ from }: Props) {
+  const month = monthStartOf(from);
+  const quarter = quarterStartOf(from);
+
+  const vat = useVatReturnPL(month);
+  const oss = useOssReturn(quarter);
+
+  const ret = vat.data;
+  const rows: VatRow[] = ret
+    ? [
+        { label: 'output VAT — domestic (PL)', value: ret.outputDomestic },
+        { label: 'output VAT — WNT self-charge', value: ret.outputWntSelfCharge },
+        { label: 'OSS output VAT', value: ret.ossInfoTotal, note: INFORMATIONAL },
+        { label: 'input VAT — domestic (PL)', value: ret.inputDomestic },
+        { label: 'input VAT — WNT', value: ret.inputWnt },
+        { label: 'input VAT — import', value: ret.inputImport },
+        { label: 'net payable', value: ret.netPayable, bold: true },
+        { label: 'UK output VAT — stock domestic', value: ret.outputUkStockDomestic, note: INFORMATIONAL },
+        { label: 'UK input VAT — domestic', value: ret.inputUkDomestic, note: INFORMATIONAL },
+        { label: 'net WDT (zero-rated base)', value: ret.netWdt, note: INFORMATIONAL },
+        { label: 'net export (zero-rated base)', value: ret.netExport, note: INFORMATIONAL },
+      ]
+    : [];
+
+  // TSV mirrors the visible table; amounts are the raw decimal `value` strings (unformatted).
+  const vatCopyHeaders = ['line', 'amount'];
+  const vatCopyRows: (string | number | undefined)[][] = rows.map((r) => [r.label, r.value?.value]);
+
+  const ossRows = oss.data?.rows ?? [];
+  const ossCopyHeaders = ['country', 'rate %', 'net', 'vat'];
+  const ossCopyRows: (string | number | undefined)[][] = [
+    ...ossRows.map((r) => [r.country, r.ratePct?.value, r.net?.value, r.vat?.value]),
+    ['total', '', oss.data?.totalNet?.value, oss.data?.totalVat?.value],
+  ];
+
+  return (
+    <div className='flex flex-col gap-8'>
+      <section className='flex flex-col gap-3'>
+        <Text variant='uppercase' className='font-medium'>
+          JPK_VAT — monthly return · {formatMonthLabel(month)}
+        </Text>
+        <ReportState
+          isLoading={vat.isLoading}
+          isError={vat.isError}
+          onRetry={() => vat.refetch()}
+          isEmpty={!ret}
+        >
+          <div className='flex flex-col gap-3'>
+            <CaveatsNote caveats={ret?.caveats ?? []} />
+            <div className='flex justify-end'>
+              <CopyTableButton headers={vatCopyHeaders} rows={vatCopyRows} filename='vat-return' />
+            </div>
+            <div className='overflow-x-auto'>
+              <table className='w-full min-w-max border-collapse'>
+                <thead className='border-b border-textColor'>
+                  <tr>
+                    <th className='px-2 py-2 text-left text-textBaseSize uppercase'>line</th>
+                    <th className='min-w-32 px-2 py-2 text-right text-textBaseSize uppercase'>
+                      amount
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((r) => (
+                    <tr key={r.label} className='border-b border-textInactiveColor'>
+                      <td
+                        className={`whitespace-nowrap px-2 py-1${r.bold ? ' border-t border-textColor font-medium' : ''}`}
+                      >
+                        {r.label}
+                        {r.note ? (
+                          <Text component='span' size='small' variant='inactive' className='ml-2'>
+                            ({r.note})
+                          </Text>
+                        ) : null}
+                      </td>
+                      <AmountCell value={r.value} bold={r.bold} />
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </ReportState>
+      </section>
+
+      <section className='flex flex-col gap-3'>
+        <Text variant='uppercase' className='font-medium'>
+          OSS — quarterly return · {formatQuarterLabel(quarter)}
+        </Text>
+        <ReportState
+          isLoading={oss.isLoading}
+          isError={oss.isError}
+          onRetry={() => oss.refetch()}
+          isEmpty={ossRows.length === 0}
+        >
+          <div className='flex flex-col gap-3'>
+            <div className='flex justify-end'>
+              <CopyTableButton headers={ossCopyHeaders} rows={ossCopyRows} filename='oss-return' />
+            </div>
+            <div className='overflow-x-auto'>
+              <table className='w-full min-w-max border-collapse'>
+                <thead className='border-b border-textColor'>
+                  <tr>
+                    <th className='px-2 py-2 text-left text-textBaseSize uppercase'>country</th>
+                    <th className='min-w-32 px-2 py-2 text-right text-textBaseSize uppercase'>
+                      rate %
+                    </th>
+                    <th className='min-w-32 px-2 py-2 text-right text-textBaseSize uppercase'>net</th>
+                    <th className='min-w-32 px-2 py-2 text-right text-textBaseSize uppercase'>vat</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {ossRows.map((r, i) => (
+                    <tr key={r.country ?? i} className='border-b border-textInactiveColor'>
+                      <td className='whitespace-nowrap px-2 py-1'>{r.country}</td>
+                      <td className='w-32 min-w-32 whitespace-nowrap px-2 py-1 text-right tabular-nums'>
+                        {formatPercent(r.ratePct)}
+                      </td>
+                      <AmountCell value={r.net} />
+                      <AmountCell value={r.vat} />
+                    </tr>
+                  ))}
+                </tbody>
+                <tfoot>
+                  <tr>
+                    <td className='border-t border-textColor px-2 py-1 font-medium'>total</td>
+                    <td className='border-t border-textColor' />
+                    <AmountCell value={oss.data?.totalNet} bold />
+                    <AmountCell value={oss.data?.totalVat} bold />
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
+          </div>
+        </ReportState>
+      </section>
+    </div>
+  );
+}

--- a/src/components/managers/accounting/reports/page.tsx
+++ b/src/components/managers/accounting/reports/page.tsx
@@ -8,18 +8,20 @@ import { RangeControls, type ControlsMode } from './components/range-controls';
 import { ReconciliationTab } from './components/reconciliation';
 import { defaultAsOf, defaultRange } from './components/report-utils';
 import { TrialBalanceTab } from './components/trial-balance';
+import { VatTab } from './components/vat';
 
 // Reports screen (04): one page, five tabs in ?tab (opex pattern — plain buttons + useSearchParams,
 // not Radix Tabs). The whole selection — tab, from/to, asOf, account code — lives in searchParams,
 // so every view is a shareable link and the TB/BS/P&L drill-downs, recon and dashboard alerts can
 // deep-link into an exact report state (§8.2). searchParams contract:
-// ?tab=tb|pl|bs|ledger|recon & from & to & asOf & code.
+// ?tab=tb|pl|bs|ledger|recon|vat & from & to & asOf & code.
 const TABS = [
   { id: 'tb', label: 'trial balance' },
   { id: 'pl', label: 'p&l' },
   { id: 'bs', label: 'balance sheet' },
   { id: 'ledger', label: 'ledger' },
   { id: 'recon', label: 'reconciliation' },
+  { id: 'vat', label: 'vat' },
 ] as const;
 
 type TabId = (typeof TABS)[number]['id'];
@@ -112,6 +114,7 @@ export function AcctReportsPage() {
       {tab === 'bs' && <BalanceSheetTab asOf={asOf} onDrill={(c) => drillToLedger(c, true)} />}
       {tab === 'ledger' && <LedgerTab code={code} from={from} to={to} />}
       {tab === 'recon' && <ReconciliationTab from={from} to={to} />}
+      {tab === 'vat' && <VatTab from={from} />}
     </div>
   );
 }

--- a/src/components/managers/accounting/utils/hooks.ts
+++ b/src/components/managers/accounting/utils/hooks.ts
@@ -35,6 +35,8 @@ export const acctKeys = {
   balanceSheet: (asOf: string) => [...acctKeys.all, 'bs', asOf] as const,
   ledger: (code: string, f: LedgerFilter) => [...acctKeys.all, 'ledger', code, f] as const,
   reconciliation: (from: string, to: string) => [...acctKeys.all, 'recon', from, to] as const,
+  vatReturn: (month: string) => [...acctKeys.all, 'vat-return', month] as const,
+  ossReturn: (q: string) => [...acctKeys.all, 'oss-return', q] as const,
 };
 
 // ---- Chart of accounts ----
@@ -199,5 +201,25 @@ export function useReconciliation(from: string, to: string) {
     queryKey: acctKeys.reconciliation(from, to),
     queryFn: () => adminService.GetAcctReconciliation({ from, to }),
     enabled: Boolean(from && to),
+  });
+}
+
+// JPK_VAT monthly return (phase 2). `month` is any day within the target filing month; the backend
+// normalises it to the 1st. The OSS block is filed separately (GetOssReturn), not here.
+export function useVatReturnPL(month: string) {
+  return useQuery({
+    queryKey: acctKeys.vatReturn(month),
+    queryFn: () => adminService.GetVatReturnPL({ month }),
+    enabled: Boolean(month),
+  });
+}
+
+// Quarterly OSS return (phase 2). `quarterStart` is any day within the target quarter; the request
+// field is `quarter` (backend snaps it to the quarter's first day).
+export function useOssReturn(quarterStart: string) {
+  return useQuery({
+    queryKey: acctKeys.ossReturn(quarterStart),
+    queryFn: () => adminService.GetOssReturn({ quarter: quarterStart }),
+    enabled: Boolean(quarterStart),
   });
 }

--- a/src/components/managers/custom-orders/components/billing-fields-group.tsx
+++ b/src/components/managers/custom-orders/components/billing-fields-group.tsx
@@ -20,6 +20,7 @@ export function BillingFieldsGroup() {
         'space-y-8': !billingSameAsShipping,
       })}
     >
+      <InputField name='buyerVatId' label='VAT ID (B2B)' />
       <CheckboxField name='billingSameAsShipping' label='Billing address same as shipping' />
       {!billingSameAsShipping && (
         <div className='grid gap-6'>

--- a/src/components/managers/custom-orders/components/custom-order-form.tsx
+++ b/src/components/managers/custom-orders/components/custom-order-form.tsx
@@ -120,6 +120,8 @@ export function CustomOrderForm({
         items,
         billingAddress,
         currency,
+        // Optional B2B EU VAT id (phase 2); omit when blank so the backend keeps the B2C path.
+        buyerVatId: data.buyerVatId?.trim() || undefined,
       } as CreateCustomOrderRequest;
       const response = await adminService.CreateCustomOrder(payload);
       showMessage('Custom order created successfully', 'success');

--- a/src/components/managers/custom-orders/components/schema.ts
+++ b/src/components/managers/custom-orders/components/schema.ts
@@ -41,6 +41,9 @@ const baseCustomOrderSchema = z.object({
   shipmentCost: z.object({
     value: z.string().min(1, 'Shipment cost is required'),
   }),
+  // Optional B2B EU VAT id (phase 2). Its presence drives the wdt / reverse-charge classification on
+  // the backend; free-form here (VIES lookup is out of scope).
+  buyerVatId: z.string().optional(),
 });
 
 export const customOrderSchema = baseCustomOrderSchema;
@@ -73,4 +76,5 @@ export const defaultCustomOrder = {
   paymentMethod: 'PAYMENT_METHOD_NAME_ENUM_BANK_INVOICE' as const,
   shipmentCarrierId: 0,
   shipmentCost: { value: '' },
+  buyerVatId: '',
 };

--- a/src/components/managers/materials/components/movement-modals.tsx
+++ b/src/components/managers/materials/components/movement-modals.tsx
@@ -102,6 +102,15 @@ function Field({ label, children }: { label: string; children: ReactNode }) {
 
 // ---- Receive (purchase-in) ------------------------------------------------------------------
 
+// Input-VAT treatment for the extended M1 posting rule (phase 2). Matches the backend's accepted
+// set (wnt|import|domestic_pl|domestic_uk); '' = not recorded.
+const vatRegimeOptions = [
+  { value: 'wnt', label: 'WNT (intra-EU)' },
+  { value: 'import', label: 'import' },
+  { value: 'domestic_pl', label: 'domestic PL' },
+  { value: 'domestic_uk', label: 'domestic UK' },
+];
+
 export function ReceiveStockModal({
   open,
   onOpenChange,
@@ -117,6 +126,10 @@ export function ReceiveStockModal({
   const [quantity, setQuantity] = useState('');
   const [unitCost, setUnitCost] = useState('');
   const [currency, setCurrency] = useState('EUR');
+  // Recoverable input VAT for this receipt (base currency EUR) + its regime — kept separate from
+  // the NET unit cost so the two aren't double-counted. Both optional; when set, both should be set.
+  const [inputVat, setInputVat] = useState('');
+  const [inputVatRegime, setInputVatRegime] = useState('');
   const [lot, setLot] = useState('');
   // #48: "lot / roll" read as unexplained jargon ("не понимаю что это, для малого производства
   // оверкил") — collapsed behind an opt-in toggle instead of an unconditional field.
@@ -130,6 +143,8 @@ export function ReceiveStockModal({
     setQuantity('');
     setUnitCost('');
     setCurrency('EUR');
+    setInputVat('');
+    setInputVatRegime('');
     setLot('');
     setShowLot(false);
     setSupplierDoc('');
@@ -141,6 +156,14 @@ export function ReceiveStockModal({
     const qty = parseDecimalNumber(quantity);
     if (!Number.isFinite(qty) || qty <= 0) {
       showMessage('Quantity must be greater than zero', 'error');
+      return;
+    }
+    // Input VAT is all-or-nothing (the backend rejects one without the other); catch it here to save a
+    // round-trip.
+    const hasInputVat = inputVat.trim() !== '';
+    const hasInputVatRegime = inputVatRegime !== '';
+    if (hasInputVat !== hasInputVatRegime) {
+      showMessage('Input VAT needs both an amount and a regime, or neither', 'error');
       return;
     }
     // Setting a cost is a costing write; omit it (uncosted receipt, average unchanged) otherwise.
@@ -155,6 +178,9 @@ export function ReceiveStockModal({
         supplierDoc: supplierDoc.trim(),
         occurredAt,
         comment: comment.trim(),
+        // Recording input VAT is a costing write; both fields optional, sent only when set.
+        inputVatAmount: canWriteCosting ? inputToDecimal(inputVat) : undefined,
+        inputVatRegime: canWriteCosting && inputVatRegime ? inputVatRegime : undefined,
       });
       showMessage(posted(res.movement), 'success');
       onOpenChange(false);
@@ -181,26 +207,57 @@ export function ReceiveStockModal({
         />
       </Field>
       {canWriteCosting ? (
-        <div className='grid grid-cols-[1fr_auto] gap-2'>
-          <Field label='unit cost'>
-            <input
-              className={cell}
-              inputMode='decimal'
-              placeholder='blank = uncosted'
-              value={unitCost}
-              onChange={(e) => setUnitCost(sanitizeDecimal(e.target.value))}
-            />
-          </Field>
-          <Field label='currency'>
-            <select className={cell} value={currency} onChange={(e) => setCurrency(e.target.value)}>
-              {EXPENSE_CURRENCIES.map((c) => (
-                <option key={c.value} value={c.value}>
-                  {c.value}
-                </option>
-              ))}
-            </select>
-          </Field>
-        </div>
+        <>
+          <div className='grid grid-cols-[1fr_auto] gap-2'>
+            <Field label='unit cost (net)'>
+              <input
+                className={cell}
+                inputMode='decimal'
+                placeholder='blank = uncosted'
+                value={unitCost}
+                onChange={(e) => setUnitCost(sanitizeDecimal(e.target.value))}
+              />
+            </Field>
+            <Field label='currency'>
+              <select
+                className={cell}
+                value={currency}
+                onChange={(e) => setCurrency(e.target.value)}
+              >
+                {EXPENSE_CURRENCIES.map((c) => (
+                  <option key={c.value} value={c.value}>
+                    {c.value}
+                  </option>
+                ))}
+              </select>
+            </Field>
+          </div>
+          <div className='grid grid-cols-[1fr_auto] gap-2'>
+            <Field label='input VAT (EUR)'>
+              <input
+                className={cell}
+                inputMode='decimal'
+                placeholder='optional — VAT-exclusive of unit cost'
+                value={inputVat}
+                onChange={(e) => setInputVat(sanitizeDecimal(e.target.value))}
+              />
+            </Field>
+            <Field label='VAT regime'>
+              <select
+                className={cell}
+                value={inputVatRegime}
+                onChange={(e) => setInputVatRegime(e.target.value)}
+              >
+                <option value=''>— none —</option>
+                {vatRegimeOptions.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            </Field>
+          </div>
+        </>
       ) : (
         <Text variant='inactive' size='small'>
           Uncosted receipt — moving average unchanged.


### PR DESCRIPTION
Adds the phase-2 VAT admin surface (backend already deployed to beta). Proto submodule bumped to grbpwr-proto@a80d1c2 + regenerated. `yarn build:check` green; independently code-reviewed (verdict: ship — field mappings, request shapes, month/quarter math, recon wiring, and both forms verified correct; two label/UX nits fixed).

- **Reports → `vat` tab**: JPK_VAT monthly return (output/input VAT by regime, net_payable; UK output/input + WDT/export net bases shown but flagged "informational / filed separately") and the OSS quarterly return (per-country rate/net/vat + totals). Copy-as-TSV per table.
- **Reconciliation**: a `vat` card (2070 ledger vs regime-classified orders).
- **Custom orders**: `buyer_vat_id` (B2B) field.
- **Material receive**: `input_vat_amount` + `input_vat_regime` (costing:write gated), unit cost relabelled "unit cost (net)", all-or-nothing client guard.

Deferred: wdt reverse-charge invoice note (needs the order proto to expose vat_regime) and the segmented-field stub delete (active WIP in the tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)