### PR TITLE
fix(accounting): reconciliation details linked opex month 2026-07 to a dead order

### DIFF
--- a/src/components/managers/accounting/reports/components/reconciliation.tsx
+++ b/src/components/managers/accounting/reports/components/reconciliation.tsx
@@ -50,14 +50,15 @@ function LedgerVsOp({ label, value }: { label: string; value?: googletype_Decima
   );
 }
 
-// A recon item's `ref` is an operational identity. When it looks like a uuid (order/movement) AND
-// the block is an order-bearing one (not materials / unposted movements), link to the order;
-// otherwise it's plain text (§4.5).
+// A recon item's `ref` is an operational identity. Order-bearing blocks carry the order reference
+// (always `ORD-…`; order_refund events suffix it `:seq`) — only those deep-link to the order. Every
+// other ref renders as plain text: opex months (`2026-07`), production-run / movement ids, and
+// non-order event keys. We match the `ORD-` prefix rather than a loose "contains a dash / is long"
+// heuristic, which used to link e.g. the opex month `2026-07` to a non-existent /orders/2026-07 (§4.5).
 function ReconItemRow({ item, linkOrders }: { item: AcctReconItem; linkOrders: boolean }) {
   const ref = item.ref ?? '';
-  const looksUuid = ref.length > 20 || ref.includes('-');
   const uuid = ref.split(':')[0];
-  const linkable = linkOrders && looksUuid && Boolean(uuid);
+  const linkable = linkOrders && uuid.startsWith('ORD-');
   return (
     <div className='flex items-start justify-between gap-2'>
       <div className='flex min-w-0 flex-col'>


### PR DESCRIPTION
## Problem
On **ACCOUNTING → REPORTS → RECONCILIATION**, the `pending` block's **details** rows rendered broken order links — e.g. `https://admin.beta.grbpwr.com/orders/2026-07`, an order that does not exist.

## Root cause
`ReconItemRow` decided a ref was an order uuid via a loose heuristic — `ref.length > 20 || ref.includes('-')` — then linked it to `/orders/<ref>`. The `pending` block mixes heterogeneous refs:
- pending order events → `ORD-XXXXXXX` (optionally `:seq`) — order-linkable ✅
- pending production runs → integer id — not an order
- **pending opex months → `2026-07`** — contains a dash → wrongly treated as a uuid → `/orders/2026-07` 💥

## Fix
Gate the deep-link on the real order-reference shape — the **`ORD-` prefix** (after stripping the `:seq` suffix) — instead of "looks like a uuid". This matches how the journal table (`entries-table.tsx`) and ledger (`ledger.tsx`) already gate on `source_type`. Non-order refs (opex months, run / movement ids, non-order event keys) now render as **plain text**, not dead links.

Order references are always `ORD-XXXXXXX` (`generateOrderReference`, backend `insert.go`) — the only prod insert path — so no real order link is lost.

- 1 file, client-only, no proto change.
- `yarn build:check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)