### PR TITLE
accounting(vat): download JPK_V7M XML button

### DIFF
--- a/src/api/proto-http/admin/index.ts
+++ b/src/api/proto-http/admin/index.ts
@@ -7262,6 +7262,16 @@ export type GetOssReturnResponse = {
   totalVat: googletype_Decimal | undefined;
 };
 
+export type ExportJpkV7MRequest = {
+  // month: YYYY-MM-DD, any day within the target filing month (normalised to the 1st).
+  month: string | undefined;
+};
+
+export type ExportJpkV7MResponse = {
+  filename: string | undefined;
+  xmlContent: string | undefined;
+};
+
 export interface AdminService {
   // Retrieves a key-value dictionary.
   GetDictionary(request: GetDictionaryRequest): Promise<GetDictionaryResponse>;
@@ -7846,6 +7856,11 @@ export interface AdminService {
   // GetOssReturn returns the quarterly OSS aggregate: EU B2C sales (vat_regime=oss) broken down by
   // destination country with the applied rate, net and VAT.
   GetOssReturn(request: GetOssReturnRequest): Promise<GetOssReturnResponse>;
+  // ExportJpkV7M generates the official Polish JPK_V7M (JPK_VAT) XML for a month: the taxpayer header,
+  // the VAT-7 declaration, and the sales evidence register. It is the OUTPUT-SIDE filing — the
+  // accountant merges the purchase register (input VAT), so the file's ZakupWiersz is empty. Requires
+  // the JPK_* taxpayer identity to be configured; returns FailedPrecondition otherwise.
+  ExportJpkV7M(request: ExportJpkV7MRequest): Promise<ExportJpkV7MResponse>;
 }
 
 type RequestType = {
@@ -12831,6 +12846,26 @@ export function createAdminServiceClient(
         service: "AdminService",
         method: "GetOssReturn",
       }) as Promise<GetOssReturnResponse>;
+    },
+    ExportJpkV7M(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/accounting/reports/jpk-v7m`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      if (request.month) {
+        queryParams.push(`month=${encodeURIComponent(request.month.toString())}`)
+      }
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "GET",
+        body,
+      }, {
+        service: "AdminService",
+        method: "ExportJpkV7M",
+      }) as Promise<ExportJpkV7MResponse>;
     },
   };
 }

--- a/src/components/managers/accounting/reports/components/jpk-export-button.tsx
+++ b/src/components/managers/accounting/reports/components/jpk-export-button.tsx
@@ -1,0 +1,49 @@
+import { adminService } from 'api/api';
+import { useSnackBarStore } from 'lib/stores/store';
+import { useState } from 'react';
+import { Button } from 'ui/components/button';
+
+// Downloads the official JPK_V7M (JPK_VAT) XML for the month from the backend and saves it as a file.
+// The backend returns FailedPrecondition until the taxpayer identity (JPK_* env) is configured, so a
+// failure surfaces that as an actionable message rather than a silent no-op.
+export function JpkExportButton({ month }: { month: string }) {
+  const { showMessage } = useSnackBarStore();
+  const [busy, setBusy] = useState(false);
+
+  const onExport = async () => {
+    setBusy(true);
+    try {
+      const res = await adminService.ExportJpkV7M({ month });
+      const blob = new Blob([res.xmlContent ?? ''], { type: 'application/xml;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = res.filename || `JPK_V7M_${month}.xml`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+      showMessage('JPK_V7M downloaded', 'success');
+    } catch (e) {
+      showMessage(
+        e instanceof Error ? e.message : 'Could not generate JPK_V7M — check the taxpayer identity is configured',
+        'error',
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Button
+      type='button'
+      variant='main'
+      size='sm'
+      className='px-3 py-1 uppercase'
+      disabled={busy}
+      onClick={onExport}
+    >
+      {busy ? 'generating…' : 'download JPK_V7M (XML)'}
+    </Button>
+  );
+}

--- a/src/components/managers/accounting/reports/components/vat.tsx
+++ b/src/components/managers/accounting/reports/components/vat.tsx
@@ -3,6 +3,7 @@ import Text from 'ui/components/text';
 import { useOssReturn, useVatReturnPL } from '../../utils/hooks';
 import { AmountCell } from '../../components/amount-cell';
 import { CopyTableButton } from './copy-table-button';
+import { JpkExportButton } from './jpk-export-button';
 import { CaveatsNote, formatMonthLabel, formatPercent, ReportState } from './report-utils';
 
 type Props = {
@@ -98,7 +99,8 @@ export function VatTab({ from }: Props) {
         >
           <div className='flex flex-col gap-3'>
             <CaveatsNote caveats={ret?.caveats ?? []} />
-            <div className='flex justify-end'>
+            <div className='flex flex-wrap justify-end gap-2'>
+              <JpkExportButton month={month} />
               <CopyTableButton headers={vatCopyHeaders} rows={vatCopyRows} filename='vat-return' />
             </div>
             <div className='overflow-x-auto'>


### PR DESCRIPTION
Adds **download JPK_V7M (XML)** to the JPK_VAT report tab — calls `ExportJpkV7M(month)` and saves the official Polish JPK_V7M XML file. Backend FailedPrecondition (taxpayer identity not set) surfaces as an actionable message. Proto submodule bumped to `a9d1b16`; pairs with backend PR #63. build:check green; WIP untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)