### PR TITLE
accounting UI: wave 5 — Cash Flow + Financial Health tabs

### DIFF
--- a/src/api/proto-http/admin/index.ts
+++ b/src/api/proto-http/admin/index.ts
@@ -7489,6 +7489,68 @@ export type GetFrs105AccountsResponse = {
   caveats: string[] | undefined;
 };
 
+export type GetCashFlowStatementRequest = {
+  from: string | undefined;
+  to: string | undefined;
+};
+
+// AcctCashFlowLine is one cash-flow line: a label and its SIGNED cash impact (source positive, use
+// negative).
+export type AcctCashFlowLine = {
+  label: string | undefined;
+  amount: googletype_Decimal | undefined;
+};
+
+// AcctCashFlowSection groups cash-flow lines (operating | investing | financing) with the section subtotal.
+export type AcctCashFlowSection = {
+  name: string | undefined;
+  lines: AcctCashFlowLine[] | undefined;
+  subtotal: googletype_Decimal | undefined;
+};
+
+// GetCashFlowStatementResponse is the indirect-method statement over [from, to). closing_cash is derived
+// (opening_cash + net_change); closing_cash_actual is the real cash-account balance as at `to`; check =
+// closing_cash_actual − closing_cash (0 when balanced, the trust panel).
+export type GetCashFlowStatementResponse = {
+  from: string | undefined;
+  to: string | undefined;
+  currency: string | undefined;
+  operating: AcctCashFlowSection | undefined;
+  investing: AcctCashFlowSection | undefined;
+  financing: AcctCashFlowSection | undefined;
+  netChange: googletype_Decimal | undefined;
+  openingCash: googletype_Decimal | undefined;
+  closingCash: googletype_Decimal | undefined;
+  closingCashActual: googletype_Decimal | undefined;
+  check: googletype_Decimal | undefined;
+  balanced: boolean | undefined;
+  caveats: string[] | undefined;
+};
+
+export type GetFinancialHealthRequest = {
+  from: string | undefined;
+  to: string | undefined;
+};
+
+// AcctFinancialHealthRow is one ratio row: its value, the owner's benchmark string, a status
+// (ok | warn | na | track) and a display unit ("%", "x", "days", the base currency, or "").
+export type AcctFinancialHealthRow = {
+  name: string | undefined;
+  formula: string | undefined;
+  value: googletype_Decimal | undefined;
+  benchmark: string | undefined;
+  status: string | undefined;
+  unit: string | undefined;
+};
+
+export type GetFinancialHealthResponse = {
+  from: string | undefined;
+  to: string | undefined;
+  currency: string | undefined;
+  rows: AcctFinancialHealthRow[] | undefined;
+  caveats: string[] | undefined;
+};
+
 // FixedAsset is one capitalised asset, depreciated straight-line over useful_life_months from acquired_on.
 export type FixedAsset = {
   id: number | undefined;
@@ -8141,6 +8203,14 @@ export interface AdminService {
   // Statement of Financial Position). A base-currency DRAFT: a filing-ready UK Ltd set needs GBP
   // conversion + isolation of the UK entity's transactions — surfaced in caveats, not done here.
   GetFrs105Accounts(request: GetFrs105AccountsRequest): Promise<GetFrs105AccountsResponse>;
+  // GetCashFlowStatement returns the indirect-method cash-flow statement over [from, to) (exclusive):
+  // net profit + depreciation add-back + balance-sheet working-capital / investing / financing deltas,
+  // with a Check that reconciles the derived closing cash to the actual 1010/1030 balance.
+  GetCashFlowStatement(request: GetCashFlowStatementRequest): Promise<GetCashFlowStatementResponse>;
+  // GetFinancialHealth returns the financial-health ratio set over [from, to) (exclusive): each row a
+  // {name, formula, value, benchmark, status} tuple. Money is ledger-derived; unit counts come from
+  // operational metrics (labelled in caveats).
+  GetFinancialHealth(request: GetFinancialHealthRequest): Promise<GetFinancialHealthResponse>;
   // ImportBankCsv parses a bank CSV export (Revolut) into the inbox, deduplicating on the bank
   // transaction id + payment currency; a re-imported statement is a no-op for lines already present.
   ImportBankCsv(request: ImportBankCsvRequest): Promise<ImportBankCsvResponse>;
@@ -13241,6 +13311,52 @@ export function createAdminServiceClient(
         service: "AdminService",
         method: "GetFrs105Accounts",
       }) as Promise<GetFrs105AccountsResponse>;
+    },
+    GetCashFlowStatement(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/accounting/reports/cash-flow`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      if (request.from) {
+        queryParams.push(`from=${encodeURIComponent(request.from.toString())}`)
+      }
+      if (request.to) {
+        queryParams.push(`to=${encodeURIComponent(request.to.toString())}`)
+      }
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "GET",
+        body,
+      }, {
+        service: "AdminService",
+        method: "GetCashFlowStatement",
+      }) as Promise<GetCashFlowStatementResponse>;
+    },
+    GetFinancialHealth(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
+      const path = `api/admin/accounting/reports/financial-health`; // eslint-disable-line quotes
+      const body = null;
+      const queryParams: string[] = [];
+      if (request.from) {
+        queryParams.push(`from=${encodeURIComponent(request.from.toString())}`)
+      }
+      if (request.to) {
+        queryParams.push(`to=${encodeURIComponent(request.to.toString())}`)
+      }
+      let uri = path;
+      if (queryParams.length > 0) {
+        uri += `?${queryParams.join("&")}`
+      }
+      return handler({
+        path: uri,
+        method: "GET",
+        body,
+      }, {
+        service: "AdminService",
+        method: "GetFinancialHealth",
+      }) as Promise<GetFinancialHealthResponse>;
     },
     ImportBankCsv(request) { // eslint-disable-line @typescript-eslint/no-unused-vars
       const path = `api/admin/accounting/bank/import`; // eslint-disable-line quotes

--- a/src/components/managers/accounting/reports/components/cash-flow.tsx
+++ b/src/components/managers/accounting/reports/components/cash-flow.tsx
@@ -1,0 +1,122 @@
+import { AcctCashFlowSection } from 'api/proto-http/admin';
+import Text from 'ui/components/text';
+import { useCashFlow } from '../../utils/hooks';
+import { AmountCell } from '../../components/amount-cell';
+import { BalancedBadge } from '../../components/balanced-badge';
+import { CopyTableButton } from './copy-table-button';
+import { CaveatsNote, ReportState } from './report-utils';
+
+type Props = {
+  from: string;
+  to: string;
+};
+
+// One cash-flow grouping (operating / investing / financing): signed line rows (label · amount)
+// with a bordered section subtotal. Amounts are signed — a use of cash arrives negative and
+// AmountCell reddens it (§8.3). The subtotal comes from the server, never summed on the client.
+function Section({ section }: { section?: AcctCashFlowSection }) {
+  if (!section) return null;
+  const lines = section.lines ?? [];
+  return (
+    <div className='flex flex-col gap-1'>
+      <Text variant='uppercase' size='small' className='text-textInactiveColor'>
+        {section.name}
+      </Text>
+      <table className='w-full border-collapse'>
+        <tbody>
+          {lines.map((l, i) => (
+            <tr key={i} className='border-b border-textInactiveColor'>
+              <td className='px-2 py-1'>{l.label}</td>
+              <AmountCell value={l.amount} />
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>
+          <tr>
+            <td className='border-t border-textColor px-2 py-1 font-medium uppercase'>
+              total {section.name}
+            </td>
+            <AmountCell value={section.subtotal} bold />
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  );
+}
+
+// 4.x Cash Flow: the indirect-method statement over [from, to) — operating / investing / financing
+// stacked vertically, then a reconciliation footer (net change → opening → closing cash) and a
+// trust row. `closingCash` is derived (opening + net change); `closingCashActual` is the real cash
+// balance as at `to`; `check` = actual − derived (0 when balanced, mirrors the BS balance check).
+// The client never sums anything itself (§8.6 #6) — every figure, including check, is server-sent.
+export function CashFlowTab({ from, to }: Props) {
+  const { data, isLoading, isError, refetch } = useCashFlow(from, to);
+  const caveats = data?.caveats ?? [];
+  const isEmpty = !data || (!data.operating && !data.investing && !data.financing);
+
+  const copyRows: (string | number | undefined)[][] = [];
+  const pushSection = (s?: AcctCashFlowSection) => {
+    if (!s) return;
+    copyRows.push([(s.name ?? '').toUpperCase()]);
+    (s.lines ?? []).forEach((l) => copyRows.push([l.label, l.amount?.value]));
+    copyRows.push([`total ${s.name ?? ''}`, s.subtotal?.value]);
+  };
+  pushSection(data?.operating);
+  pushSection(data?.investing);
+  pushSection(data?.financing);
+  copyRows.push(['NET CHANGE IN CASH', data?.netChange?.value]);
+  copyRows.push(['OPENING CASH', data?.openingCash?.value]);
+  copyRows.push(['CLOSING CASH', data?.closingCash?.value]);
+  copyRows.push(['CLOSING CASH (ACTUAL)', data?.closingCashActual?.value]);
+  copyRows.push(['CHECK', data?.check?.value]);
+
+  return (
+    <ReportState
+      isLoading={isLoading}
+      isError={isError}
+      onRetry={() => refetch()}
+      isEmpty={isEmpty}
+    >
+      <div className='flex flex-col gap-4'>
+        <CaveatsNote caveats={caveats} />
+        <div className='flex justify-end'>
+          <CopyTableButton headers={['line', 'amount']} rows={copyRows} filename='cash-flow' />
+        </div>
+
+        <div className='flex max-w-2xl flex-col gap-5'>
+          <Section section={data?.operating} />
+          <Section section={data?.investing} />
+          <Section section={data?.financing} />
+
+          <div className='flex flex-col gap-2 border-t-2 border-textColor pt-3'>
+            <div className='flex items-center justify-between'>
+              <Text className='font-medium uppercase'>net change in cash</Text>
+              <AmountCell as='span' value={data?.netChange} className='font-medium' />
+            </div>
+            <div className='flex items-center justify-between'>
+              <Text className='uppercase'>opening cash</Text>
+              <AmountCell as='span' value={data?.openingCash} />
+            </div>
+            <div className='flex items-center justify-between border-t border-textColor pt-2'>
+              <Text className='font-medium uppercase'>closing cash</Text>
+              <AmountCell as='span' value={data?.closingCash} className='font-medium' />
+            </div>
+            <div className='flex items-center justify-between'>
+              <Text variant='inactive' className='uppercase'>
+                closing cash (actual)
+              </Text>
+              <AmountCell as='span' value={data?.closingCashActual} />
+            </div>
+            <div className='flex items-center justify-between border-t border-textColor pt-2'>
+              <Text className='font-medium uppercase'>check</Text>
+              <div className='flex items-center gap-3'>
+                <AmountCell as='span' value={data?.check} className='font-medium' />
+                <BalancedBadge balanced={data?.balanced} />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </ReportState>
+  );
+}

--- a/src/components/managers/accounting/reports/components/financial-health.tsx
+++ b/src/components/managers/accounting/reports/components/financial-health.tsx
@@ -1,0 +1,110 @@
+import { googletype_Decimal } from 'api/proto-http/admin';
+import { cn } from 'lib/utility';
+import { useFinancialHealth } from '../../utils/hooks';
+import { CopyTableButton } from './copy-table-button';
+import { CaveatsNote, ReportState } from './report-utils';
+
+type Props = {
+  from: string;
+  to: string;
+};
+
+// Status → cell colour. Reuses the repo's ok/error convention (text-success / text-error, see
+// BalancedBadge): a ratio that breaches its benchmark reads red like every other loss/warn signal;
+// `na`/`track` (no data yet, or an informational metric) stay muted grey. Unknown → muted too.
+const STATUS_CLS: Record<string, string> = {
+  ok: 'text-success',
+  warn: 'text-error',
+  na: 'text-textInactiveColor',
+  track: 'text-textInactiveColor',
+};
+
+// A ratio value carries its own display unit ("%", "x"/"×", "days", the base currency, or "").
+// The backend computes the figure (§8.6 #6); this only appends the unit. Missing/non-finite → em
+// dash, matching formatBase's "no data".
+function formatHealthValue(value?: googletype_Decimal, unit?: string): string {
+  const raw = value?.value;
+  if (raw == null || raw === '') return '—';
+  const n = parseFloat(raw);
+  if (!Number.isFinite(n)) return '—';
+  switch (unit) {
+    case '%':
+      return `${n.toFixed(1)} %`;
+    case 'x':
+    case '×':
+      return `${n.toFixed(2)}×`;
+    case 'days':
+      return `${n.toFixed(0)} days`;
+    default: {
+      const s = n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+      return unit ? `${s} ${unit}` : s;
+    }
+  }
+}
+
+// 4.x Financial Health: the ratio set over [from, to) as a flat table — metric · formula ·
+// benchmark · value (unit-aware) · status. Status is the only colour-bearing column, so the
+// benchmark comparison is legible at a glance without re-reading the numbers (§8.5).
+export function FinancialHealthTab({ from, to }: Props) {
+  const { data, isLoading, isError, refetch } = useFinancialHealth(from, to);
+  const rows = data?.rows ?? [];
+  const caveats = data?.caveats ?? [];
+
+  const copyHeaders = ['metric', 'formula', 'benchmark', 'value', 'status'];
+  const copyRows: (string | number | undefined)[][] = rows.map((r) => [
+    r.name,
+    r.formula,
+    r.benchmark,
+    r.value?.value,
+    r.status,
+  ]);
+
+  return (
+    <ReportState
+      isLoading={isLoading}
+      isError={isError}
+      onRetry={() => refetch()}
+      isEmpty={rows.length === 0}
+    >
+      <div className='flex flex-col gap-3'>
+        <CaveatsNote caveats={caveats} />
+        <div className='flex justify-end'>
+          <CopyTableButton headers={copyHeaders} rows={copyRows} filename='financial-health' />
+        </div>
+        <div className='overflow-x-auto'>
+          <table className='w-full min-w-max border-collapse'>
+            <thead className='border-b border-textColor'>
+              <tr>
+                <th className='px-2 py-2 text-left text-textBaseSize uppercase'>metric</th>
+                <th className='px-2 py-2 text-left text-textBaseSize uppercase'>formula</th>
+                <th className='px-2 py-2 text-left text-textBaseSize uppercase'>benchmark</th>
+                <th className='min-w-32 px-2 py-2 text-right text-textBaseSize uppercase'>value</th>
+                <th className='px-2 py-2 text-right text-textBaseSize uppercase'>status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r, i) => (
+                <tr key={r.name ?? i} className='border-b border-textInactiveColor'>
+                  <td className='whitespace-nowrap px-2 py-1'>{r.name}</td>
+                  <td className='px-2 py-1 text-labelColor'>{r.formula}</td>
+                  <td className='whitespace-nowrap px-2 py-1 text-labelColor'>{r.benchmark}</td>
+                  <td className='w-32 min-w-32 whitespace-nowrap px-2 py-1 text-right tabular-nums'>
+                    {formatHealthValue(r.value, r.unit)}
+                  </td>
+                  <td
+                    className={cn(
+                      'whitespace-nowrap px-2 py-1 text-right uppercase',
+                      STATUS_CLS[r.status ?? ''] ?? 'text-textInactiveColor',
+                    )}
+                  >
+                    {r.status ?? '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </ReportState>
+  );
+}

--- a/src/components/managers/accounting/reports/page.tsx
+++ b/src/components/managers/accounting/reports/page.tsx
@@ -2,6 +2,8 @@ import { cn } from 'lib/utility';
 import { useSearchParams } from 'react-router-dom';
 import { AcctSectionHeader } from '../components/section-header';
 import { BalanceSheetTab } from './components/balance-sheet';
+import { CashFlowTab } from './components/cash-flow';
+import { FinancialHealthTab } from './components/financial-health';
 import { Frs105Tab } from './components/frs105';
 import { LedgerTab } from './components/ledger';
 import { ProfitLossTab } from './components/profit-loss';
@@ -15,15 +17,17 @@ import { VatTab } from './components/vat';
 // not Radix Tabs). The whole selection — tab, from/to, asOf, account code — lives in searchParams,
 // so every view is a shareable link and the TB/BS/P&L drill-downs, recon and dashboard alerts can
 // deep-link into an exact report state (§8.2). searchParams contract:
-// ?tab=tb|pl|bs|ledger|recon|vat & from & to & asOf & code.
+// ?tab=tb|pl|bs|cf|ledger|recon|vat|frs105|health & from & to & asOf & code.
 const TABS = [
   { id: 'tb', label: 'trial balance' },
   { id: 'pl', label: 'p&l' },
   { id: 'bs', label: 'balance sheet' },
+  { id: 'cf', label: 'cash flow' },
   { id: 'ledger', label: 'ledger' },
   { id: 'recon', label: 'reconciliation' },
   { id: 'vat', label: 'vat' },
   { id: 'frs105', label: 'frs 105' },
+  { id: 'health', label: 'health' },
 ] as const;
 
 type TabId = (typeof TABS)[number]['id'];
@@ -114,10 +118,12 @@ export function AcctReportsPage() {
       {tab === 'tb' && <TrialBalanceTab from={from} to={to} onDrill={(c) => drillToLedger(c)} />}
       {tab === 'pl' && <ProfitLossTab from={from} to={to} onDrill={(c) => drillToLedger(c)} />}
       {tab === 'bs' && <BalanceSheetTab asOf={asOf} onDrill={(c) => drillToLedger(c, true)} />}
+      {tab === 'cf' && <CashFlowTab from={from} to={to} />}
       {tab === 'ledger' && <LedgerTab code={code} from={from} to={to} />}
       {tab === 'recon' && <ReconciliationTab from={from} to={to} />}
       {tab === 'vat' && <VatTab from={from} />}
       {tab === 'frs105' && <Frs105Tab from={from} to={to} />}
+      {tab === 'health' && <FinancialHealthTab from={from} to={to} />}
     </div>
   );
 }

--- a/src/components/managers/accounting/utils/hooks.ts
+++ b/src/components/managers/accounting/utils/hooks.ts
@@ -34,6 +34,9 @@ export const acctKeys = {
   trialBalance: (from: string, to: string) => [...acctKeys.all, 'tb', from, to] as const,
   profitLoss: (from: string, to: string) => [...acctKeys.all, 'pl', from, to] as const,
   balanceSheet: (asOf: string) => [...acctKeys.all, 'bs', asOf] as const,
+  cashFlow: (from: string, to: string) => [...acctKeys.all, 'cash-flow', from, to] as const,
+  financialHealth: (from: string, to: string) =>
+    [...acctKeys.all, 'financial-health', from, to] as const,
   ledger: (code: string, f: LedgerFilter) => [...acctKeys.all, 'ledger', code, f] as const,
   reconciliation: (from: string, to: string) => [...acctKeys.all, 'recon', from, to] as const,
   vatReturn: (month: string) => [...acctKeys.all, 'vat-return', month] as const,
@@ -188,6 +191,26 @@ export function useBalanceSheet(asOf: string) {
     queryKey: acctKeys.balanceSheet(asOf),
     queryFn: () => adminService.GetBalanceSheet({ asOf }),
     enabled: Boolean(asOf),
+  });
+}
+
+// Indirect-method cash-flow statement over [from, to) (exclusive). Same range guard as the other
+// range reports — closing_cash / check come from the server, never recomputed here (§8.6 #6).
+export function useCashFlow(from: string, to: string) {
+  return useQuery({
+    queryKey: acctKeys.cashFlow(from, to),
+    queryFn: () => adminService.GetCashFlowStatement({ from, to }),
+    enabled: Boolean(from && to),
+  });
+}
+
+// Financial-health ratio set over [from, to). Each row carries its own value/benchmark/status, so
+// this is a straight pass-through — the client only lays the ratios out, it doesn't compute them.
+export function useFinancialHealth(from: string, to: string) {
+  return useQuery({
+    queryKey: acctKeys.financialHealth(from, to),
+    queryFn: () => adminService.GetFinancialHealth({ from, to }),
+    enabled: Boolean(from && to),
   });
 }
 


### PR DESCRIPTION
Two report tabs (cash flow indirect statement + financial-health ratio table). Bumps proto submodule to the wave-5 mirror. build:check green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)