### PR TITLE
Accounting: event review-queue (dead-letter) UI

### DIFF
--- a/src/api/proto-http/admin/index.ts
+++ b/src/api/proto-http/admin/index.ts
@@ -7007,6 +7007,41 @@ export type ReopenAcctPeriodRequest = {
 export type ReopenAcctPeriodResponse = {
 };
 
+// AcctEvent is one posting-outbox event's disposition (the internal JSON payload is omitted).
+export type AcctEvent = {
+  id: number | undefined;
+  eventType: string | undefined;
+  sourceKey: string | undefined;
+  occurredAt: string | undefined;
+  createdAt: string | undefined;
+  processedAt: string | undefined;
+  attempts: number | undefined;
+  lastError: string | undefined;
+  needsReview: boolean | undefined;
+};
+
+export type ListAcctEventsNeedingReviewRequest = {
+  limit: number | undefined;
+};
+
+export type ListAcctEventsNeedingReviewResponse = {
+  events: AcctEvent[] | undefined;
+};
+
+export type ReprocessAcctEventRequest = {
+  id: number | undefined;
+};
+
+export type ReprocessAcctEventResponse = {
+};
+
+export type ResolveAcctEventRequest = {
+  id: number | undefined;
+};
+
+export type ResolveAcctEventResponse = {
+};
+
 export type GetTrialBalanceRequest = {
   from: string | undefined;
   to: string | undefined;
@@ -7785,6 +7820,15 @@ export interface AdminService {
   // COGS, materials, finished goods) and lists what is deliberately left unposted, over
   // [from, to) (to exclusive).
   GetAcctReconciliation(request: GetAcctReconciliationRequest): Promise<GetAcctReconciliationResponse>;
+  // ListAcctEventsNeedingReview lists outbox events that were terminally disposed but need an operator
+  // (a non-EUR/degenerate order needing a manual entry, an orphan refund, or a dead-letter). Their
+  // month cannot close until each is resolved or reprocessed.
+  ListAcctEventsNeedingReview(request: ListAcctEventsNeedingReviewRequest): Promise<ListAcctEventsNeedingReviewResponse>;
+  // ReprocessAcctEvent resets an event so the worker re-attempts it from scratch (used after the cause
+  // is fixed, e.g. the missing vat_rate was added).
+  ReprocessAcctEvent(request: ReprocessAcctEventRequest): Promise<ReprocessAcctEventResponse>;
+  // ResolveAcctEvent clears the review flag on an event handled manually (a manual journal entry posted).
+  ResolveAcctEvent(request: ResolveAcctEventRequest): Promise<ResolveAcctEventResponse>;
   // GetVatReturnPL returns the JPK_VAT monthly aggregate (filed by the 25th): output VAT by regime
   // (domestic PL, WNT/import self-charge, OSS shown for reference only), input VAT by type, and the
   // net payable. Source-type-agnostic and aggregated by the payment period, so it survives wave 2's
@@ -12684,6 +12728,60 @@ export function createAdminServiceClient(
         service: "AdminService",
         method: "GetAcctReconciliation",
       }) as Promise<GetAcctReconciliationResponse>;
+    },
+    ListAcctEventsNeedingReview(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/accounting/events/needs-review`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      if (request.limit) {
+        queryParams.push(`limit=${encodeURIComponent(request.limit.toString())}`)
+      }
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "GET",
+        body,
+      }, {
+        service: "AdminService",
+        method: "ListAcctEventsNeedingReview",
+      }) as Promise<ListAcctEventsNeedingReviewResponse>;
+    },
+    ReprocessAcctEvent(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/accounting/events/reprocess`; // eslint-disable-line quotes
+      const body = JSON.stringify(request);
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "POST",
+        body,
+      }, {
+        service: "AdminService",
+        method: "ReprocessAcctEvent",
+      }) as Promise<ReprocessAcctEventResponse>;
+    },
+    ResolveAcctEvent(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/accounting/events/resolve`; // eslint-disable-line quotes
+      const body = JSON.stringify(request);
+      const queryParams: string[] = [];
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "POST",
+        body,
+      }, {
+        service: "AdminService",
+        method: "ResolveAcctEvent",
+      }) as Promise<ResolveAcctEventResponse>;
     },
     GetVatReturnPL(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
       const path = `api/admin/accounting/reports/vat-return`; // eslint-disable-line quotes

--- a/src/components/managers/accounting/components/section-header.tsx
+++ b/src/components/managers/accounting/components/section-header.tsx
@@ -9,6 +9,7 @@ const TABS: { label: string; route: string }[] = [
   { label: 'accounts', route: ROUTES.accountingAccounts },
   { label: 'reports', route: ROUTES.accountingReports },
   { label: 'periods', route: ROUTES.accountingPeriods },
+  { label: 'events', route: ROUTES.accountingEvents },
 ];
 
 type Props = {

--- a/src/components/managers/accounting/events/page.tsx
+++ b/src/components/managers/accounting/events/page.tsx
@@ -1,0 +1,127 @@
+import { AcctEvent } from 'api/proto-http/admin';
+import { Button } from 'ui/components/button';
+import Text from 'ui/components/text';
+import { AcctSectionHeader } from '../components/section-header';
+import { ReportState } from '../reports/components/report-utils';
+import { formatAcctDate } from '../utils/format';
+import {
+  useAcctEventsNeedingReview,
+  useReprocessAcctEvent,
+  useResolveAcctEvent,
+} from '../utils/hooks';
+
+// Event review queue / dead-letter (accounting §events). The posting worker terminally disposes
+// outbox events it can't auto-post — a non-EUR or degenerate order needing a manual entry, an
+// orphan refund, a dead-letter — and flags them needs_review; the month can't close until an
+// operator either REPROCESSES (retry after fixing the cause, e.g. a missing vat_rate) or RESOLVES
+// (mark handled after posting a manual journal entry). This screen is that queue: one row per
+// flagged event with the two terminal actions. Toasts + invalidation live in the mutation hooks.
+export function AcctEventsPage() {
+  const { data, isLoading, isError, refetch } = useAcctEventsNeedingReview();
+  const events = data?.events ?? [];
+
+  const reprocess = useReprocessAcctEvent();
+  const resolve = useResolveAcctEvent();
+
+  // A row is busy while either of its two actions is in flight; both mutations are shared across
+  // rows, so scope "pending" to the id currently being mutated rather than a global isPending.
+  const pendingId = (m: { isPending: boolean; variables?: { id: number } }): number | null =>
+    m.isPending ? (m.variables?.id ?? null) : null;
+  const reprocessingId = pendingId(reprocess);
+  const resolvingId = pendingId(resolve);
+
+  return (
+    <div className='px-2.5'>
+      <AcctSectionHeader />
+
+      <div className='flex flex-col gap-4 py-6'>
+        <Text variant='inactive' size='small'>
+          events the posting worker could not post automatically — reprocess after fixing the cause,
+          or resolve once you have posted a manual journal entry
+        </Text>
+
+        <ReportState
+          isLoading={isLoading}
+          isError={isError}
+          onRetry={() => refetch()}
+          isEmpty={events.length === 0}
+          emptyHint='no events need review'
+        >
+          <div className='overflow-x-auto'>
+            <table className='w-full min-w-max border-collapse border-2 border-textInactiveColor'>
+              <thead className='h-10 bg-textInactiveColor'>
+                <tr className='border-b border-textInactiveColor'>
+                  <th className='px-2 text-left text-textBaseSize uppercase'>id</th>
+                  <th className='px-2 text-left text-textBaseSize uppercase'>type</th>
+                  <th className='px-2 text-left text-textBaseSize uppercase'>source key</th>
+                  <th className='px-2 text-left text-textBaseSize uppercase'>occurred</th>
+                  <th className='px-2 text-right text-textBaseSize uppercase'>attempts</th>
+                  <th className='px-2 text-left text-textBaseSize uppercase'>reason</th>
+                  <th className='px-2 text-right text-textBaseSize uppercase'>action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {events.map((e: AcctEvent) => {
+                  const id = e.id;
+                  const rowBusy = id != null && (reprocessingId === id || resolvingId === id);
+                  return (
+                    <tr key={id} className='border-b border-textInactiveColor align-top'>
+                      <td className='px-2 py-2'>
+                        <Text className='font-medium'>{id ?? '—'}</Text>
+                      </td>
+                      <td className='px-2 py-2'>
+                        <Text size='small'>{e.eventType || '—'}</Text>
+                      </td>
+                      <td className='px-2 py-2'>
+                        <Text size='small' variant='inactive'>
+                          {e.sourceKey || '—'}
+                        </Text>
+                      </td>
+                      <td className='px-2 py-2'>
+                        <Text size='small' variant='inactive'>
+                          {e.occurredAt ? formatAcctDate(e.occurredAt) : '—'}
+                        </Text>
+                      </td>
+                      <td className='px-2 py-2 text-right'>
+                        <Text size='small' variant='inactive'>
+                          {e.attempts ?? 0}
+                        </Text>
+                      </td>
+                      <td className='max-w-sm px-2 py-2'>
+                        <Text size='small' className='break-words text-error'>
+                          {e.lastError || '—'}
+                        </Text>
+                      </td>
+                      <td className='px-2 py-2'>
+                        <div className='flex items-center justify-end gap-2'>
+                          <Button
+                            variant='secondary'
+                            size='sm'
+                            disabled={id == null || rowBusy}
+                            loading={reprocessingId === id}
+                            onClick={() => id != null && reprocess.mutate({ id })}
+                          >
+                            reprocess
+                          </Button>
+                          <Button
+                            variant='main'
+                            size='sm'
+                            disabled={id == null || rowBusy}
+                            loading={resolvingId === id}
+                            onClick={() => id != null && resolve.mutate({ id })}
+                          >
+                            resolve
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </ReportState>
+      </div>
+    </div>
+  );
+}

--- a/src/components/managers/accounting/utils/hooks.ts
+++ b/src/components/managers/accounting/utils/hooks.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { adminService } from 'api/api';
 import { AcctJournalLineInput } from 'api/proto-http/admin';
+import { useSnackBarStore } from 'lib/stores/store';
 
 // Accounting module (backend `feature/accounting-core`; docs/plan-accounting-ui/
 // 01-contract-and-api.md §1.3). One query-key domain for the whole section — small enough that
@@ -37,6 +38,7 @@ export const acctKeys = {
   reconciliation: (from: string, to: string) => [...acctKeys.all, 'recon', from, to] as const,
   vatReturn: (month: string) => [...acctKeys.all, 'vat-return', month] as const,
   ossReturn: (q: string) => [...acctKeys.all, 'oss-return', q] as const,
+  eventsReview: () => [...acctKeys.all, 'events-review'] as const,
 };
 
 // ---- Chart of accounts ----
@@ -221,5 +223,50 @@ export function useOssReturn(quarterStart: string) {
     queryKey: acctKeys.ossReturn(quarterStart),
     queryFn: () => adminService.GetOssReturn({ quarter: quarterStart }),
     enabled: Boolean(quarterStart),
+  });
+}
+
+// ---- Event review queue (dead-letter) ----
+// The posting worker terminally disposes events it can't auto-post (non-EUR/degenerate orders,
+// orphan refunds, dead-letters) and flags them needs_review; the accounting month can't close
+// until an operator reprocesses (retry after fixing the cause) or resolves (mark handled after a
+// manual journal entry). limit is fixed at 100 — the queue is small by design (backend contract).
+// Unlike the other mutations in this file, these two own their own success/error toasts: the
+// review actions are one-click terminal decisions with no calling modal to host the feedback.
+
+export function useAcctEventsNeedingReview() {
+  return useQuery({
+    queryKey: acctKeys.eventsReview(),
+    queryFn: () => adminService.ListAcctEventsNeedingReview({ limit: 100 }),
+  });
+}
+
+export function useReprocessAcctEvent() {
+  const qc = useQueryClient();
+  const { showMessage } = useSnackBarStore();
+  return useMutation({
+    mutationFn: (vars: { id: number }) => adminService.ReprocessAcctEvent(vars),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: acctKeys.eventsReview() });
+      qc.invalidateQueries({ queryKey: acctKeys.all });
+      showMessage('Event queued for reprocessing', 'success');
+    },
+    onError: (e) =>
+      showMessage(e instanceof Error ? e.message : 'Failed to reprocess event', 'error'),
+  });
+}
+
+export function useResolveAcctEvent() {
+  const qc = useQueryClient();
+  const { showMessage } = useSnackBarStore();
+  return useMutation({
+    mutationFn: (vars: { id: number }) => adminService.ResolveAcctEvent(vars),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: acctKeys.eventsReview() });
+      qc.invalidateQueries({ queryKey: acctKeys.all });
+      showMessage('Event marked resolved', 'success');
+    },
+    onError: (e) =>
+      showMessage(e instanceof Error ? e.message : 'Failed to resolve event', 'error'),
   });
 }

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -100,6 +100,7 @@ export enum ROUTES {
   accountingAccounts = '/accounting/accounts',
   accountingReports = '/accounting/reports',
   accountingPeriods = '/accounting/periods',
+  accountingEvents = '/accounting/events',
   employees = '/employees',
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -129,6 +129,11 @@ const AcctPeriods = lazy(() =>
     default: m.AcctPeriodsPage,
   })),
 );
+const AcctEvents = lazy(() =>
+  import('components/managers/accounting/events/page').then((m) => ({
+    default: m.AcctEventsPage,
+  })),
+);
 const Employees = lazy(() =>
   import('components/managers/employees').then((m) => ({ default: m.Employees })),
 );
@@ -286,6 +291,7 @@ root.render(
                     <Route path={ROUTES.accountingAccounts} element={<AcctAccounts />} />
                     <Route path={ROUTES.accountingReports} element={<AcctReports />} />
                     <Route path={ROUTES.accountingPeriods} element={<AcctPeriods />} />
+                    <Route path={ROUTES.accountingEvents} element={<AcctEvents />} />
                   </Route>
                   <Route path={ROUTES.employees} element={<Employees />} />
                   <Route path={ROUTES.taskDetails} element={<TaskDetail />} />


### PR DESCRIPTION
Companion to the backend resilience epic (grbpwr-manager PR #58). Bumps the proto submodule to grbpwr-proto@add88e9 and adds an **events** tab under Accounting: the dead-letter / manual-review queue.

Lists posting-outbox events flagged needs_review (non-EUR/degenerate manual entries, orphan refunds, dead-letters) with per-row **reprocess** (retry after fixing the cause) and **resolve** (mark handled) actions — the queue an operator clears before a month with such events can close. Hooks mirror the existing accounting query/mutation pattern; `yarn build:check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)