### PR TITLE
order(invoice): reverse-charge note for WDT orders

### DIFF
--- a/src/api/proto-http/admin/index.ts
+++ b/src/api/proto-http/admin/index.ts
@@ -1395,6 +1395,11 @@ export type common_Order = {
   buyerEmail: string | undefined;
   buyerFirstName: string | undefined;
   buyerLastName: string | undefined;
+  // vat_regime is the VAT treatment snapshotted onto the order at accounting-posting time
+  // (customer_order.vat_regime): oss / pl_domestic / export / wdt / uk_stock_domestic / none. Empty
+  // until the order's sale event is posted. Surfaced so the invoice can print the legally-required
+  // note for zero-VAT regimes — notably wdt (intra-community B2B supply → reverse charge).
+  vatRegime: string | undefined;
 };
 
 export type common_OrderItem = {

--- a/src/api/proto-http/common/index.ts
+++ b/src/api/proto-http/common/index.ts
@@ -869,6 +869,11 @@ export type Order = {
   buyerEmail: string | undefined;
   buyerFirstName: string | undefined;
   buyerLastName: string | undefined;
+  // vat_regime is the VAT treatment snapshotted onto the order at accounting-posting time
+  // (customer_order.vat_regime): oss / pl_domestic / export / wdt / uk_stock_domestic / none. Empty
+  // until the order's sale event is posted. Surfaced so the invoice can print the legally-required
+  // note for zero-VAT regimes — notably wdt (intra-community B2B supply → reverse charge).
+  vatRegime: string | undefined;
 };
 
 export type OrderItem = {

--- a/src/api/proto-http/frontend/index.ts
+++ b/src/api/proto-http/frontend/index.ts
@@ -990,6 +990,11 @@ export type common_Order = {
   buyerEmail: string | undefined;
   buyerFirstName: string | undefined;
   buyerLastName: string | undefined;
+  // vat_regime is the VAT treatment snapshotted onto the order at accounting-posting time
+  // (customer_order.vat_regime): oss / pl_domestic / export / wdt / uk_stock_domestic / none. Empty
+  // until the order's sale event is posted. Surfaced so the invoice can print the legally-required
+  // note for zero-VAT regimes — notably wdt (intra-community B2B supply → reverse charge).
+  vatRegime: string | undefined;
 };
 
 export type common_OrderItem = {

--- a/src/components/managers/order/components/invoice-document.tsx
+++ b/src/components/managers/order/components/invoice-document.tsx
@@ -126,6 +126,15 @@ export function InvoiceDocument({
   const paymentMethod = payment?.paymentMethod?.replace('PAYMENT_METHOD_NAME_ENUM_', '');
   const paid = !!payment?.isTransactionDone;
 
+  // Legally-required VAT note for zero-VAT regimes. WDT (intra-community B2B supply) is
+  // reverse-charged: the seller charges no VAT and the buyer accounts for it in the destination
+  // country — the invoice must state this. order.vatRegime is snapshotted at accounting-posting
+  // time, so the note appears once the order's sale event is posted (empty regime → no note).
+  const reverseChargeNote =
+    order.vatRegime === 'wdt'
+      ? 'Reverse charge — intra-community supply of goods (WDT). VAT is not charged by the seller; the buyer accounts for VAT in the country of destination. (EU VAT Directive 2006/112/EC, Art. 138)'
+      : undefined;
+
   // Customer-facing link to this order on the storefront, scannable off the printed
   // invoice. Origin tracks the admin environment (beta admin → beta store), so it works
   // in both. Only shown when we have the uuid + email needed to resolve it.
@@ -299,6 +308,14 @@ export function InvoiceDocument({
           )}
         </div>
       </div>
+
+      {/* VAT / REVERSE CHARGE NOTE */}
+      {reverseChargeNote && (
+        <div className='mb-5 break-inside-avoid border border-black px-3 py-2 text-[10px] leading-snug'>
+          <div className='mb-0.5 font-bold uppercase tracking-[0.12em]'>vat — reverse charge</div>
+          <div>{reverseChargeNote}</div>
+        </div>
+      )}
 
       {/* PAYMENT */}
       <Sheet title='payment'>


### PR DESCRIPTION
## Why
**WDT** (intra-community B2B supply) is VAT **reverse-charged**: GRBPWR charges no VAT and the buyer accounts for it in the destination country. The invoice is only compliant if it *states* this — and the invoice document had no VAT note at all.

## What
- Bump proto submodule to grbpwr-proto `0f1ca0d` (common `Order` gains `vat_regime`); regen client (`vatRegime` on common/admin/frontend Order, additive only).
- `invoice-document`: when `order.vatRegime === 'wdt'`, print a **"VAT — reverse charge"** note citing the intra-community supply basis (EU VAT Directive 2006/112/EC, Art. 138).

`order.vatRegime` is snapshotted backend-side at accounting-posting time, so the note appears once the order's sale event is posted (empty regime → no note).

Pairs with backend PR #59 (exposes `vat_regime` on `GetOrderByUUID`). **Backend must be on beta first** for the field to be populated.

- `yarn build:check` green. WIP in the tree untouched (only the 5 listed files committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)