### PR TITLE
accounting(vat): OSS export button + generic XML export

### DIFF
--- a/src/api/proto-http/admin/index.ts
+++ b/src/api/proto-http/admin/index.ts
@@ -7272,6 +7272,16 @@ export type ExportJpkV7MResponse = {
   xmlContent: string | undefined;
 };
 
+export type ExportOssReturnRequest = {
+  // quarter: YYYY-MM-DD, any day within the target quarter (snapped to the quarter's first day).
+  quarter: string | undefined;
+};
+
+export type ExportOssReturnResponse = {
+  filename: string | undefined;
+  xmlContent: string | undefined;
+};
+
 export interface AdminService {
   // Retrieves a key-value dictionary.
   GetDictionary(request: GetDictionaryRequest): Promise<GetDictionaryResponse>;
@@ -7861,6 +7871,10 @@ export interface AdminService {
   // accountant merges the purchase register (input VAT), so the file's ZakupWiersz is empty. Requires
   // the JPK_* taxpayer identity to be configured; returns FailedPrecondition otherwise.
   ExportJpkV7M(request: ExportJpkV7MRequest): Promise<ExportJpkV7MResponse>;
+  // ExportOssReturn generates the quarterly OSS (Union scheme, VIU-DO) return XML — one row per member
+  // state of consumption with its rate, taxable base and VAT — for the accountant to validate against
+  // the official schema / transcribe into the OSS portal. Requires the JPK_* taxpayer identity.
+  ExportOssReturn(request: ExportOssReturnRequest): Promise<ExportOssReturnResponse>;
 }
 
 type RequestType = {
@@ -12866,6 +12880,26 @@ export function createAdminServiceClient(
         service: "AdminService",
         method: "ExportJpkV7M",
       }) as Promise<ExportJpkV7MResponse>;
+    },
+    ExportOssReturn(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/accounting/reports/oss-export`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      if (request.quarter) {
+        queryParams.push(`quarter=${encodeURIComponent(request.quarter.toString())}`)
+      }
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "GET",
+        body,
+      }, {
+        service: "AdminService",
+        method: "ExportOssReturn",
+      }) as Promise<ExportOssReturnResponse>;
     },
   };
 }

--- a/src/components/managers/accounting/reports/components/vat.tsx
+++ b/src/components/managers/accounting/reports/components/vat.tsx
@@ -2,8 +2,9 @@ import { googletype_Decimal } from 'api/proto-http/admin';
 import Text from 'ui/components/text';
 import { useOssReturn, useVatReturnPL } from '../../utils/hooks';
 import { AmountCell } from '../../components/amount-cell';
+import { adminService } from 'api/api';
 import { CopyTableButton } from './copy-table-button';
-import { JpkExportButton } from './jpk-export-button';
+import { XmlExportButton } from './xml-export-button';
 import { CaveatsNote, formatMonthLabel, formatPercent, ReportState } from './report-utils';
 
 type Props = {
@@ -100,7 +101,11 @@ export function VatTab({ from }: Props) {
           <div className='flex flex-col gap-3'>
             <CaveatsNote caveats={ret?.caveats ?? []} />
             <div className='flex flex-wrap justify-end gap-2'>
-              <JpkExportButton month={month} />
+              <XmlExportButton
+                label='download JPK_V7M (XML)'
+                fallbackName={`JPK_V7M_${month}.xml`}
+                run={() => adminService.ExportJpkV7M({ month })}
+              />
               <CopyTableButton headers={vatCopyHeaders} rows={vatCopyRows} filename='vat-return' />
             </div>
             <div className='overflow-x-auto'>
@@ -147,7 +152,12 @@ export function VatTab({ from }: Props) {
           isEmpty={ossRows.length === 0}
         >
           <div className='flex flex-col gap-3'>
-            <div className='flex justify-end'>
+            <div className='flex flex-wrap justify-end gap-2'>
+              <XmlExportButton
+                label='download OSS (XML)'
+                fallbackName={`OSS_${quarter}.xml`}
+                run={() => adminService.ExportOssReturn({ quarter })}
+              />
               <CopyTableButton headers={ossCopyHeaders} rows={ossCopyRows} filename='oss-return' />
             </div>
             <div className='overflow-x-auto'>

--- a/src/components/managers/accounting/reports/components/xml-export-button.tsx
+++ b/src/components/managers/accounting/reports/components/xml-export-button.tsx
@@ -1,32 +1,37 @@
-import { adminService } from 'api/api';
 import { useSnackBarStore } from 'lib/stores/store';
 import { useState } from 'react';
 import { Button } from 'ui/components/button';
 
-// Downloads the official JPK_V7M (JPK_VAT) XML for the month from the backend and saves it as a file.
-// The backend returns FailedPrecondition until the taxpayer identity (JPK_* env) is configured, so a
-// failure surfaces that as an actionable message rather than a silent no-op.
-export function JpkExportButton({ month }: { month: string }) {
+type Props = {
+  label: string;
+  fallbackName: string;
+  // Returns the backend export payload. A FailedPrecondition (taxpayer identity not configured) throws
+  // and is surfaced as an actionable message rather than a silent no-op.
+  run: () => Promise<{ filename?: string; xmlContent?: string }>;
+};
+
+// Fetches a statutory XML export (JPK_V7M, OSS, …) from the backend and saves it as a file.
+export function XmlExportButton({ label, fallbackName, run }: Props) {
   const { showMessage } = useSnackBarStore();
   const [busy, setBusy] = useState(false);
 
   const onExport = async () => {
     setBusy(true);
     try {
-      const res = await adminService.ExportJpkV7M({ month });
+      const res = await run();
       const blob = new Blob([res.xmlContent ?? ''], { type: 'application/xml;charset=utf-8' });
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = url;
-      link.download = res.filename || `JPK_V7M_${month}.xml`;
+      link.download = res.filename || fallbackName;
       document.body.appendChild(link);
       link.click();
       link.remove();
       URL.revokeObjectURL(url);
-      showMessage('JPK_V7M downloaded', 'success');
+      showMessage(`${res.filename || fallbackName} downloaded`, 'success');
     } catch (e) {
       showMessage(
-        e instanceof Error ? e.message : 'Could not generate JPK_V7M — check the taxpayer identity is configured',
+        e instanceof Error ? e.message : 'Export failed — check the taxpayer identity is configured',
         'error',
       );
     } finally {
@@ -43,7 +48,7 @@ export function JpkExportButton({ month }: { month: string }) {
       disabled={busy}
       onClick={onExport}
     >
-      {busy ? 'generating…' : 'download JPK_V7M (XML)'}
+      {busy ? 'generating…' : label}
     </Button>
   );
 }


### PR DESCRIPTION
Adds **download OSS (XML)** to the OSS quarterly section (`ExportOssReturn`). Generalises the download control into `XmlExportButton` (used by JPK_V7M + OSS). Submodule `caec50d`; pairs with backend PR #64. build:check green; WIP untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)