### PR TITLE
accounting(periods): explain create/close + show why an action is unavailable

### DIFF
--- a/src/components/managers/accounting/periods/components/periods-table.tsx
+++ b/src/components/managers/accounting/periods/components/periods-table.tsx
@@ -87,8 +87,25 @@ export function PeriodsTable({ periods, canWrite, onClose, onReopen }: Props) {
                   </Text>
                 </td>
                 <td className='px-2 py-2 text-right'>
+                  {/* Every non-actionable state shows a VISIBLE reason (not a bare "—"), with the
+                      full explanation on hover — so it's never ambiguous whether an action is
+                      missing or simply not applicable yet. */}
                   {!canWrite ? (
-                    <span className='text-textBaseSize text-textInactiveColor'>—</span>
+                    <Tooltip
+                      trigger={
+                        <span
+                          tabIndex={0}
+                          className='cursor-help text-textBaseSize uppercase text-textInactiveColor'
+                        >
+                          read-only
+                        </span>
+                      }
+                    >
+                      <span className='block max-w-56 text-textBaseSize'>
+                        closing / reopening a period needs the accounting:write permission — ask an
+                        admin to grant it.
+                      </span>
+                    </Tooltip>
                   ) : isOpen && past ? (
                     <Button variant='secondary' size='sm' onClick={() => onClose(p)}>
                       close
@@ -98,14 +115,15 @@ export function PeriodsTable({ periods, canWrite, onClose, onReopen }: Props) {
                       trigger={
                         <span
                           tabIndex={0}
-                          className='cursor-help text-textBaseSize text-textInactiveColor'
+                          className='cursor-help text-textBaseSize uppercase text-textInactiveColor'
                         >
-                          —
+                          not over yet
                         </span>
                       }
                     >
                       <span className='block max-w-56 text-textBaseSize'>
-                        month is not over yet
+                        a month can only be closed once it has fully ended. This is the current (or a
+                        future) month — its “close” button appears on the 1st of the next month.
                       </span>
                     </Tooltip>
                   ) : isClosed ? (

--- a/src/components/managers/accounting/periods/page.tsx
+++ b/src/components/managers/accounting/periods/page.tsx
@@ -47,24 +47,39 @@ export function AcctPeriodsPage() {
       <AcctSectionHeader />
 
       <div className='flex flex-col gap-4 py-6'>
-        {/* Ritual hint (05 / backend plan 08): static, three steps, always visible above the
-            table so the accountant never has to guess what "close" presupposes. */}
+        {/* Ritual hint (05 / backend plan 08): static, always visible above the table so the
+            accountant never has to guess what "close" presupposes — and how periods come to
+            exist (there is no manual "create"). */}
         <div className='flex flex-col gap-1'>
+          <Text variant='inactive' size='small'>
+            Periods open <span className='text-textColor'>automatically</span> on the first posting
+            into a month — there is no “create”. A month becomes closable{' '}
+            <span className='text-textColor'>only after it has ended</span> (the “close” button
+            appears on its row on the 1st of the next month). To close a finished month:
+          </Text>
           <Text variant='inactive' size='small'>
             1. review reconciliation
           </Text>
           <Text variant='inactive' size='small'>
-            2. add missing manual entries
+            2. add any missing manual entries
           </Text>
           <Text variant='inactive' size='small'>
-            3. close
+            3. close (a pre-close check flags pending events / unposted movements / revenue delta)
           </Text>
-          <Link
-            to={`${ROUTES.accountingReports}?tab=recon`}
-            className='w-fit text-textBaseSize text-textInactiveColor underline underline-offset-2 hover:text-textColor'
-          >
-            open reconciliation →
-          </Link>
+          <div className='flex flex-wrap gap-4'>
+            <Link
+              to={`${ROUTES.accountingReports}?tab=recon`}
+              className='w-fit text-textBaseSize text-textInactiveColor underline underline-offset-2 hover:text-textColor'
+            >
+              open reconciliation →
+            </Link>
+            <Link
+              to={`${ROUTES.accounting}?new=1`}
+              className='w-fit text-textBaseSize text-textInactiveColor underline underline-offset-2 hover:text-textColor'
+            >
+              add manual entry →
+            </Link>
+          </div>
         </div>
 
         {isLoading ? (


### PR DESCRIPTION
The Periods screen read as broken: no "create period" button (periods open **automatically** on the first posting), and a month that isn't over yet showed a bare **—** in the action column (close only appears for a *past* month) with the reason hidden in a hover tooltip.

- **periods-table**: non-actionable states now show a VISIBLE labelled reason instead of a bare "—" — **read-only** (needs `accounting:write`) and **not over yet** (closes on the 1st of the next month), full explanation on hover.
- **periods page**: the hint now says periods are auto-created and closable only after the month ends, and adds an **add manual entry →** deep link next to **open reconciliation →**.

Directly answers "how do I create/close periods and where do I fix things". `yarn build:check` green; WIP untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)