### PR TITLE
accounting(frs105): soften draft banner (structure corrected)

### DIFF
--- a/src/components/managers/accounting/reports/components/frs105.tsx
+++ b/src/components/managers/accounting/reports/components/frs105.tsx
@@ -54,9 +54,9 @@ export function Frs105Tab({ from, to }: Props) {
   return (
     <ReportState isLoading={isLoading} isError={isError} onRetry={() => refetch()} isEmpty={!data}>
       <div className='flex flex-col gap-6'>
-        <div className='border border-error/60 bg-error/5 p-3'>
-          <Text variant='uppercase' size='small' className='font-semibold text-error'>
-            draft — not filing-ready
+        <div className='border border-textInactiveColor p-3'>
+          <Text variant='uppercase' size='small' className='font-medium'>
+            draft — for accountant finalisation
           </Text>
           <div className='mt-1'>
             <CaveatsNote caveats={data?.caveats ?? []} />


### PR DESCRIPTION
The FRS 105 tab flagged "not filing-ready" in error red, implying a currency/scope problem that doesn't exist (single UK Ltd, EUR functional → whole-ledger scope + EUR figures are correct). Neutral "draft — for accountant finalisation" banner; the accurate completeness caveats come from the backend (PR #68). build:check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)