### PR TITLE
accounting(reports): FRS 105 micro-entity accounts tab (draft)

### DIFF
--- a/src/api/proto-http/admin/index.ts
+++ b/src/api/proto-http/admin/index.ts
@@ -7300,6 +7300,38 @@ export type GetUkVatReturnResponse = {
   box7NetPurchases: googletype_Decimal | undefined;
 };
 
+export type GetFrs105AccountsRequest = {
+  from: string | undefined;
+  to: string | undefined;
+};
+
+// GetFrs105AccountsResponse is an FRS 105 micro-entity accounts DRAFT: the Income Statement over the
+// period and the Statement of Financial Position as at `to`, re-grouped from the ledger. Figures are
+// in `currency` (the ledger base currency); the caveats flag that a UK Ltd filing needs GBP + entity
+// isolation.
+export type GetFrs105AccountsResponse = {
+  from: string | undefined;
+  to: string | undefined;
+  currency: string | undefined;
+  turnover: googletype_Decimal | undefined;
+  costOfSales: googletype_Decimal | undefined;
+  grossProfit: googletype_Decimal | undefined;
+  administrativeExpenses: googletype_Decimal | undefined;
+  depreciation: googletype_Decimal | undefined;
+  operatingProfit: googletype_Decimal | undefined;
+  tax: googletype_Decimal | undefined;
+  profitForYear: googletype_Decimal | undefined;
+  fixedAssets: googletype_Decimal | undefined;
+  currentAssets: googletype_Decimal | undefined;
+  creditorsWithinYear: googletype_Decimal | undefined;
+  netCurrentAssets: googletype_Decimal | undefined;
+  totalAssetsLessCurrentLiab: googletype_Decimal | undefined;
+  creditorsAfterYear: googletype_Decimal | undefined;
+  netAssets: googletype_Decimal | undefined;
+  capitalAndReserves: googletype_Decimal | undefined;
+  caveats: string[] | undefined;
+};
+
 export interface AdminService {
   // Retrieves a key-value dictionary.
   GetDictionary(request: GetDictionaryRequest): Promise<GetDictionaryResponse>;
@@ -7897,6 +7929,10 @@ export interface AdminService {
   // regime (a separate jurisdiction from the Polish JPK). Boxes 2/8/9 are zero post-Brexit for a GB
   // return; the figures are entered into MTD-compatible software / the HMRC bridge to submit.
   GetUkVatReturn(request: GetUkVatReturnRequest): Promise<GetUkVatReturnResponse>;
+  // GetFrs105Accounts re-groups the ledger into FRS 105 UK micro-entity line items (Income Statement +
+  // Statement of Financial Position). A base-currency DRAFT: a filing-ready UK Ltd set needs GBP
+  // conversion + isolation of the UK entity's transactions — surfaced in caveats, not done here.
+  GetFrs105Accounts(request: GetFrs105AccountsRequest): Promise<GetFrs105AccountsResponse>;
 }
 
 type RequestType = {
@@ -12942,6 +12978,29 @@ export function createAdminServiceClient(
         service: "AdminService",
         method: "GetUkVatReturn",
       }) as Promise<GetUkVatReturnResponse>;
+    },
+    GetFrs105Accounts(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/accounting/reports/frs105`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      if (request.from) {
+        queryParams.push(`from=${encodeURIComponent(request.from.toString())}`)
+      }
+      if (request.to) {
+        queryParams.push(`to=${encodeURIComponent(request.to.toString())}`)
+      }
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "GET",
+        body,
+      }, {
+        service: "AdminService",
+        method: "GetFrs105Accounts",
+      }) as Promise<GetFrs105AccountsResponse>;
     },
   };
 }

--- a/src/components/managers/accounting/reports/components/frs105.tsx
+++ b/src/components/managers/accounting/reports/components/frs105.tsx
@@ -1,0 +1,104 @@
+import { googletype_Decimal } from 'api/proto-http/admin';
+import Text from 'ui/components/text';
+import { useFrs105Accounts } from '../../utils/hooks';
+import { AmountCell } from '../../components/amount-cell';
+import { CopyTableButton } from './copy-table-button';
+import { CaveatsNote, ReportState } from './report-utils';
+
+type Props = {
+  from: string;
+  to: string;
+};
+
+type Line = { label: string; value?: googletype_Decimal; bold?: boolean; indent?: boolean };
+
+// FRS 105 UK micro-entity accounts (04, statutory-exports track). A DRAFT re-grouping of the ledger:
+// the Income Statement over [from, to) and the Statement of Financial Position as at `to`. Figures are
+// in the ledger base currency — the response caveats flag that a filing-ready UK Ltd set needs GBP +
+// isolation of the UK entity's transactions.
+export function Frs105Tab({ from, to }: Props) {
+  const { data, isLoading, isError, refetch } = useFrs105Accounts(from, to);
+
+  const income: Line[] = data
+    ? [
+        { label: 'Turnover', value: data.turnover },
+        { label: 'Cost of sales', value: data.costOfSales },
+        { label: 'Gross profit', value: data.grossProfit, bold: true },
+        { label: 'Administrative expenses', value: data.administrativeExpenses },
+        { label: 'Depreciation', value: data.depreciation },
+        { label: 'Operating profit', value: data.operatingProfit, bold: true },
+        { label: 'Tax', value: data.tax },
+        { label: 'Profit for the year', value: data.profitForYear, bold: true },
+      ]
+    : [];
+
+  const position: Line[] = data
+    ? [
+        { label: 'Fixed assets (net book value)', value: data.fixedAssets },
+        { label: 'Current assets', value: data.currentAssets },
+        { label: 'Creditors: within one year', value: data.creditorsWithinYear },
+        { label: 'Net current assets', value: data.netCurrentAssets, bold: true },
+        { label: 'Total assets less current liabilities', value: data.totalAssetsLessCurrentLiab, bold: true },
+        { label: 'Creditors: after more than one year', value: data.creditorsAfterYear },
+        { label: 'Net assets', value: data.netAssets, bold: true },
+        { label: 'Capital and reserves', value: data.capitalAndReserves, bold: true },
+      ]
+    : [];
+
+  const copyHeaders = ['statement', 'line', 'amount'];
+  const copyRows: (string | number | undefined)[][] = [
+    ...income.map((l) => ['income', l.label, l.value?.value ?? '0']),
+    ...position.map((l) => ['position', l.label, l.value?.value ?? '0']),
+  ];
+
+  return (
+    <ReportState isLoading={isLoading} isError={isError} onRetry={() => refetch()} isEmpty={!data}>
+      <div className='flex flex-col gap-6'>
+        <div className='border border-error/60 bg-error/5 p-3'>
+          <Text variant='uppercase' size='small' className='font-semibold text-error'>
+            draft — not filing-ready
+          </Text>
+          <div className='mt-1'>
+            <CaveatsNote caveats={data?.caveats ?? []} />
+          </div>
+        </div>
+
+        <div className='flex justify-end'>
+          <CopyTableButton headers={copyHeaders} rows={copyRows} filename='frs105-accounts' />
+        </div>
+
+        <Frs105Section
+          title={`Income statement · figures in ${data?.currency ?? ''}`}
+          lines={income}
+        />
+        <Frs105Section title={`Statement of financial position · as at end of period`} lines={position} />
+      </div>
+    </ReportState>
+  );
+}
+
+function Frs105Section({ title, lines }: { title: string; lines: Line[] }) {
+  return (
+    <section className='flex flex-col gap-2'>
+      <Text variant='uppercase' className='font-medium'>
+        {title}
+      </Text>
+      <div className='overflow-x-auto'>
+        <table className='w-full min-w-max border-collapse'>
+          <tbody>
+            {lines.map((l) => (
+              <tr key={l.label} className='border-b border-textInactiveColor'>
+                <td
+                  className={`whitespace-nowrap px-2 py-1${l.bold ? ' border-t border-textColor font-medium' : ''}`}
+                >
+                  {l.label}
+                </td>
+                <AmountCell value={l.value} bold={l.bold} />
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/components/managers/accounting/reports/page.tsx
+++ b/src/components/managers/accounting/reports/page.tsx
@@ -2,6 +2,7 @@ import { cn } from 'lib/utility';
 import { useSearchParams } from 'react-router-dom';
 import { AcctSectionHeader } from '../components/section-header';
 import { BalanceSheetTab } from './components/balance-sheet';
+import { Frs105Tab } from './components/frs105';
 import { LedgerTab } from './components/ledger';
 import { ProfitLossTab } from './components/profit-loss';
 import { RangeControls, type ControlsMode } from './components/range-controls';
@@ -22,6 +23,7 @@ const TABS = [
   { id: 'ledger', label: 'ledger' },
   { id: 'recon', label: 'reconciliation' },
   { id: 'vat', label: 'vat' },
+  { id: 'frs105', label: 'frs 105' },
 ] as const;
 
 type TabId = (typeof TABS)[number]['id'];
@@ -115,6 +117,7 @@ export function AcctReportsPage() {
       {tab === 'ledger' && <LedgerTab code={code} from={from} to={to} />}
       {tab === 'recon' && <ReconciliationTab from={from} to={to} />}
       {tab === 'vat' && <VatTab from={from} />}
+      {tab === 'frs105' && <Frs105Tab from={from} to={to} />}
     </div>
   );
 }

--- a/src/components/managers/accounting/utils/hooks.ts
+++ b/src/components/managers/accounting/utils/hooks.ts
@@ -39,6 +39,7 @@ export const acctKeys = {
   vatReturn: (month: string) => [...acctKeys.all, 'vat-return', month] as const,
   ossReturn: (q: string) => [...acctKeys.all, 'oss-return', q] as const,
   ukVatReturn: (q: string) => [...acctKeys.all, 'uk-vat-return', q] as const,
+  frs105: (from: string, to: string) => [...acctKeys.all, 'frs105', from, to] as const,
   eventsReview: () => [...acctKeys.all, 'events-review'] as const,
 };
 
@@ -233,6 +234,16 @@ export function useUkVatReturn(quarterStart: string) {
     queryKey: acctKeys.ukVatReturn(quarterStart),
     queryFn: () => adminService.GetUkVatReturn({ quarter: quarterStart }),
     enabled: Boolean(quarterStart),
+  });
+}
+
+// FRS 105 UK micro-entity accounts draft over [from, to). Base-currency (a DRAFT, per the response
+// caveats); the Income Statement is the period, the SoFP is as at `to`.
+export function useFrs105Accounts(from: string, to: string) {
+  return useQuery({
+    queryKey: acctKeys.frs105(from, to),
+    queryFn: () => adminService.GetFrs105Accounts({ from, to }),
+    enabled: Boolean(from && to),
   });
 }
 


### PR DESCRIPTION
New **frs 105** tab on the accounting Reports — UK micro-entity Income Statement + Statement of Financial Position from the ledger, with a prominent DRAFT banner (base-currency, whole-company caveats) + copy-table. Submodule `a78d292`; pairs with backend PR #67. build:check green; WIP untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)