### PR TITLE
accounting(vat): UK VAT 9-box return section

### DIFF
--- a/src/api/proto-http/admin/index.ts
+++ b/src/api/proto-http/admin/index.ts
@@ -7282,6 +7282,24 @@ export type ExportOssReturnResponse = {
   xmlContent: string | undefined;
 };
 
+export type GetUkVatReturnRequest = {
+  // quarter: YYYY-MM-DD, any day within the target quarter (snapped to the quarter's first day).
+  quarter: string | undefined;
+};
+
+// GetUkVatReturnResponse is the 9-box UK VAT return. Boxes 2 (EU acquisitions VAT), 8 and 9 (EU
+// supplies/acquisitions) are always zero for a post-Brexit GB return, so they are omitted here; Box 3 =
+// Box 1 and Box 5 = Box 3 − Box 4.
+export type GetUkVatReturnResponse = {
+  quarterStart: string | undefined;
+  box1OutputVat: googletype_Decimal | undefined;
+  box3TotalVatDue: googletype_Decimal | undefined;
+  box4InputVat: googletype_Decimal | undefined;
+  box5NetVat: googletype_Decimal | undefined;
+  box6NetSales: googletype_Decimal | undefined;
+  box7NetPurchases: googletype_Decimal | undefined;
+};
+
 export interface AdminService {
   // Retrieves a key-value dictionary.
   GetDictionary(request: GetDictionaryRequest): Promise<GetDictionaryResponse>;
@@ -7875,6 +7893,10 @@ export interface AdminService {
   // state of consumption with its rate, taxable base and VAT — for the accountant to validate against
   // the official schema / transcribe into the OSS portal. Requires the JPK_* taxpayer identity.
   ExportOssReturn(request: ExportOssReturnRequest): Promise<ExportOssReturnResponse>;
+  // GetUkVatReturn returns the quarterly UK VAT return in 9-box MTD layout for the uk_stock_domestic
+  // regime (a separate jurisdiction from the Polish JPK). Boxes 2/8/9 are zero post-Brexit for a GB
+  // return; the figures are entered into MTD-compatible software / the HMRC bridge to submit.
+  GetUkVatReturn(request: GetUkVatReturnRequest): Promise<GetUkVatReturnResponse>;
 }
 
 type RequestType = {
@@ -12900,6 +12922,26 @@ export function createAdminServiceClient(
         service: "AdminService",
         method: "ExportOssReturn",
       }) as Promise<ExportOssReturnResponse>;
+    },
+    GetUkVatReturn(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/accounting/reports/uk-vat-return`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      if (request.quarter) {
+        queryParams.push(`quarter=${encodeURIComponent(request.quarter.toString())}`)
+      }
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "GET",
+        body,
+      }, {
+        service: "AdminService",
+        method: "GetUkVatReturn",
+      }) as Promise<GetUkVatReturnResponse>;
     },
   };
 }

--- a/src/components/managers/accounting/reports/components/vat.tsx
+++ b/src/components/managers/accounting/reports/components/vat.tsx
@@ -1,6 +1,6 @@
 import { googletype_Decimal } from 'api/proto-http/admin';
 import Text from 'ui/components/text';
-import { useOssReturn, useVatReturnPL } from '../../utils/hooks';
+import { useOssReturn, useUkVatReturn, useVatReturnPL } from '../../utils/hooks';
 import { AmountCell } from '../../components/amount-cell';
 import { adminService } from 'api/api';
 import { CopyTableButton } from './copy-table-button';
@@ -57,6 +57,7 @@ export function VatTab({ from }: Props) {
 
   const vat = useVatReturnPL(month);
   const oss = useOssReturn(quarter);
+  const ukvat = useUkVatReturn(quarter);
 
   const ret = vat.data;
   const rows: VatRow[] = ret
@@ -85,6 +86,28 @@ export function VatTab({ from }: Props) {
     ...ossRows.map((r) => [r.country, r.ratePct?.value, r.net?.value, r.vat?.value]),
     ['total', '', oss.data?.totalNet?.value, oss.data?.totalVat?.value],
   ];
+
+  // UK VAT 9-box return (separate jurisdiction). Boxes 2/8/9 are always 0 for a GB return.
+  const uk = ukvat.data;
+  const ukBoxes: { box: string; label: string; value?: googletype_Decimal; bold?: boolean }[] = uk
+    ? [
+        { box: '1', label: 'VAT due on sales', value: uk.box1OutputVat },
+        { box: '2', label: 'VAT due on EU acquisitions', value: undefined },
+        { box: '3', label: 'total VAT due', value: uk.box3TotalVatDue },
+        { box: '4', label: 'VAT reclaimed on purchases', value: uk.box4InputVat },
+        { box: '5', label: 'net VAT (pay / reclaim)', value: uk.box5NetVat, bold: true },
+        { box: '6', label: 'total sales ex-VAT', value: uk.box6NetSales },
+        { box: '7', label: 'total purchases ex-VAT', value: uk.box7NetPurchases },
+        { box: '8', label: 'EU supplies ex-VAT', value: undefined },
+        { box: '9', label: 'EU acquisitions ex-VAT', value: undefined },
+      ]
+    : [];
+  const ukCopyHeaders = ['box', 'description', 'amount'];
+  const ukCopyRows: (string | number | undefined)[][] = ukBoxes.map((b) => [
+    b.box,
+    b.label,
+    b.value?.value ?? '0',
+  ]);
 
   return (
     <div className='flex flex-col gap-8'>
@@ -192,6 +215,54 @@ export function VatTab({ from }: Props) {
                     <AmountCell value={oss.data?.totalVat} bold />
                   </tr>
                 </tfoot>
+              </table>
+            </div>
+          </div>
+        </ReportState>
+      </section>
+
+      <section className='flex flex-col gap-3'>
+        <Text variant='uppercase' className='font-medium'>
+          UK VAT — quarterly return (9-box) · {formatQuarterLabel(quarter)}
+        </Text>
+        <ReportState
+          isLoading={ukvat.isLoading}
+          isError={ukvat.isError}
+          onRetry={() => ukvat.refetch()}
+          isEmpty={!uk}
+        >
+          <div className='flex flex-col gap-3'>
+            <Text size='small' variant='inactive'>
+              UK-stock domestic regime — a separate jurisdiction, excluded from the Polish net payable.
+              Enter these figures into MTD-compatible software to submit to HMRC.
+            </Text>
+            <div className='flex justify-end'>
+              <CopyTableButton headers={ukCopyHeaders} rows={ukCopyRows} filename='uk-vat-return' />
+            </div>
+            <div className='overflow-x-auto'>
+              <table className='w-full min-w-max border-collapse'>
+                <thead className='border-b border-textColor'>
+                  <tr>
+                    <th className='px-2 py-2 text-left text-textBaseSize uppercase'>box</th>
+                    <th className='px-2 py-2 text-left text-textBaseSize uppercase'>description</th>
+                    <th className='min-w-32 px-2 py-2 text-right text-textBaseSize uppercase'>
+                      amount
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {ukBoxes.map((b) => (
+                    <tr key={b.box} className='border-b border-textInactiveColor'>
+                      <td className='w-10 px-2 py-1 tabular-nums text-labelColor'>{b.box}</td>
+                      <td
+                        className={`whitespace-nowrap px-2 py-1${b.bold ? ' border-t border-textColor font-medium' : ''}`}
+                      >
+                        {b.label}
+                      </td>
+                      <AmountCell value={b.value} bold={b.bold} />
+                    </tr>
+                  ))}
+                </tbody>
               </table>
             </div>
           </div>

--- a/src/components/managers/accounting/utils/hooks.ts
+++ b/src/components/managers/accounting/utils/hooks.ts
@@ -38,6 +38,7 @@ export const acctKeys = {
   reconciliation: (from: string, to: string) => [...acctKeys.all, 'recon', from, to] as const,
   vatReturn: (month: string) => [...acctKeys.all, 'vat-return', month] as const,
   ossReturn: (q: string) => [...acctKeys.all, 'oss-return', q] as const,
+  ukVatReturn: (q: string) => [...acctKeys.all, 'uk-vat-return', q] as const,
   eventsReview: () => [...acctKeys.all, 'events-review'] as const,
 };
 
@@ -222,6 +223,15 @@ export function useOssReturn(quarterStart: string) {
   return useQuery({
     queryKey: acctKeys.ossReturn(quarterStart),
     queryFn: () => adminService.GetOssReturn({ quarter: quarterStart }),
+    enabled: Boolean(quarterStart),
+  });
+}
+
+// Quarterly UK VAT return (9-box MTD). Same quarter dimension as OSS; a separate UK jurisdiction.
+export function useUkVatReturn(quarterStart: string) {
+  return useQuery({
+    queryKey: acctKeys.ukVatReturn(quarterStart),
+    queryFn: () => adminService.GetUkVatReturn({ quarter: quarterStart }),
     enabled: Boolean(quarterStart),
   });
 }


### PR DESCRIPTION
Adds a **UK VAT quarterly (9-box)** section to the VAT report tab, below JPK + OSS — `GetUkVatReturn` for the uk_stock_domestic jurisdiction, with copy-table for MTD software entry. Submodule `77b50ad`; pairs with backend PR #65. build:check green; WIP untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)