### PR TITLE
order(invoice): print VAT numbers on B2B invoices

### DIFF
--- a/src/api/proto-http/admin/index.ts
+++ b/src/api/proto-http/admin/index.ts
@@ -1400,6 +1400,10 @@ export type common_Order = {
   // until the order's sale event is posted. Surfaced so the invoice can print the legally-required
   // note for zero-VAT regimes — notably wdt (intra-community B2B supply → reverse charge).
   vatRegime: string | undefined;
+  // buyer_vat_id is the B2B buyer's EU VAT identifier (2-letter country prefix + digits), set on
+  // custom orders only; empty for B2C/storefront orders. Surfaced so a reverse-charge invoice can
+  // print the buyer's VAT number, which substantiates the zero-rated intra-community supply.
+  buyerVatId: string | undefined;
 };
 
 export type common_OrderItem = {

--- a/src/api/proto-http/common/index.ts
+++ b/src/api/proto-http/common/index.ts
@@ -874,6 +874,10 @@ export type Order = {
   // until the order's sale event is posted. Surfaced so the invoice can print the legally-required
   // note for zero-VAT regimes — notably wdt (intra-community B2B supply → reverse charge).
   vatRegime: string | undefined;
+  // buyer_vat_id is the B2B buyer's EU VAT identifier (2-letter country prefix + digits), set on
+  // custom orders only; empty for B2C/storefront orders. Surfaced so a reverse-charge invoice can
+  // print the buyer's VAT number, which substantiates the zero-rated intra-community supply.
+  buyerVatId: string | undefined;
 };
 
 export type OrderItem = {

--- a/src/api/proto-http/frontend/index.ts
+++ b/src/api/proto-http/frontend/index.ts
@@ -995,6 +995,10 @@ export type common_Order = {
   // until the order's sale event is posted. Surfaced so the invoice can print the legally-required
   // note for zero-VAT regimes — notably wdt (intra-community B2B supply → reverse charge).
   vatRegime: string | undefined;
+  // buyer_vat_id is the B2B buyer's EU VAT identifier (2-letter country prefix + digits), set on
+  // custom orders only; empty for B2C/storefront orders. Surfaced so a reverse-charge invoice can
+  // print the buyer's VAT number, which substantiates the zero-rated intra-community supply.
+  buyerVatId: string | undefined;
 };
 
 export type common_OrderItem = {

--- a/src/components/managers/order/components/invoice-document.tsx
+++ b/src/components/managers/order/components/invoice-document.tsx
@@ -10,11 +10,13 @@ const TD = 'border border-black px-1.5 py-1 align-top';
 const TH = 'border border-black px-1.5 py-1 text-left font-semibold bg-neutral-100 uppercase';
 
 // GRBPWR seller identity printed as the invoice "from" party. Contact only — no legal
-// entity address is carried in the client, so we surface what we know.
+// entity address is carried in the client, so we surface what we know. vatId is GRBPWR's
+// own VAT/NIP number, printed on B2B (reverse-charge) invoices; leave empty to omit the line.
 const SELLER = {
   name: 'GRBPWR',
   site: 'grbpwr.com',
   email: 'customercare@grbpwr.com',
+  vatId: '',
 };
 
 const toNum = (s?: string): number => {
@@ -185,6 +187,7 @@ export function InvoiceDocument({
             <div className='font-bold uppercase'>{SELLER.name}</div>
             <div>{SELLER.site}</div>
             <div>{SELLER.email}</div>
+            {SELLER.vatId && <div>VAT {SELLER.vatId}</div>}
           </div>
         </div>
         <div>
@@ -197,6 +200,7 @@ export function InvoiceDocument({
             </div>
             {buyer?.email && <div>{buyer.email}</div>}
             {buyer?.phone && <div>{buyer.phone}</div>}
+            {order.buyerVatId && <div className='font-medium'>VAT {order.buyerVatId}</div>}
           </div>
           <div className='mt-1'>
             <AddressLines address={billAddr} />


### PR DESCRIPTION
Adds both parties' VAT numbers to the reverse-charge (WDT) invoice:
- **bill-to** — the buyer's VAT number (`order.buyerVatId`), the element that substantiates the zero-rated intra-community supply. Data-driven; B2B custom orders only.
- **from** — a slot for GRBPWR's own VAT/NIP (`SELLER.vatId`); renders only when set. Left empty pending the legal number, so no line shows until filled in.

Bumps proto submodule to grbpwr-proto `99f7ea6` (common `Order` gains `buyer_vat_id`); regen. Pairs with backend PR #60.

`yarn build:check` green. WIP untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)